### PR TITLE
fix: implement allowance-based Blend supply flow and CI cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
   build-test:
     name: Build, Lint & Test
     runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ runner.temp }}/neurowealth-target
 
     steps:
-
       - name: Checkout code
         uses: actions/checkout@v4
-
 
       - name: Install Rust toolchain with components
         uses: dtolnay/rust-toolchain@stable
@@ -23,13 +23,12 @@ jobs:
           components: rustfmt, clippy
           targets: wasm32-unknown-unknown
 
-
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: neurowealth-vault
 
-      - name: Cache cargo registry and target
+      - name: Cache cargo registry and tooling
         uses: actions/cache@v4
         with:
           path: |
@@ -37,11 +36,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            neurowealth-vault/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-
 
       - name: Install Stellar CLI
         run: |
@@ -49,16 +46,27 @@ jobs:
           sudo mv soroban /usr/local/bin/
           soroban --version
 
+      - name: Pre-build disk diagnostics
+        run: |
+          df -h
+          du -sh neurowealth-vault || true
+          du -sh "${CARGO_TARGET_DIR}" || true
 
-       - name: Check formatting
-         working-directory: neurowealth-vault
-         run: cargo fmt --all -- --check
+      - name: Clean previous build artifacts
+        working-directory: neurowealth-vault
+        run: |
+          cargo clean
+          rm -rf "${CARGO_TARGET_DIR}"
+          mkdir -p "${CARGO_TARGET_DIR}"
+
+      - name: Check formatting
+        working-directory: neurowealth-vault
+        run: cargo fmt --all -- --check
 
       - name: Lint with Clippy
         working-directory: neurowealth-vault
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-  
       - name: Build contract WASM (MVP-compatible)
         working-directory: neurowealth-vault
         run: |
@@ -84,3 +92,10 @@ jobs:
       - name: Tail last 20 lines of tests
         working-directory: neurowealth-vault/contracts/vault
         run: cargo test -- --nocapture 2>&1 | tail -20
+
+      - name: Post-build disk diagnostics
+        if: always()
+        run: |
+          df -h
+          du -sh neurowealth-vault || true
+          du -sh "${CARGO_TARGET_DIR}" || true

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -98,7 +98,9 @@
 
 use core::cmp::min;
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env, Symbol,
+    auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
+    contract, contractimpl, contracttype, symbol_short, token, vec, Address, BytesN, Env, IntoVal,
+    Symbol, Val, Vec,
 };
 
 // ============================================================================
@@ -359,6 +361,16 @@ pub struct UpgradedEvent {
 /// - `get_user_reserve_data` - Gets user's reserve data including balance
 struct BlendPoolClient;
 
+#[derive(Clone)]
+#[contracttype]
+struct BlendRequest {
+    request_type: u32,
+    address: Address,
+    amount: i128,
+}
+
+const BLEND_REQUEST_TYPE_SUPPLY: u32 = 0;
+
 impl BlendPoolClient {
     /// Deposits assets to the Blend pool.
     ///
@@ -375,18 +387,31 @@ impl BlendPoolClient {
     /// # Returns
     /// The amount of pool tokens received (or amount deposited on success)
     fn supply(
-        _env: &Env,
-        _pool_address: &Address,
-        _asset: &Address,
+        env: &Env,
+        pool_address: &Address,
+        asset: &Address,
         amount: i128,
-        _to: &Address,
+        to: &Address,
     ) -> i128 {
-        // Call Blend's deposit function
-        // Function signature: deposit(env, asset: Address, amount: i128, to: Address) -> i128
-        // Based on blend-interfaces: https://docs.rs/blend-interfaces/0.0.1/blend_interfaces/pool/trait.Pool.html
-        // TODO: Verify exact function signature and argument pattern against Blend's deployed contract
-        // For now, return amount as placeholder - this will be replaced with actual cross-contract call
-        // once Blend's interface is verified on testnet
+        let request = BlendRequest {
+            request_type: BLEND_REQUEST_TYPE_SUPPLY,
+            address: asset.clone(),
+            amount,
+        };
+        let requests: Vec<BlendRequest> = vec![env, request];
+        let args: Vec<Val> = vec![
+            env,
+            to.into_val(env),
+            to.into_val(env),
+            to.into_val(env),
+            requests.into_val(env),
+        ];
+
+        env.invoke_contract::<Val>(
+            pool_address,
+            &Symbol::new(env, "submit_with_allowance"),
+            args,
+        );
         amount
     }
 
@@ -2198,15 +2223,70 @@ impl NeuroWealthVault {
 
         let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
         let vault_address = env.current_contract_address();
+        let approval_ledger = env.ledger().sequence() + 100_000;
+        let request = BlendRequest {
+            request_type: BLEND_REQUEST_TYPE_SUPPLY,
+            address: usdc_token.clone(),
+            amount,
+        };
+        let requests: Vec<BlendRequest> = vec![env, request];
+        let approval_args: Vec<Val> = vec![
+            env,
+            vault_address.clone().into_val(env),
+            pool_address.clone().into_val(env),
+            amount.into_val(env),
+            approval_ledger.into_val(env),
+        ];
+        let submit_args: Vec<Val> = vec![
+            env,
+            vault_address.clone().into_val(env),
+            vault_address.clone().into_val(env),
+            vault_address.clone().into_val(env),
+            requests.into_val(env),
+        ];
+        let transfer_from_args: Vec<Val> = vec![
+            env,
+            pool_address.clone().into_val(env),
+            vault_address.clone().into_val(env),
+            pool_address.clone().into_val(env),
+            amount.into_val(env),
+        ];
 
-        // Approve Blend pool to spend USDC from vault
         let token_client = token::Client::new(env, &usdc_token);
-        token_client.approve(&vault_address, &pool_address, &amount, &1000000);
+        env.authorize_as_current_contract(vec![
+            env,
+            InvokerContractAuthEntry::Contract(SubContractInvocation {
+                context: ContractContext {
+                    contract: usdc_token.clone(),
+                    fn_name: Symbol::new(env, "approve"),
+                    args: approval_args,
+                },
+                sub_invocations: vec![env],
+            }),
+        ]);
+        token_client.approve(&vault_address, &pool_address, &amount, &approval_ledger);
 
-        // Supply to Blend pool
-        // Note: Blend's supply function may require the vault to transfer USDC first,
-        // then call supply. The exact pattern depends on Blend's interface.
-        // For now, we assume Blend handles the transfer internally via approval.
+        env.authorize_as_current_contract(vec![
+            env,
+            InvokerContractAuthEntry::Contract(SubContractInvocation {
+                context: ContractContext {
+                    contract: pool_address.clone(),
+                    fn_name: Symbol::new(env, "submit_with_allowance"),
+                    args: submit_args.clone(),
+                },
+                sub_invocations: vec![
+                    env,
+                    InvokerContractAuthEntry::Contract(SubContractInvocation {
+                        context: ContractContext {
+                            contract: usdc_token.clone(),
+                            fn_name: Symbol::new(env, "transfer_from"),
+                            args: transfer_from_args,
+                        },
+                        sub_invocations: vec![env],
+                    }),
+                ],
+            }),
+        ]);
         let supplied =
             BlendPoolClient::supply(env, &pool_address, &usdc_token, amount, &vault_address);
 

--- a/neurowealth-vault/contracts/vault/src/tests/test_rebalance.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_rebalance.rs
@@ -27,11 +27,11 @@ fn test_rebalance_emits_event() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (contract_id, _agent, owner, usdc_token) = setup_vault_with_token(&env);
+    let (contract_id, _agent, owner, usdc_token, blend_pool) =
+        setup_vault_with_token_and_blend(&env);
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     // Set up Blend pool and deposit so there are assets
-    let blend_pool = Address::generate(&env);
     client.set_blend_pool(&owner, &blend_pool);
 
     let user = Address::generate(&env);
@@ -65,11 +65,9 @@ fn test_rebalance_with_blend_after_deposit() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (contract_id, _agent, owner, usdc_token) = setup_vault_with_token(&env);
+    let (contract_id, _agent, owner, usdc_token, blend_pool) =
+        setup_vault_with_token_and_blend(&env);
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
-
-    // Configure Blend pool
-    let blend_pool = Address::generate(&env);
     client.set_blend_pool(&owner, &blend_pool);
 
     // Deposit so vault has a token balance to supply
@@ -77,8 +75,15 @@ fn test_rebalance_with_blend_after_deposit() {
     let deposit_amount = 10_000_000_i128;
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
 
-    // Rebalance should succeed (BlendPoolClient methods are stubs)
     client.rebalance(&symbol_short!("blend"), &500_i128);
+
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+    let blend_client = MockBlendPoolClient::new(&env, &blend_pool);
+
+    assert_eq!(blend_client.supplied(&usdc_token), deposit_amount);
+    assert_eq!(token_client.balance(&contract_id), 0);
+    assert_eq!(token_client.balance(&blend_pool), deposit_amount);
+    assert_eq!(token_client.allowance(&contract_id, &blend_pool), 0);
 }
 
 #[test]
@@ -127,4 +132,28 @@ fn test_blend_rebalance_without_pool_panics() {
 
     // blend pool not set → should panic
     client.rebalance(&symbol_short!("blend"), &500_i128);
+}
+
+#[test]
+fn test_mock_token_transfer_from_uses_and_decrements_allowance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token = env.register_contract(None, TestToken);
+    let token_client = TestTokenClient::new(&env, &token);
+
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    token_client.mint(&owner, &10_000_000_i128);
+    token_client.approve(&owner, &spender, &6_000_000_i128, &10_000_u32);
+
+    assert_eq!(token_client.allowance(&owner, &spender), 6_000_000_i128);
+
+    token_client.transfer_from(&spender, &owner, &recipient, &4_000_000_i128);
+
+    assert_eq!(token_client.balance(&owner), 6_000_000_i128);
+    assert_eq!(token_client.balance(&recipient), 4_000_000_i128);
+    assert_eq!(token_client.allowance(&owner, &spender), 2_000_000_i128);
 }

--- a/neurowealth-vault/contracts/vault/src/tests/utils.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/utils.rs
@@ -18,6 +18,14 @@ pub use soroban_sdk::testutils::Events;
 #[contracttype]
 enum TokenDataKey {
     Balance(Address),
+    Allowance(Address, Address),
+    AllowanceExpiration(Address, Address),
+}
+
+#[derive(Clone)]
+#[contracttype]
+enum BlendMockDataKey {
+    Supplied(Address),
 }
 
 #[contract]
@@ -69,13 +77,129 @@ impl TestToken {
     }
 
     pub fn approve(
-        _env: Env,
-        _from: Address,
-        _spender: Address,
-        _amount: i128,
-        _expiration_ledger: u32,
+        env: Env,
+        from: Address,
+        spender: Address,
+        amount: i128,
+        expiration_ledger: u32,
     ) {
-        // Stub – no-op for testing
+        from.require_auth();
+        assert!(amount >= 0, "amount must be non-negative");
+
+        env.storage().persistent().set(
+            &TokenDataKey::Allowance(from.clone(), spender.clone()),
+            &amount,
+        );
+        env.storage().persistent().set(
+            &TokenDataKey::AllowanceExpiration(from, spender),
+            &expiration_ledger,
+        );
+    }
+
+    pub fn allowance(env: Env, from: Address, spender: Address) -> i128 {
+        let expiration: u32 = env
+            .storage()
+            .persistent()
+            .get(&TokenDataKey::AllowanceExpiration(
+                from.clone(),
+                spender.clone(),
+            ))
+            .unwrap_or(0);
+
+        if expiration > 0 && expiration < env.ledger().sequence() {
+            return 0;
+        }
+
+        env.storage()
+            .persistent()
+            .get(&TokenDataKey::Allowance(from, spender))
+            .unwrap_or(0)
+    }
+
+    pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
+        spender.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let allowance = Self::allowance(env.clone(), from.clone(), spender.clone());
+        assert!(allowance >= amount, "insufficient allowance");
+
+        let from_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&TokenDataKey::Balance(from.clone()))
+            .unwrap_or(0);
+        assert!(from_balance >= amount, "insufficient balance");
+
+        let to_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&TokenDataKey::Balance(to.clone()))
+            .unwrap_or(0);
+
+        env.storage().persistent().set(
+            &TokenDataKey::Balance(from.clone()),
+            &(from_balance - amount),
+        );
+        env.storage()
+            .persistent()
+            .set(&TokenDataKey::Balance(to), &(to_balance + amount));
+        env.storage().persistent().set(
+            &TokenDataKey::Allowance(from, spender.clone()),
+            &(allowance - amount),
+        );
+    }
+}
+
+#[contract]
+pub struct MockBlendPool;
+
+#[contractimpl]
+impl MockBlendPool {
+    pub fn submit_with_allowance(
+        env: Env,
+        from: Address,
+        spender: Address,
+        _to: Address,
+        requests: Vec<crate::BlendRequest>,
+    ) -> i128 {
+        assert_eq!(requests.len(), 1, "expected one request");
+        let request = requests.get(0).unwrap();
+        assert_eq!(request.request_type, 0, "expected supply request");
+
+        let token_client = TestTokenClient::new(&env, &request.address);
+        let allowance = token_client.allowance(&spender, &env.current_contract_address());
+        assert!(
+            allowance >= request.amount,
+            "expected allowance before pool pull"
+        );
+
+        token_client.transfer_from(
+            &env.current_contract_address(),
+            &spender,
+            &env.current_contract_address(),
+            &request.amount,
+        );
+
+        let total_supplied: i128 = env
+            .storage()
+            .persistent()
+            .get(&BlendMockDataKey::Supplied(request.address.clone()))
+            .unwrap_or(0);
+        env.storage().persistent().set(
+            &BlendMockDataKey::Supplied(request.address),
+            &(total_supplied + request.amount),
+        );
+
+        from.clone().require_auth();
+
+        request.amount
+    }
+
+    pub fn supplied(env: Env, asset: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&BlendMockDataKey::Supplied(asset))
+            .unwrap_or(0)
     }
 }
 
@@ -108,6 +232,15 @@ pub fn setup_vault_with_token(env: &Env) -> (Address, Address, Address, Address)
     client.initialize(&agent, &usdc_token);
 
     (contract_id, agent, owner, usdc_token)
+}
+
+pub fn setup_vault_with_token_and_blend(
+    env: &Env,
+) -> (Address, Address, Address, Address, Address) {
+    let (contract_id, agent, owner, usdc_token) = setup_vault_with_token(env);
+    let blend_pool = env.register_contract(None, MockBlendPool);
+
+    (contract_id, agent, owner, usdc_token, blend_pool)
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #59
Closes #60
Closes #61

## Changes

- implemented allowance storage, `approve`, `allowance`, and `transfer_from` semantics in the test token mock
- switched vault Blend supply flow to the real allowance-based submit pattern used by Blend pools
- added a mock Blend pool contract that asserts allowance state and pulls funds via `transfer_from` during rebalance tests
- updated rebalance coverage to verify pool balances, allowance consumption, and the new mock token behavior
- hardened CI with explicit disk diagnostics, dedicated target directory cleanup, and safer cargo caching

## Testing

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`