### PR TITLE
feat:implment test acces control, balanced/conservative/growth, recon…

### DIFF
--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -215,7 +215,7 @@ pub struct WithdrawEvent {
 /// - `SymbolShort("rebalance")` - Event identifier
 #[contracttype]
 pub struct RebalanceEvent {
-    /// The protocol being deployed to (e.g., "conservative", "balanced", "growth")
+    /// The target protocol (supported: "blend", "none")
     pub protocol: Symbol,
     /// Expected APY in basis points (e.g., 850 = 8.5%)
     pub expected_apy: i128,
@@ -430,19 +430,22 @@ impl BlendPoolClient {
     /// # Returns
     /// The amount of assets actually redeemed
     fn withdraw(
-        _env: &Env,
-        _pool_address: &Address,
-        _asset: &Address,
+        env: &Env,
+        pool_address: &Address,
+        asset: &Address,
         amount: i128,
-        _to: &Address,
+        to: &Address,
     ) -> i128 {
         // Call Blend's redeem function
         // Function signature: redeem(env, asset: Address, amount: i128, to: Address) -> i128
-        // Based on blend-interfaces: https://docs.rs/blend-interfaces/0.0.1/blend_interfaces/pool/trait.Pool.html
-        // TODO: Verify exact function signature and argument pattern against Blend's deployed contract
-        // For now, return amount as placeholder - this will be replaced with actual cross-contract call
-        // once Blend's interface is verified on testnet
-        amount
+        let args: Vec<Val> = vec![
+            env,
+            asset.into_val(env),
+            amount.into_val(env),
+            to.into_val(env),
+        ];
+
+        env.invoke_contract::<i128>(pool_address, &Symbol::new(env, "redeem"), args)
     }
 
     /// Gets the balance of assets supplied to the Blend pool.
@@ -458,16 +461,13 @@ impl BlendPoolClient {
     ///
     /// # Returns
     /// The balance of assets supplied by the user
-    fn get_balance(_env: &Env, _pool_address: &Address, _asset: &Address, _user: &Address) -> i128 {
-        // Call Blend's get_user_reserve_data function
-        // Function signature: get_user_reserve_data(env, key: UserReserveKey) -> UserReserveData
-        // UserReserveKey is a struct with { user: Address, asset: Address }
-        // Based on blend-interfaces: https://docs.rs/blend-interfaces/0.0.1/blend_interfaces/pool/trait.Pool.html
-        // TODO: Verify exact function signature and argument pattern against Blend's deployed contract
-        // For now, return 0 as placeholder - this will be replaced with actual cross-contract call
-        // once Blend's interface is verified on testnet
-        // Note: The actual return type may be a struct, not i128
-        0
+    fn get_balance(env: &Env, pool_address: &Address, asset: &Address, user: &Address) -> i128 {
+        // Call Blend's user_reserve_data function
+        // Reference: https://docs.rs/blend-interfaces/0.0.1/blend_interfaces/pool/trait.Pool.html
+        // For the mock/prototype, we use a simplified balance call.
+        let args: Vec<Val> = vec![env, asset.into_val(env), user.into_val(env)];
+
+        env.invoke_contract::<i128>(pool_address, &Symbol::new(env, "balance"), args)
     }
 }
 
@@ -552,6 +552,12 @@ impl NeuroWealthVault {
         env.storage()
             .instance()
             .set(&DataKey::UserDepositCap, &10_000_000_000_i128); // 10K USDC default
+        env.storage()
+            .instance()
+            .set(&DataKey::MinDeposit, &1_000_000_i128); // 1 USDC default
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxDeposit, &10_000_000_000_i128); // 10K USDC default
         env.storage().instance().set(&DataKey::Version, &1_u32);
 
         env.events().publish(
@@ -723,10 +729,15 @@ impl NeuroWealthVault {
             .get(&DataKey::CurrentProtocol)
             .unwrap_or(symbol_short!("none"));
 
+        let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
+        let token_client = token::Client::new(&env, &usdc_token);
+
+        // We use actual_to_return to track how much we can really give back.
+        // Initially, we assume we can fulfill the whole request.
+        let mut actual_to_return = amount;
+
         if current_protocol == symbol_short!("blend") {
             // Check vault's USDC balance
-            let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
-            let token_client = token::Client::new(&env, &usdc_token);
             let vault_balance = token_client.balance(&env.current_contract_address());
 
             // If vault doesn't have enough USDC, try to withdraw from Blend
@@ -735,23 +746,20 @@ impl NeuroWealthVault {
                 let needed = amount - vault_balance;
 
                 // Attempt to withdraw from Blend
-                // If this fails, we'll check balance again and may panic
-                // This ensures funds are available even when actively earning yield
+                // If this returns less than needed, we will reconcile below
                 let _withdrawn = Self::withdraw_from_blend(&env, needed);
 
-                // Verify we now have enough balance
-                // If not, the transaction will fail at the transfer step
-                let new_balance = token_client.balance(&env.current_contract_address());
-                if new_balance < amount {
-                    // This could happen if Blend withdrawal failed or returned less than expected
-                    // We continue anyway - the transfer will fail if insufficient
-                    // This prevents permanent lockup while still protecting user funds
-                }
+                // RECONCILIATION: Check actual available USDC after Blend withdrawal.
+                // We cap the withdrawal to what the vault actually has available.
+                let available_usdc = token_client.balance(&env.current_contract_address());
+                actual_to_return = min(amount, available_usdc);
             }
         }
 
+        assert!(actual_to_return > 0, "vault: insufficient liquidity");
+
         // Share-based withdrawal:
-        // - Convert requested asset amount to shares
+        // - Convert reconciled asset amount to shares
         // - Burn shares from user
         // - Return proportional assets based on current share price
 
@@ -769,7 +777,10 @@ impl NeuroWealthVault {
             "vault: no assets to withdraw"
         );
 
-        let shares_to_burn = Self::convert_to_shares_internal(&env, amount);
+        // We use actual_to_return to determine how many shares to burn.
+        // If Blend returned less than needed, the user will receive a partial
+        // withdrawal and keep their remaining shares.
+        let shares_to_burn = Self::convert_to_shares_internal(&env, actual_to_return);
         assert!(shares_to_burn > 0, "vault: shares to burn must be positive");
         assert!(
             user_shares >= shares_to_burn,
@@ -777,7 +788,7 @@ impl NeuroWealthVault {
         );
 
         // Calculate actual assets to return based on burned shares.
-        // Due to integer division, this may be slightly less than `amount`,
+        // Due to integer division, this may be slightly less than `actual_to_return`,
         // but never more (prevents over-withdrawal due to rounding).
         let usdc_to_return = Self::convert_to_assets_internal(&env, shares_to_burn);
 
@@ -822,8 +833,6 @@ impl NeuroWealthVault {
             );
         }
 
-        let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
-        let token_client = token::Client::new(&env, &usdc_token);
         token_client.transfer(&env.current_contract_address(), &user, &usdc_to_return);
 
         env.events().publish(
@@ -884,36 +893,8 @@ impl NeuroWealthVault {
             .get(&DataKey::CurrentProtocol)
             .unwrap_or(symbol_short!("none"));
 
-        if current_protocol == symbol_short!("blend") {
-            // Calculate how much the user is entitled to
-            let user_shares: i128 = env
-                .storage()
-                .persistent()
-                .get(&DataKey::Shares(user.clone()))
-                .unwrap_or(0);
-
-            if user_shares > 0 {
-                let total_shares = Self::get_total_shares_internal(&env);
-                let total_assets = Self::get_total_assets_internal(&env);
-
-                if total_shares > 0 && total_assets > 0 {
-                    let estimated_amount = Self::convert_to_assets_internal(&env, user_shares);
-
-                    // Check vault's USDC balance
-                    let usdc_token: Address =
-                        env.storage().instance().get(&DataKey::UsdcToken).unwrap();
-                    let token_client = token::Client::new(&env, &usdc_token);
-                    let vault_balance = token_client.balance(&env.current_contract_address());
-
-                    // If vault doesn't have enough USDC, try to withdraw from Blend
-                    if vault_balance < estimated_amount {
-                        // Attempt to withdraw enough from Blend
-                        let needed = estimated_amount - vault_balance;
-                        let _ = Self::withdraw_from_blend(&env, needed);
-                    }
-                }
-            }
-        }
+        let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
+        let token_client = token::Client::new(&env, &usdc_token);
 
         let user_shares: i128 = env
             .storage()
@@ -929,19 +910,47 @@ impl NeuroWealthVault {
             "vault: no assets to withdraw"
         );
 
-        // Calculate assets to return based on ALL user shares
-        let usdc_to_return = Self::convert_to_assets_internal(&env, user_shares);
-        assert!(usdc_to_return > 0, "vault: no assets to return");
+        // Calculate assets user is entitled to based on their shares
+        let entitled_amount = Self::convert_to_assets_internal(&env, user_shares);
+        let mut usdc_to_return = entitled_amount;
+        let mut shares_to_burn = user_shares;
 
-        // Update user shares to zero
-        env.storage()
-            .persistent()
-            .set(&DataKey::Shares(user.clone()), &0_i128);
+        if current_protocol == symbol_short!("blend") {
+            // Check vault's USDC balance
+            let vault_balance = token_client.balance(&env.current_contract_address());
+
+            // If vault doesn't have enough USDC, try to withdraw from Blend
+            if vault_balance < entitled_amount {
+                // Attempt to withdraw from Blend
+                let needed = entitled_amount - vault_balance;
+                let _ = Self::withdraw_from_blend(&env, needed);
+
+                // RECONCILIATION: Check actual available USDC after potential Blend withdrawal
+                let available_usdc = token_client.balance(&env.current_contract_address());
+
+                // If vault has less than entitled, we cap the withdrawal.
+                // The user receives what's available and keeps their remaining shares.
+                if available_usdc < entitled_amount {
+                    usdc_to_return = available_usdc;
+                    assert!(usdc_to_return > 0, "vault: no liquidity available");
+                    shares_to_burn = Self::convert_to_shares_internal(&env, usdc_to_return);
+                }
+            }
+        }
+
+        assert!(usdc_to_return > 0, "vault: no assets to return");
+        assert!(shares_to_burn > 0, "vault: no shares to burn");
+
+        // Update user shares
+        env.storage().persistent().set(
+            &DataKey::Shares(user.clone()),
+            &(user_shares - shares_to_burn),
+        );
 
         // Update total shares
         env.storage()
             .instance()
-            .set(&DataKey::TotalShares, &(total_shares - user_shares));
+            .set(&DataKey::TotalShares, &(total_shares - shares_to_burn));
 
         // Update total assets
         env.storage()
@@ -955,11 +964,12 @@ impl NeuroWealthVault {
             .get(&DataKey::Balance(user.clone()))
             .unwrap_or(0);
         if principal_balance > 0 {
-            let principal_repaid = min(principal_balance, usdc_to_return);
+            let principal_repaid = core::cmp::min(principal_balance, usdc_to_return);
 
-            env.storage()
-                .persistent()
-                .set(&DataKey::Balance(user.clone()), &0_i128);
+            env.storage().persistent().set(
+                &DataKey::Balance(user.clone()),
+                &(principal_balance - principal_repaid),
+            );
 
             let total_deposits: i128 = env
                 .storage()
@@ -1007,7 +1017,7 @@ impl NeuroWealthVault {
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
-    /// * `protocol` - The target protocol symbol (e.g., "blend", "none")
+    /// * `protocol` - The target protocol symbol. Supported values: "blend", "none"
     /// * `expected_apy` - Expected APY in basis points (e.g., 850 = 8.5%)
     ///
     /// # Returns
@@ -1084,11 +1094,7 @@ impl NeuroWealthVault {
                 .instance()
                 .set(&DataKey::CurrentProtocol, &symbol_short!("none"));
         } else {
-            // For other protocols (neither "blend" nor "none"), update the protocol tracking
-            // This ensures get_current_protocol() returns the expected value for tests
-            env.storage()
-                .instance()
-                .set(&DataKey::CurrentProtocol, &protocol);
+            panic!("vault: unsupported protocol");
         }
 
         env.events().publish(
@@ -2129,7 +2135,7 @@ impl NeuroWealthVault {
             .storage()
             .instance()
             .get(&DataKey::MinDeposit)
-            .unwrap_or(1_000_000);
+            .unwrap_or(0);
         assert!(amount >= min_deposit, "vault: below minimum deposit");
     }
 
@@ -2145,8 +2151,8 @@ impl NeuroWealthVault {
             .storage()
             .instance()
             .get(&DataKey::MaxDeposit)
-            .unwrap_or(10_000_000_000);
-        assert!(amount <= max_deposit, "vault: exceeds maximum deposit");
+            .unwrap_or(i128::MAX);
+        assert!(amount <= max_deposit, "vault: maximum deposit exceeded");
     }
 
     /// Validates that a deposit is within the user's cap.
@@ -2785,7 +2791,7 @@ mod tests {
         let (contract_id, _agent, _owner) = setup_vault(&env);
         let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
-        let protocol = symbol_short!("balanced");
+        let protocol = symbol_short!("none");
         let expected_apy = 850_i128; // 8.5% in basis points
 
         // Call rebalance as the agent (should succeed with mock_all_auths)

--- a/neurowealth-vault/contracts/vault/src/test.rs
+++ b/neurowealth-vault/contracts/vault/src/test.rs
@@ -14,69 +14,68 @@ enum TokenDataKey {
     Balance(Address),
 }
 
-#[contract]
-pub struct TestToken;
+mod token {
+    use super::*;
 
-#[contractimpl]
-impl TestToken {
-    pub fn mint(env: Env, to: Address, amount: i128) {
-        let balance: i128 = env
-            .storage()
-            .persistent()
-            .get(&TokenDataKey::Balance(to.clone()))
-            .unwrap_or(0);
-        env.storage()
-            .persistent()
-            .set(&TokenDataKey::Balance(to), &(balance + amount));
-    }
+    #[contract]
+    pub struct TestToken;
 
-    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
-        from.require_auth();
-        assert!(amount > 0, "amount must be positive");
+    #[contractimpl]
+    impl TestToken {
+        pub fn mint(env: Env, to: Address, amount: i128) {
+            let balance: i128 = env
+                .storage()
+                .persistent()
+                .get(&TokenDataKey::Balance(to.clone()))
+                .unwrap_or(0);
+            env.storage()
+                .persistent()
+                .set(&TokenDataKey::Balance(to), &(balance + amount));
+        }
 
-        let from_balance: i128 = env
-            .storage()
-            .persistent()
-            .get(&TokenDataKey::Balance(from.clone()))
-            .unwrap_or(0);
-        assert!(from_balance >= amount, "insufficient balance");
+        pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+            from.require_auth();
+            assert!(amount > 0, "amount must be positive");
 
-        let to_balance: i128 = env
-            .storage()
-            .persistent()
-            .get(&TokenDataKey::Balance(to.clone()))
-            .unwrap_or(0);
+            let from_balance: i128 = env
+                .storage()
+                .persistent()
+                .get(&TokenDataKey::Balance(from.clone()))
+                .unwrap_or(0);
+            assert!(from_balance >= amount, "insufficient balance");
 
-        env.storage()
-            .persistent()
-            .set(&TokenDataKey::Balance(from), &(from_balance - amount));
-        env.storage()
-            .persistent()
-            .set(&TokenDataKey::Balance(to), &(to_balance + amount));
-    }
+            let to_balance: i128 = env
+                .storage()
+                .persistent()
+                .get(&TokenDataKey::Balance(to.clone()))
+                .unwrap_or(0);
 
-    pub fn balance(env: Env, owner: Address) -> i128 {
-        env.storage()
-            .persistent()
-            .get(&TokenDataKey::Balance(owner))
-            .unwrap_or(0)
+            env.storage()
+                .persistent()
+                .set(&TokenDataKey::Balance(from), &(from_balance - amount));
+            env.storage()
+                .persistent()
+                .set(&TokenDataKey::Balance(to), &(to_balance + amount));
+        }
+
+        pub fn balance(env: Env, owner: Address) -> i128 {
+            env.storage()
+                .persistent()
+                .get(&TokenDataKey::Balance(owner))
+                .unwrap_or(0)
+        }
     }
 }
+
+use token::{TestToken, TestTokenClient};
+
 
 // ============================================================================
 // TEST SETUP FUNCTIONS
 // ============================================================================
 
 fn setup_vault(env: &Env) -> (Address, Address, Address) {
-    let contract_id = env.register_contract(None, NeuroWealthVault);
-    let client = NeuroWealthVaultClient::new(env, &contract_id);
-
-    let agent = Address::generate(env);
-    let usdc_token = Address::generate(env);
-    let owner = agent.clone();
-
-    client.initialize(&agent, &usdc_token);
-
+    let (contract_id, agent, owner, _usdc_token) = setup_vault_with_token(env);
     (contract_id, agent, owner)
 }
 
@@ -746,3 +745,145 @@ fn test_upgrade_emits_upgraded_event() {
     assert_eq!(event_data.old_version, 1u32);
     assert_eq!(event_data.new_version, 2u32);
 }
+
+// ============================================================================
+// MOCK BLEND POOL CONTRACT
+// ============================================================================
+
+mod blend {
+    use super::*;
+
+    #[contract]
+    pub struct MockBlendPool;
+
+    #[contractimpl]
+    impl MockBlendPool {
+        pub fn submit_with_allowance(
+            env: Env,
+            _from: Address,
+            _to: Address,
+            _spender: Address,
+            requests: Vec<BlendRequest>,
+        ) {
+            // Simple mock: just transfer tokens from vault to pool
+            let usdc_token = requests.get(0).unwrap().address;
+            let amount = requests.get(0).unwrap().amount;
+            let pool = env.current_contract_address();
+            let vault = _from;
+
+            let token_client = TestTokenClient::new(&env, &usdc_token);
+            token_client.transfer(&vault, &pool, &amount);
+        }
+
+        pub fn redeem(env: Env, asset: Address, amount: i128, to: Address) -> i128 {
+            let token_client = TestTokenClient::new(&env, &asset);
+            let pool_balance = token_client.balance(&env.current_contract_address());
+
+            // Mock partial redemption: return only half of what's in the pool if requested > 0
+            // this simulates a protocol with limited liquidity
+            let actual_to_return = if amount > 0 {
+                core::cmp::min(amount, pool_balance / 2)
+            } else {
+                0
+            };
+
+            if actual_to_return > 0 {
+                token_client.transfer(&env.current_contract_address(), &to, &actual_to_return);
+            }
+            actual_to_return
+        }
+
+        pub fn balance(env: Env, asset: Address, _user: Address) -> i128 {
+            TestTokenClient::new(&env, &asset).balance(&env.current_contract_address())
+        }
+    }
+}
+
+use blend::MockBlendPool;
+
+
+// ============================================================================
+// RECONCILIATION TESTS
+// ============================================================================
+
+#[test]
+fn test_withdraw_reconciles_partial_blend_redemption() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    let pool_id = env.register_contract(None, MockBlendPool);
+    client.set_blend_pool(&pool_id);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 10_000_000_i128; // 10 USDC
+
+    // 1. Initial Deposit
+    token_client.mint(&user, &deposit_amount);
+    client.deposit(&user, &deposit_amount);
+
+    // 2. Rebalance to Blend
+    client.rebalance(&symbol_short!("blend"), &800_i128);
+
+    // Verify funds moved to pool
+    assert_eq!(token_client.balance(&contract_id), 0);
+    assert_eq!(token_client.balance(&pool_id), deposit_amount);
+
+    // 3. User attempts to withdraw 6 USDC
+    // MockBlendPool will only return 5 USDC (half of its 10 USDC balance)
+    let withdraw_request = 6_000_000_i128;
+    client.withdraw(&user, &withdraw_request);
+
+    // 4. Verify Reconciliation
+    // User should have received 5 USDC, not 6.
+    assert_eq!(token_client.balance(&user), 5_000_000_i128);
+
+    // User's remaining shares should reflect that they only got 5 USDC.
+    // At 1:1 price, they should have 5,000,000 shares remaining (10M - 5M).
+    assert_eq!(client.get_shares(&user), 5_000_000_i128);
+
+    // Vault accounting should be consistent
+    assert_eq!(client.get_total_assets(), 5_000_000_i128);
+    assert_eq!(client.get_total_deposits(), 5_000_000_i128);
+}
+
+#[test]
+fn test_withdraw_all_reconciles_partial_blend_redemption() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    let pool_id = env.register_contract(None, MockBlendPool);
+    client.set_blend_pool(&pool_id);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 20_000_000_i128; // 20 USDC
+
+    // 1. Initial Deposit
+    token_client.mint(&user, &deposit_amount);
+    client.deposit(&user, &deposit_amount);
+
+    // 2. Rebalance to Blend
+    client.rebalance(&symbol_short!("blend"), &800_i128);
+
+    // 3. User attempts to withdraw_all (entitled to 20 USDC)
+    // MockBlendPool will only return 10 USDC (half of its 20 USDC balance)
+    client.withdraw_all(&user);
+
+    // 4. Verify Reconciliation
+    // User should have received 10 USDC
+    assert_eq!(token_client.balance(&user), 10_000_000_i128);
+
+    // User should still have 10,000,000 shares remaining
+    assert_eq!(client.get_shares(&user), 10_000_000_i128);
+
+    // Vault accounting should be consistent
+    assert_eq!(client.get_total_assets(), 10_000_000_i128);
+}
+

--- a/neurowealth-vault/contracts/vault/src/tests/test_access_control.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_access_control.rs
@@ -1,14 +1,106 @@
 //! Tests for ownership and agent access control
+//!
+//! Covers:
+//! - Owner-only functions: pause, unpause, emergency_pause, set_* config, upgrade
+//! - Agent-only functions: rebalance, update_total_assets
+//! - Two-step ownership transfer: initiate, accept, cancel
+//! - Paused-state enforcement on user operations
 
 use super::utils::*;
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+// ============================================================================
+// OWNER-ONLY HAPPY PATHS
+// ============================================================================
 
 #[test]
-fn test_update_agent_changes_agent() {
+fn test_owner_can_pause() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (contract_id, old_agent, _owner) = setup_vault(&env);
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    assert!(!client.is_paused());
+    client.pause(&owner);
+    assert!(client.is_paused());
+}
+
+#[test]
+fn test_owner_can_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.pause(&owner);
+    assert!(client.is_paused());
+
+    client.unpause(&owner);
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn test_owner_can_emergency_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    assert!(!client.is_paused());
+    client.emergency_pause(&owner);
+    assert!(client.is_paused());
+}
+
+#[test]
+fn test_owner_can_set_tvl_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let cap = 50_000_000_000_i128;
+    client.set_tvl_cap(&cap);
+    assert_eq!(client.get_tvl_cap(), cap);
+}
+
+#[test]
+fn test_owner_can_set_user_deposit_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let cap = 25_000_000_000_i128;
+    client.set_user_deposit_cap(&cap);
+    assert_eq!(client.get_user_deposit_cap(), cap);
+}
+
+#[test]
+fn test_owner_can_set_deposit_limits() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let min = 2_000_000_i128;
+    let max = 50_000_000_000_i128;
+    client.set_deposit_limits(&min, &max);
+    assert_eq!(client.get_min_deposit(), min);
+    assert_eq!(client.get_max_deposit(), max);
+}
+
+#[test]
+fn test_owner_can_update_agent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, old_agent, _owner, _usdc_token) = setup_vault_with_token(&env);
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     let new_agent = Address::generate(&env);
@@ -23,17 +115,13 @@ fn test_update_agent_emits_event() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (contract_id, _old_agent, _owner) = setup_vault(&env);
+    let (contract_id, _old_agent, _owner, _usdc_token) = setup_vault_with_token(&env);
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     let new_agent = Address::generate(&env);
     client.update_agent(&new_agent);
 
-    let agent_events = find_events_by_topic(
-        env.events().all(),
-        &env,
-        soroban_sdk::symbol_short!("agent"),
-    );
+    let agent_events = find_events_by_topic(env.events().all(), &env, symbol_short!("agent"));
     assert!(
         !agent_events.is_empty(),
         "update_agent should emit an event"
@@ -41,100 +129,7 @@ fn test_update_agent_emits_event() {
 }
 
 #[test]
-fn test_transfer_ownership_sets_pending_owner() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let (contract_id, _agent, _owner) = setup_vault(&env);
-    let client = NeuroWealthVaultClient::new(&env, &contract_id);
-
-    let new_owner = Address::generate(&env);
-    client.transfer_ownership(&new_owner);
-
-    // Pending owner should be set
-    let pending = client.get_pending_owner();
-    assert!(pending.is_some(), "Pending owner should be set");
-    assert_eq!(pending.unwrap(), new_owner);
-}
-
-#[test]
-fn test_accept_ownership_completes_transfer() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let (contract_id, _agent, old_owner) = setup_vault(&env);
-    let client = NeuroWealthVaultClient::new(&env, &contract_id);
-
-    let new_owner = Address::generate(&env);
-
-    // Initiate transfer
-    client.transfer_ownership(&new_owner);
-    assert_eq!(client.get_pending_owner().unwrap(), new_owner);
-
-    // Complete transfer
-    client.accept_ownership(&new_owner);
-
-    assert_eq!(client.get_owner(), new_owner);
-    assert_ne!(client.get_owner(), old_owner);
-    // Pending owner is cleared after acceptance
-    assert!(
-        client.get_pending_owner().is_none(),
-        "Pending owner should be cleared"
-    );
-}
-
-#[test]
-#[should_panic(expected = "vault: caller is not the pending owner")]
-fn test_wrong_address_cannot_accept_ownership() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let (contract_id, _agent, _owner) = setup_vault(&env);
-    let client = NeuroWealthVaultClient::new(&env, &contract_id);
-
-    let new_owner = Address::generate(&env);
-    client.transfer_ownership(&new_owner);
-
-    // A different address tries to accept
-    let impostor = Address::generate(&env);
-    client.accept_ownership(&impostor);
-}
-
-#[test]
-fn test_cancel_ownership_transfer_clears_pending() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let (contract_id, _agent, _owner) = setup_vault(&env);
-    let client = NeuroWealthVaultClient::new(&env, &contract_id);
-
-    let new_owner = Address::generate(&env);
-    client.transfer_ownership(&new_owner);
-    assert!(client.get_pending_owner().is_some());
-
-    client.cancel_ownership_transfer();
-
-    assert!(
-        client.get_pending_owner().is_none(),
-        "Pending owner should be cleared after cancel"
-    );
-}
-
-#[test]
-#[should_panic(expected = "vault: no pending owner to cancel")]
-fn test_cancel_without_pending_panics() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let (contract_id, _agent, _owner) = setup_vault(&env);
-    let client = NeuroWealthVaultClient::new(&env, &contract_id);
-
-    // No pending transfer started
-    client.cancel_ownership_transfer();
-}
-
-#[test]
-fn test_set_blend_pool_stores_address() {
+fn test_owner_can_set_blend_pool() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -144,30 +139,12 @@ fn test_set_blend_pool_stores_address() {
     let blend_pool = Address::generate(&env);
     client.set_blend_pool(&owner, &blend_pool);
 
-    // Just verify no "Blend pool not configured" panic when vault_balance is 0
-    client.rebalance(&soroban_sdk::symbol_short!("blend"), &500_i128);
-}
-
-#[test]
-#[should_panic(expected = "vault: only owner can set blend pool")]
-fn test_non_owner_cannot_set_blend_pool() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let (contract_id, _agent, _owner) = setup_vault(&env);
-    let client = NeuroWealthVaultClient::new(&env, &contract_id);
-
-    let blend_pool = Address::generate(&env);
-    let non_owner = Address::generate(&env);
-    // set_blend_pool checks owner == stored_owner explicitly
-    client.set_blend_pool(&non_owner, &blend_pool);
+    assert_eq!(client.get_blend_pool(), Some(blend_pool));
 }
 
 // ============================================================================
-// COMPREHENSIVE NEGATIVE ACCESS CONTROL TESTS
+// OWNER-ONLY NEGATIVE PATHS (non-owner must be rejected)
 // ============================================================================
-
-// --- Owner-only function tests (non-owner must be rejected) ---
 
 #[test]
 #[should_panic(expected = "vault: only owner can pause")]
@@ -184,7 +161,7 @@ fn test_non_owner_cannot_pause() {
 
 #[test]
 #[should_panic(expected = "vault: only owner can unpause")]
-fn test_non_owner_cannot_unpause_ac() {
+fn test_non_owner_cannot_unpause() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -217,6 +194,21 @@ fn test_non_owner_cannot_emergency_pause() {
 }
 
 #[test]
+#[should_panic(expected = "vault: only owner can set blend pool")]
+fn test_non_owner_cannot_set_blend_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let blend_pool = Address::generate(&env);
+    let non_owner = Address::generate(&env);
+    // set_blend_pool checks owner == stored_owner explicitly
+    client.set_blend_pool(&non_owner, &blend_pool);
+}
+
+#[test]
 #[should_panic(expected = "vault: caller is not the owner")]
 fn test_non_owner_cannot_upgrade() {
     let env = Env::default();
@@ -230,7 +222,48 @@ fn test_non_owner_cannot_upgrade() {
     client.upgrade(&non_owner, &fake_wasm_hash);
 }
 
-// --- Agent-only function tests (non-agent must be rejected) ---
+// ============================================================================
+// AGENT-ONLY HAPPY PATHS
+// ============================================================================
+
+#[test]
+fn test_agent_can_rebalance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    // "none" protocol is always safe — no external pool required
+    client.rebalance(&symbol_short!("none"), &500_i128);
+
+    assert_eq!(
+        client.get_current_protocol(),
+        symbol_short!("none"),
+        "CurrentProtocol should be 'none' after rebalance"
+    );
+}
+
+#[test]
+fn test_agent_can_update_total_assets() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 10_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
+
+    let new_total = deposit_amount;
+    client.update_total_assets(&agent, &new_total);
+    assert_eq!(client.get_total_assets(), new_total);
+}
+
+// ============================================================================
+// AGENT-ONLY NEGATIVE PATHS (non-agent must be rejected)
+// ============================================================================
 
 #[test]
 #[should_panic(expected = "vault: only agent can update total assets")]
@@ -249,11 +282,221 @@ fn test_non_agent_cannot_update_total_assets() {
     client.update_total_assets(&non_agent, &deposit_amount);
 }
 
-// --- Paused-state tests (user operations must be rejected) ---
+// ============================================================================
+// TWO-STEP OWNERSHIP TRANSFER
+// ============================================================================
+
+#[test]
+fn test_transfer_ownership_sets_pending_owner() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let new_owner = Address::generate(&env);
+    client.transfer_ownership(&new_owner);
+
+    // Pending owner should be set
+    let pending = client.get_pending_owner();
+    assert!(pending.is_some(), "Pending owner should be set");
+    assert_eq!(pending.unwrap(), new_owner);
+}
+
+#[test]
+fn test_transfer_ownership_does_not_change_owner_immediately() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let new_owner = Address::generate(&env);
+    client.transfer_ownership(&new_owner);
+
+    // Owner should remain unchanged until accept_ownership is called
+    assert_eq!(
+        client.get_owner(),
+        owner,
+        "Owner should not change until acceptance"
+    );
+}
+
+#[test]
+fn test_accept_ownership_completes_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, old_owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let new_owner = Address::generate(&env);
+
+    // Initiate transfer
+    client.transfer_ownership(&new_owner);
+    assert_eq!(client.get_pending_owner().unwrap(), new_owner);
+
+    // Complete transfer
+    client.accept_ownership(&new_owner);
+
+    assert_eq!(client.get_owner(), new_owner);
+    assert_ne!(client.get_owner(), old_owner);
+    // Pending owner is cleared after acceptance
+    assert!(
+        client.get_pending_owner().is_none(),
+        "Pending owner should be cleared"
+    );
+}
+
+#[test]
+fn test_new_owner_can_use_owner_functions_after_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _old_owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let new_owner = Address::generate(&env);
+    client.transfer_ownership(&new_owner);
+    client.accept_ownership(&new_owner);
+
+    // New owner can now pause (owner-only function)
+    client.pause(&new_owner);
+    assert!(client.is_paused());
+
+    // New owner can unpause
+    client.unpause(&new_owner);
+    assert!(!client.is_paused());
+}
+
+#[test]
+#[should_panic(expected = "vault: only owner can pause")]
+fn test_old_owner_cannot_use_owner_functions_after_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, old_owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let new_owner = Address::generate(&env);
+    client.transfer_ownership(&new_owner);
+    client.accept_ownership(&new_owner);
+
+    // Old owner can no longer pause
+    client.pause(&old_owner);
+}
+
+#[test]
+fn test_transfer_ownership_can_be_overwritten() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let first_candidate = Address::generate(&env);
+    let second_candidate = Address::generate(&env);
+
+    client.transfer_ownership(&first_candidate);
+    assert_eq!(client.get_pending_owner().unwrap(), first_candidate);
+
+    // Overwrite with a different candidate
+    client.transfer_ownership(&second_candidate);
+    assert_eq!(
+        client.get_pending_owner().unwrap(),
+        second_candidate,
+        "Pending owner should be updated to the latest candidate"
+    );
+}
+
+#[test]
+#[should_panic(expected = "vault: caller is not the pending owner")]
+fn test_wrong_address_cannot_accept_ownership() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let new_owner = Address::generate(&env);
+    client.transfer_ownership(&new_owner);
+
+    // A different address tries to accept
+    let impostor = Address::generate(&env);
+    client.accept_ownership(&impostor);
+}
+
+#[test]
+#[should_panic(expected = "vault: no pending owner")]
+fn test_accept_ownership_without_pending_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    // No transfer initiated — accept should panic
+    let random = Address::generate(&env);
+    client.accept_ownership(&random);
+}
+
+#[test]
+fn test_cancel_ownership_transfer_clears_pending() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let new_owner = Address::generate(&env);
+    client.transfer_ownership(&new_owner);
+    assert!(client.get_pending_owner().is_some());
+
+    client.cancel_ownership_transfer();
+
+    assert!(
+        client.get_pending_owner().is_none(),
+        "Pending owner should be cleared after cancel"
+    );
+}
+
+#[test]
+#[should_panic(expected = "vault: no pending owner to cancel")]
+fn test_cancel_without_pending_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    // No pending transfer started
+    client.cancel_ownership_transfer();
+}
+
+#[test]
+#[should_panic(expected = "vault: no pending owner")]
+fn test_accept_after_cancel_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let new_owner = Address::generate(&env);
+    client.transfer_ownership(&new_owner);
+    client.cancel_ownership_transfer();
+
+    // Transfer was cancelled — accept should fail
+    client.accept_ownership(&new_owner);
+}
+
+// ============================================================================
+// PAUSED-STATE ENFORCEMENT
+// ============================================================================
 
 #[test]
 #[should_panic(expected = "vault: paused")]
-fn test_deposit_blocked_while_paused_ac() {
+fn test_deposit_blocked_while_paused() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -271,7 +514,7 @@ fn test_deposit_blocked_while_paused_ac() {
 
 #[test]
 #[should_panic(expected = "vault: paused")]
-fn test_withdraw_blocked_while_paused_ac() {
+fn test_withdraw_blocked_while_paused() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -305,7 +548,7 @@ fn test_withdraw_all_blocked_while_paused() {
 
 #[test]
 #[should_panic(expected = "vault: paused")]
-fn test_rebalance_blocked_while_paused_ac() {
+fn test_rebalance_blocked_while_paused() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -313,5 +556,5 @@ fn test_rebalance_blocked_while_paused_ac() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     client.pause(&owner);
-    client.rebalance(&soroban_sdk::symbol_short!("none"), &500_i128);
+    client.rebalance(&symbol_short!("none"), &500_i128);
 }

--- a/neurowealth-vault/contracts/vault/src/tests/test_deposit.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_deposit.rs
@@ -56,7 +56,7 @@ fn test_deposit_below_minimum_panics() {
 }
 
 #[test]
-#[should_panic(expected = "vault: exceeds maximum deposit")]
+#[should_panic(expected = "vault: maximum deposit exceeded")]
 fn test_deposit_above_maximum_panics() {
     let env = Env::default();
     env.mock_all_auths();

--- a/neurowealth-vault/contracts/vault/src/tests/test_events.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_events.rs
@@ -1,33 +1,11 @@
 //! Tests verifying that each contract operation emits the expected event with correct payload values
 
 use super::utils::*;
-use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, TryFromVal, Val, Vec};
-
-fn get_val_at_index(env: &Env, vec: &Vec<Val>, index: u32) -> Val {
-    match vec.get(index) {
-        Some(val) => val,
-        None => Val::from_void().into(),
-    }
-}
-
-fn extract_i128(env: &Env, vec: &Vec<Val>, index: u32) -> i128 {
-    let val = get_val_at_index(env, vec, index);
-    i128::try_from_val(env, &val).unwrap_or(0)
-}
-
-fn extract_address(env: &Env, vec: &Vec<Val>, index: u32) -> Address {
-    let val = get_val_at_index(env, vec, index);
-    Address::try_from_val(env, &val).unwrap()
-}
-
-fn extract_symbol(env: &Env, vec: &Vec<Val>, index: u32) -> soroban_sdk::Symbol {
-    let val = get_val_at_index(env, vec, index);
-    soroban_sdk::Symbol::try_from_val(env, &val).unwrap_or(symbol_short!(""))
-}
-
-fn parse_event_data_as_vec(env: &Env, data: Val) -> Vec<Val> {
-    Vec::<Val>::try_from_val(env, &data).unwrap_or_else(|_| Vec::new(env))
-}
+use crate::{
+    AgentUpdatedEvent, AssetsUpdatedEvent, DepositEvent, EmergencyPausedEvent, LimitsUpdatedEvent,
+    RebalanceEvent, VaultInitializedEvent, VaultPausedEvent, VaultUnpausedEvent, WithdrawEvent,
+};
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, TryFromVal};
 
 #[test]
 fn test_initialize_emits_init_event_with_correct_payload() {
@@ -50,25 +28,19 @@ fn test_initialize_emits_init_event_with_correct_payload() {
     );
 
     let (_, _, data) = &init_events[0];
-    let fields = parse_event_data_as_vec(&env, data.clone());
+    let event =
+        VaultInitializedEvent::try_from_val(&env, data).expect("Should be a VaultInitializedEvent");
+
     assert_eq!(
-        fields.len(),
-        3,
-        "VaultInitializedEvent should have 3 fields"
-    );
-    assert_eq!(
-        extract_address(&env, &fields, 0),
-        agent,
+        event.agent, agent,
         "Event agent should match initialized agent"
     );
     assert_eq!(
-        extract_address(&env, &fields, 1),
-        usdc_token,
+        event.usdc_token, usdc_token,
         "Event usdc_token should match initialized token"
     );
     assert_eq!(
-        extract_i128(&env, &fields, 2),
-        expected_tvl_cap,
+        event.tvl_cap, expected_tvl_cap,
         "Event tvl_cap should match default cap"
     );
 }
@@ -89,21 +61,15 @@ fn test_deposit_emits_deposit_event_with_correct_payload() {
     assert!(!deposit_events.is_empty(), "Deposit should emit an event");
 
     let (_, _, data) = &deposit_events[0];
-    let fields = parse_event_data_as_vec(&env, data.clone());
-    assert_eq!(fields.len(), 3, "DepositEvent should have 3 fields");
+    let event = DepositEvent::try_from_val(&env, data).expect("Should be a DepositEvent");
+
+    assert_eq!(event.user, user, "Event user should match depositor");
     assert_eq!(
-        extract_address(&env, &fields, 0),
-        user,
-        "Event user should match depositor"
-    );
-    assert_eq!(
-        extract_i128(&env, &fields, 1),
-        deposit_amount,
+        event.amount, deposit_amount,
         "Event amount should match deposited amount"
     );
     assert_eq!(
-        extract_i128(&env, &fields, 2),
-        deposit_amount,
+        event.shares, deposit_amount,
         "First deposit should mint 1:1 shares"
     );
 }
@@ -128,16 +94,16 @@ fn test_deposit_multiple_users_events_correct() {
     assert_eq!(deposit_events.len(), 2, "Should emit two deposit events");
 
     let (_, _, data1) = &deposit_events[0];
-    let fields1 = parse_event_data_as_vec(&env, data1.clone());
-    assert_eq!(extract_address(&env, &fields1, 0), user1);
-    assert_eq!(extract_i128(&env, &fields1, 1), amount1);
-    assert_eq!(extract_i128(&env, &fields1, 2), amount1);
+    let event1 = DepositEvent::try_from_val(&env, data1).expect("Should be a DepositEvent");
+    assert_eq!(event1.user, user1);
+    assert_eq!(event1.amount, amount1);
+    assert_eq!(event1.shares, amount1);
 
     let (_, _, data2) = &deposit_events[1];
-    let fields2 = parse_event_data_as_vec(&env, data2.clone());
-    assert_eq!(extract_address(&env, &fields2, 0), user2);
-    assert_eq!(extract_i128(&env, &fields2, 1), amount2);
-    assert_eq!(extract_i128(&env, &fields2, 2), amount2);
+    let event2 = DepositEvent::try_from_val(&env, data2).expect("Should be a DepositEvent");
+    assert_eq!(event2.user, user2);
+    assert_eq!(event2.amount, amount2);
+    assert_eq!(event2.shares, amount2);
 }
 
 #[test]
@@ -159,21 +125,15 @@ fn test_withdraw_emits_withdraw_event_with_correct_payload() {
     assert!(!withdraw_events.is_empty(), "Withdraw should emit an event");
 
     let (_, _, data) = &withdraw_events[0];
-    let fields = parse_event_data_as_vec(&env, data.clone());
-    assert_eq!(fields.len(), 3, "WithdrawEvent should have 3 fields");
+    let event = WithdrawEvent::try_from_val(&env, data).expect("Should be a WithdrawEvent");
+
+    assert_eq!(event.user, user, "Event user should match withdrawer");
     assert_eq!(
-        extract_address(&env, &fields, 0),
-        user,
-        "Event user should match withdrawer"
-    );
-    assert_eq!(
-        extract_i128(&env, &fields, 1),
-        withdraw_amount,
+        event.amount, withdraw_amount,
         "Event amount should match withdrawn amount"
     );
     assert_eq!(
-        extract_i128(&env, &fields, 2),
-        withdraw_amount,
+        event.shares, withdraw_amount,
         "At 1:1 price, shares burned should equal amount"
     );
 }
@@ -195,24 +155,16 @@ fn test_withdraw_all_emits_withdraw_event() {
     assert_eq!(withdrawn, deposit_amount, "Should withdraw full balance");
 
     let withdraw_events = find_events_by_topic(env.events().all(), &env, symbol_short!("withdraw"));
-    let last_event = withdraw_events.last().unwrap();
-    let (_, _, data) = last_event;
-    let fields = parse_event_data_as_vec(&env, data.clone());
+    let last_event_data = &withdraw_events.last().unwrap().2;
+    let event =
+        WithdrawEvent::try_from_val(&env, last_event_data).expect("Should be a WithdrawEvent");
+
+    assert_eq!(event.user, user, "Event user should match withdrawer");
     assert_eq!(
-        extract_address(&env, &fields, 0),
-        user,
-        "Event user should match withdrawer"
-    );
-    assert_eq!(
-        extract_i128(&env, &fields, 1),
-        deposit_amount,
+        event.amount, deposit_amount,
         "Event amount should match full balance"
     );
-    assert_eq!(
-        extract_i128(&env, &fields, 2),
-        deposit_amount,
-        "Should burn all shares"
-    );
+    assert_eq!(event.shares, deposit_amount, "Should burn all shares");
 }
 
 #[test]
@@ -229,13 +181,8 @@ fn test_pause_emits_paused_event_with_correct_payload() {
     assert!(!pause_events.is_empty(), "Pause should emit an event");
 
     let (_, _, data) = &pause_events[0];
-    let fields = parse_event_data_as_vec(&env, data.clone());
-    assert_eq!(fields.len(), 1, "VaultPausedEvent should have 1 field");
-    assert_eq!(
-        extract_address(&env, &fields, 0),
-        owner,
-        "Event owner should match pauser"
-    );
+    let event = VaultPausedEvent::try_from_val(&env, data).expect("Should be a VaultPausedEvent");
+    assert_eq!(event.owner, owner, "Event owner should match pauser");
 }
 
 #[test]
@@ -253,13 +200,9 @@ fn test_unpause_emits_unpaused_event_with_correct_payload() {
     assert!(!unpause_events.is_empty(), "Unpause should emit an event");
 
     let (_, _, data) = &unpause_events[0];
-    let fields = parse_event_data_as_vec(&env, data.clone());
-    assert_eq!(fields.len(), 1, "VaultUnpausedEvent should have 1 field");
-    assert_eq!(
-        extract_address(&env, &fields, 0),
-        owner,
-        "Event owner should match unpauser"
-    );
+    let event =
+        VaultUnpausedEvent::try_from_val(&env, data).expect("Should be a VaultUnpausedEvent");
+    assert_eq!(event.owner, owner, "Event owner should match unpauser");
 }
 
 #[test]
@@ -279,11 +222,10 @@ fn test_emergency_pause_emits_emergency_event_with_correct_payload() {
     );
 
     let (_, _, data) = &emergency_events[0];
-    let fields = parse_event_data_as_vec(&env, data.clone());
-    assert_eq!(fields.len(), 1, "EmergencyPausedEvent should have 1 field");
+    let event =
+        EmergencyPausedEvent::try_from_val(&env, data).expect("Should be an EmergencyPausedEvent");
     assert_eq!(
-        extract_address(&env, &fields, 0),
-        agent,
+        event.owner, agent,
         "Event owner should match emergency pauser"
     );
 }
@@ -307,16 +249,14 @@ fn test_set_deposit_limits_emits_limits_event_with_correct_payload() {
     );
 
     let (_, _, data) = &limits_events[0];
-    let fields = parse_event_data_as_vec(&env, data.clone());
-    assert_eq!(fields.len(), 4, "LimitsUpdatedEvent should have 4 fields");
+    let event =
+        LimitsUpdatedEvent::try_from_val(&env, data).expect("Should be a LimitsUpdatedEvent");
     assert_eq!(
-        extract_i128(&env, &fields, 2),
-        new_min,
+        event.new_min, new_min,
         "Event new_min should match set value"
     );
     assert_eq!(
-        extract_i128(&env, &fields, 3),
-        new_max,
+        event.new_max, new_max,
         "Event new_max should match set value"
     );
 }
@@ -339,16 +279,14 @@ fn test_update_agent_emits_agent_event_with_correct_payload() {
     );
 
     let (_, _, data) = &agent_events[0];
-    let fields = parse_event_data_as_vec(&env, data.clone());
-    assert_eq!(fields.len(), 2, "AgentUpdatedEvent should have 2 fields");
+    let event =
+        AgentUpdatedEvent::try_from_val(&env, data).expect("Should be an AgentUpdatedEvent");
     assert_eq!(
-        extract_address(&env, &fields, 0),
-        old_agent,
+        event.old_agent, old_agent,
         "Event old_agent should match previous agent"
     );
     assert_eq!(
-        extract_address(&env, &fields, 1),
-        new_agent,
+        event.new_agent, new_agent,
         "Event new_agent should match new agent"
     );
 }
@@ -379,16 +317,14 @@ fn test_update_total_assets_emits_assets_event_with_correct_payload() {
     );
 
     let (_, _, data) = &assets_events[0];
-    let fields = parse_event_data_as_vec(&env, data.clone());
-    assert_eq!(fields.len(), 2, "AssetsUpdatedEvent should have 2 fields");
+    let event =
+        AssetsUpdatedEvent::try_from_val(&env, data).expect("Should be an AssetsUpdatedEvent");
     assert_eq!(
-        extract_i128(&env, &fields, 0),
-        old_total,
+        event.old_total, old_total,
         "Event old_total should match previous total"
     );
     assert_eq!(
-        extract_i128(&env, &fields, 1),
-        new_total,
+        event.new_total, new_total,
         "Event new_total should match new total"
     );
 }
@@ -412,16 +348,14 @@ fn test_rebalance_emits_rebalance_event_with_correct_payload() {
     );
 
     let (_, _, data) = &rebalance_events[0];
-    let fields = parse_event_data_as_vec(&env, data.clone());
-    assert_eq!(fields.len(), 2, "RebalanceEvent should have 2 fields");
+    let event = RebalanceEvent::try_from_val(&env, data).expect("Should be a RebalanceEvent");
     assert_eq!(
-        extract_symbol(&env, &fields, 0),
+        event.protocol,
         symbol_short!("none"),
         "Event protocol should match rebalance target"
     );
     assert_eq!(
-        extract_i128(&env, &fields, 1),
-        expected_apy,
+        event.expected_apy, expected_apy,
         "Event expected_apy should match provided APY"
     );
 }
@@ -445,17 +379,16 @@ fn test_rebalance_with_blend_emits_correct_event() {
 
     let rebalance_events =
         find_events_by_topic(env.events().all(), &env, symbol_short!("rebalance"));
-    let last_event = rebalance_events.last().unwrap();
-    let (_, _, data) = last_event;
-    let fields = parse_event_data_as_vec(&env, data.clone());
+    let last_event_data = &rebalance_events.last().unwrap().2;
+    let event =
+        RebalanceEvent::try_from_val(&env, last_event_data).expect("Should be a RebalanceEvent");
     assert_eq!(
-        extract_symbol(&env, &fields, 0),
+        event.protocol,
         symbol_short!("blend"),
         "Event protocol should be blend"
     );
     assert_eq!(
-        extract_i128(&env, &fields, 1),
-        expected_apy,
+        event.expected_apy, expected_apy,
         "Event expected_apy should match provided APY"
     );
 }
@@ -498,7 +431,7 @@ fn test_all_events_have_correct_topics() {
             "All events should be from vault contract"
         );
         assert!(
-            topics.len() >= 1,
+            !topics.is_empty(),
             "Each event should have at least one topic"
         );
     }

--- a/neurowealth-vault/contracts/vault/src/tests/test_rebalance.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_rebalance.rs
@@ -14,8 +14,8 @@ fn test_agent_can_rebalance_with_custom_protocol() {
     // Verify agent is set correctly
     assert_eq!(client.get_agent(), agent);
 
-    // Use a non-blend protocol so no Blend pool config is required
-    let protocol = symbol_short!("balanced");
+    // Use "none" protocol — always safe, no external pool required
+    let protocol = symbol_short!("none");
     let expected_apy = 500_i128; // 5% APY in basis points
 
     // Should succeed with mock_all_auths (require_is_agent passes)
@@ -60,8 +60,11 @@ fn test_rebalance_storage_current_protocol_changes() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let (contract_id, _agent, owner, usdc_token, blend_pool) =
+        setup_vault_with_token_and_blend(&env);
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_blend_pool(&owner, &blend_pool);
 
     // Initial state: no protocol set
     assert_eq!(
@@ -70,14 +73,18 @@ fn test_rebalance_storage_current_protocol_changes() {
         "Initial CurrentProtocol should be 'none'"
     );
 
-    // Rebalance to a protocol
-    client.rebalance(&symbol_short!("balanced"), &500_i128);
+    // Deposit so vault has funds to supply
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, 10_000_000_i128);
+
+    // Rebalance to blend
+    client.rebalance(&symbol_short!("blend"), &500_i128);
 
     // Assert storage state changed
     assert_eq!(
         client.get_current_protocol(),
-        symbol_short!("balanced"),
-        "CurrentProtocol should be 'balanced' after rebalance"
+        symbol_short!("blend"),
+        "CurrentProtocol should be 'blend' after rebalance"
     );
 }
 
@@ -248,4 +255,17 @@ fn test_mock_token_transfer_from_uses_and_decrements_allowance() {
     assert_eq!(token_client.balance(&owner), 6_000_000_i128);
     assert_eq!(token_client.balance(&recipient), 4_000_000_i128);
     assert_eq!(token_client.allowance(&owner, &spender), 2_000_000_i128);
+}
+
+#[test]
+#[should_panic(expected = "vault: unsupported protocol")]
+fn test_rebalance_with_unsupported_protocol_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    // "balanced" is not a supported protocol — should panic
+    client.rebalance(&symbol_short!("balanced"), &500_i128);
 }

--- a/neurowealth-vault/contracts/vault/src/tests/test_shares.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_shares.rs
@@ -54,9 +54,11 @@ fn test_total_shares_consistency_after_multiple_operations() {
 
     mint_and_deposit(&env, &client, &usdc_token, &user1, 2_000_000_i128);
 
+    // After yield (19.5M assets / 12M shares = 1.625 price)
+    // 2M assets / 1.625 = 1,230,769 shares
     assert_eq!(
         client.get_total_shares(),
-        total_after_withdraw + 2_000_000_i128
+        total_after_withdraw + 1_230_769_i128
     );
 }
 
@@ -273,7 +275,8 @@ fn test_withdraw_never_over_withdraws() {
     client.withdraw(&user, &10_000_000_i128);
 
     let shares_after = client.get_shares(&user);
-    assert_eq!(shares_after, shares_before - 10_000_000_i128);
+    // At 1.5x price (15M assets / 10M shares), 10M assets = 6,666,666 shares
+    assert_eq!(shares_after, shares_before - 6_666_666_i128);
     assert!(
         client.get_balance(&user) <= balance_before,
         "Balance should not increase from withdrawal"
@@ -334,18 +337,19 @@ fn test_rounding_down_on_share_mint() {
     let user1 = Address::generate(&env);
     let user2 = Address::generate(&env);
 
-    mint_and_deposit(&env, &client, &usdc_token, &user1, 3_i128);
+    // Initial deposit: 3,000,000 units -> 3,000,000 shares
+    mint_and_deposit(&env, &client, &usdc_token, &user1, 3_000_000_i128);
 
-    token_client.mint(&contract_id, &1_i128);
-    client.update_total_assets(&agent, &(4_i128));
+    // Inflate assets: total assets 4,000,000, total shares 3,000,000 (Price = 1.333...)
+    token_client.mint(&contract_id, &1_000_000_i128);
+    client.update_total_assets(&agent, &(4_000_000_i128));
 
-    mint_and_deposit(&env, &client, &usdc_token, &user2, 1_i128);
+    // User2 deposits 2,000,001 units
+    // Expected shares = floor(2,000,001 * 3,000,000 / 4,000,000) = floor(1,500,000.75) = 1,500,000
+    mint_and_deposit(&env, &client, &usdc_token, &user2, 2_000_001_i128);
 
     let user2_shares = client.get_shares(&user2);
-    assert!(
-        user2_shares <= 1_i128,
-        "Due to rounding, shares should be <= deposited amount"
-    );
+    assert_eq!(user2_shares, 1_500_000);
 }
 
 #[test]
@@ -370,10 +374,11 @@ fn test_withdraw_burns_proportional_shares_after_yield() {
     client.withdraw(&user, &withdraw_amount);
 
     let shares_after = client.get_shares(&user);
+    // At 2x price (20M assets / 10M shares), 5M assets = 2.5M shares
     assert_eq!(
         shares_after,
-        shares_before - withdraw_amount,
-        "At 2x price, should burn exactly withdraw_amount shares"
+        shares_before - 2_500_000_i128,
+        "At 2x price, should burn exactly 2.5M shares for 5M assets"
     );
 }
 

--- a/neurowealth-vault/contracts/vault/src/tests/utils.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/utils.rs
@@ -28,196 +28,220 @@ enum BlendMockDataKey {
     Supplied(Address),
 }
 
-#[contract]
-pub struct TestToken;
+pub mod token {
+    use super::*;
 
-#[contractimpl]
-impl TestToken {
-    pub fn mint(env: Env, to: Address, amount: i128) {
-        let balance: i128 = env
-            .storage()
-            .persistent()
-            .get(&TokenDataKey::Balance(to.clone()))
-            .unwrap_or(0);
-        env.storage()
-            .persistent()
-            .set(&TokenDataKey::Balance(to), &(balance + amount));
-    }
+    #[contract]
+    pub struct TestToken;
 
-    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
-        from.require_auth();
-        assert!(amount > 0, "amount must be positive");
-
-        let from_balance: i128 = env
-            .storage()
-            .persistent()
-            .get(&TokenDataKey::Balance(from.clone()))
-            .unwrap_or(0);
-        assert!(from_balance >= amount, "insufficient balance");
-
-        let to_balance: i128 = env
-            .storage()
-            .persistent()
-            .get(&TokenDataKey::Balance(to.clone()))
-            .unwrap_or(0);
-
-        env.storage()
-            .persistent()
-            .set(&TokenDataKey::Balance(from), &(from_balance - amount));
-        env.storage()
-            .persistent()
-            .set(&TokenDataKey::Balance(to), &(to_balance + amount));
-    }
-
-    pub fn balance(env: Env, owner: Address) -> i128 {
-        env.storage()
-            .persistent()
-            .get(&TokenDataKey::Balance(owner))
-            .unwrap_or(0)
-    }
-
-    pub fn approve(
-        env: Env,
-        from: Address,
-        spender: Address,
-        amount: i128,
-        expiration_ledger: u32,
-    ) {
-        from.require_auth();
-        assert!(amount >= 0, "amount must be non-negative");
-
-        env.storage().persistent().set(
-            &TokenDataKey::Allowance(from.clone(), spender.clone()),
-            &amount,
-        );
-        env.storage().persistent().set(
-            &TokenDataKey::AllowanceExpiration(from, spender),
-            &expiration_ledger,
-        );
-    }
-
-    pub fn allowance(env: Env, from: Address, spender: Address) -> i128 {
-        let expiration: u32 = env
-            .storage()
-            .persistent()
-            .get(&TokenDataKey::AllowanceExpiration(
-                from.clone(),
-                spender.clone(),
-            ))
-            .unwrap_or(0);
-
-        if expiration > 0 && expiration < env.ledger().sequence() {
-            return 0;
+    #[contractimpl]
+    impl TestToken {
+        pub fn mint(env: Env, to: Address, amount: i128) {
+            let balance: i128 = env
+                .storage()
+                .persistent()
+                .get(&TokenDataKey::Balance(to.clone()))
+                .unwrap_or(0);
+            env.storage()
+                .persistent()
+                .set(&TokenDataKey::Balance(to), &(balance + amount));
         }
 
-        env.storage()
-            .persistent()
-            .get(&TokenDataKey::Allowance(from, spender))
-            .unwrap_or(0)
-    }
+        pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+            from.require_auth();
+            assert!(amount > 0, "amount must be positive");
 
-    pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
-        spender.require_auth();
-        assert!(amount > 0, "amount must be positive");
+            let from_balance: i128 = env
+                .storage()
+                .persistent()
+                .get(&TokenDataKey::Balance(from.clone()))
+                .unwrap_or(0);
+            assert!(from_balance >= amount, "insufficient balance");
 
-        let allowance = Self::allowance(env.clone(), from.clone(), spender.clone());
-        assert!(allowance >= amount, "insufficient allowance");
+            let to_balance: i128 = env
+                .storage()
+                .persistent()
+                .get(&TokenDataKey::Balance(to.clone()))
+                .unwrap_or(0);
 
-        let from_balance: i128 = env
-            .storage()
-            .persistent()
-            .get(&TokenDataKey::Balance(from.clone()))
-            .unwrap_or(0);
-        assert!(from_balance >= amount, "insufficient balance");
+            env.storage()
+                .persistent()
+                .set(&TokenDataKey::Balance(from), &(from_balance - amount));
+            env.storage()
+                .persistent()
+                .set(&TokenDataKey::Balance(to), &(to_balance + amount));
+        }
 
-        let to_balance: i128 = env
-            .storage()
-            .persistent()
-            .get(&TokenDataKey::Balance(to.clone()))
-            .unwrap_or(0);
+        pub fn balance(env: Env, owner: Address) -> i128 {
+            env.storage()
+                .persistent()
+                .get(&TokenDataKey::Balance(owner))
+                .unwrap_or(0)
+        }
 
-        env.storage().persistent().set(
-            &TokenDataKey::Balance(from.clone()),
-            &(from_balance - amount),
-        );
-        env.storage()
-            .persistent()
-            .set(&TokenDataKey::Balance(to), &(to_balance + amount));
-        env.storage().persistent().set(
-            &TokenDataKey::Allowance(from, spender.clone()),
-            &(allowance - amount),
-        );
+        pub fn approve(
+            env: Env,
+            from: Address,
+            spender: Address,
+            amount: i128,
+            expiration_ledger: u32,
+        ) {
+            from.require_auth();
+            assert!(amount >= 0, "amount must be non-negative");
+
+            env.storage().persistent().set(
+                &TokenDataKey::Allowance(from.clone(), spender.clone()),
+                &amount,
+            );
+            env.storage().persistent().set(
+                &TokenDataKey::AllowanceExpiration(from, spender),
+                &expiration_ledger,
+            );
+        }
+
+        pub fn allowance(env: Env, from: Address, spender: Address) -> i128 {
+            let expiration: u32 = env
+                .storage()
+                .persistent()
+                .get(&TokenDataKey::AllowanceExpiration(
+                    from.clone(),
+                    spender.clone(),
+                ))
+                .unwrap_or(0);
+
+            if expiration > 0 && expiration < env.ledger().sequence() {
+                return 0;
+            }
+
+            env.storage()
+                .persistent()
+                .get(&TokenDataKey::Allowance(from, spender))
+                .unwrap_or(0)
+        }
+
+        pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
+            spender.require_auth();
+            assert!(amount > 0, "amount must be positive");
+
+            let allowance = Self::allowance(env.clone(), from.clone(), spender.clone());
+            assert!(allowance >= amount, "insufficient allowance");
+
+            let from_balance: i128 = env
+                .storage()
+                .persistent()
+                .get(&TokenDataKey::Balance(from.clone()))
+                .unwrap_or(0);
+            assert!(from_balance >= amount, "insufficient balance");
+
+            let to_balance: i128 = env
+                .storage()
+                .persistent()
+                .get(&TokenDataKey::Balance(to.clone()))
+                .unwrap_or(0);
+
+            env.storage().persistent().set(
+                &TokenDataKey::Balance(from.clone()),
+                &(from_balance - amount),
+            );
+            env.storage()
+                .persistent()
+                .set(&TokenDataKey::Balance(to), &(to_balance + amount));
+            env.storage().persistent().set(
+                &TokenDataKey::Allowance(from, spender.clone()),
+                &(allowance - amount),
+            );
+        }
     }
 }
 
-#[contract]
-pub struct MockBlendPool;
+pub use token::{TestToken, TestTokenClient};
 
-#[contractimpl]
-impl MockBlendPool {
-    pub fn submit_with_allowance(
-        env: Env,
-        from: Address,
-        spender: Address,
-        _to: Address,
-        requests: Vec<crate::BlendRequest>,
-    ) -> i128 {
-        assert_eq!(requests.len(), 1, "expected one request");
-        let request = requests.get(0).unwrap();
-        assert_eq!(request.request_type, 0, "expected supply request");
+pub mod blend {
+    use super::*;
 
-        let token_client = TestTokenClient::new(&env, &request.address);
-        let allowance = token_client.allowance(&spender, &env.current_contract_address());
-        assert!(
-            allowance >= request.amount,
-            "expected allowance before pool pull"
-        );
+    #[contract]
+    pub struct MockBlendPool;
 
-        token_client.transfer_from(
-            &env.current_contract_address(),
-            &spender,
-            &env.current_contract_address(),
-            &request.amount,
-        );
+    #[contractimpl]
+    impl MockBlendPool {
+        pub fn submit_with_allowance(
+            env: Env,
+            from: Address,
+            spender: Address,
+            _to: Address,
+            requests: Vec<crate::BlendRequest>,
+        ) -> i128 {
+            assert_eq!(requests.len(), 1, "expected one request");
+            let request = requests.get(0).unwrap();
+            assert_eq!(request.request_type, 0, "expected supply request");
 
-        let total_supplied: i128 = env
-            .storage()
-            .persistent()
-            .get(&BlendMockDataKey::Supplied(request.address.clone()))
-            .unwrap_or(0);
-        env.storage().persistent().set(
-            &BlendMockDataKey::Supplied(request.address),
-            &(total_supplied + request.amount),
-        );
+            let token_client = TestTokenClient::new(&env, &request.address);
+            let allowance = token_client.allowance(&spender, &env.current_contract_address());
+            assert!(
+                allowance >= request.amount,
+                "expected allowance before pool pull"
+            );
 
-        from.clone().require_auth();
+            token_client.transfer_from(
+                &env.current_contract_address(),
+                &spender,
+                &env.current_contract_address(),
+                &request.amount,
+            );
 
-        request.amount
-    }
+            let total_supplied: i128 = env
+                .storage()
+                .persistent()
+                .get(&BlendMockDataKey::Supplied(request.address.clone()))
+                .unwrap_or(0);
+            env.storage().persistent().set(
+                &BlendMockDataKey::Supplied(request.address),
+                &(total_supplied + request.amount),
+            );
 
-    pub fn supplied(env: Env, asset: Address) -> i128 {
-        env.storage()
-            .persistent()
-            .get(&BlendMockDataKey::Supplied(asset))
-            .unwrap_or(0)
+            from.clone().require_auth();
+
+            request.amount
+        }
+
+        pub fn redeem(env: Env, asset: Address, amount: i128, to: Address) -> i128 {
+            let token_client = TestTokenClient::new(&env, &asset);
+            let pool_balance = token_client.balance(&env.current_contract_address());
+
+            // Mock partial redemption: return only half if requested > 0
+            let actual_to_return = if amount > 0 {
+                core::cmp::min(amount, pool_balance / 2)
+            } else {
+                0
+            };
+
+            if actual_to_return > 0 {
+                token_client.transfer(&env.current_contract_address(), &to, &actual_to_return);
+            }
+            actual_to_return
+        }
+
+        pub fn balance(env: Env, asset: Address, _user: Address) -> i128 {
+            TestTokenClient::new(&env, &asset).balance(&env.current_contract_address())
+        }
+
+        pub fn supplied(env: Env, asset: Address) -> i128 {
+            env.storage()
+                .persistent()
+                .get(&BlendMockDataKey::Supplied(asset))
+                .unwrap_or(0)
+        }
     }
 }
+
+pub use blend::{MockBlendPool, MockBlendPoolClient};
 
 // ============================================================================
 // TEST SETUP FUNCTIONS
 // ============================================================================
 
-/// Sets up a vault with a mock (non-functional) USDC token address.
 pub fn setup_vault(env: &Env) -> (Address, Address, Address) {
-    let contract_id = env.register_contract(None, NeuroWealthVault);
-    let client = NeuroWealthVaultClient::new(env, &contract_id);
-
-    let agent = Address::generate(env);
-    let usdc_token = Address::generate(env);
-    let owner = agent.clone();
-
-    client.initialize(&agent, &usdc_token);
-
+    let (contract_id, agent, owner, _usdc_token) = setup_vault_with_token(env);
     (contract_id, agent, owner)
 }
 


### PR DESCRIPTION
closes #58 
closes #55 
closes #56 

## Summary
Implment test acces control, balanced/conservative/growth, reconcile withdraw-from-Blend accounting with actual redeemed amount

## Changes

### test(access_control): implement owner/agent authorization + ownership transfer tests 
(#55)

### fix(rebalance): either implement “balanced/conservative/growth” or restrict tests/docs to supported protocols
(#56)

### fix(accounting): reconcile withdraw-from-Blend accounting with actual redeemed amount
(#58)

<img width="748" height="542" alt="image" src="https://github.com/user-attachments/assets/280e931e-e673-4589-804c-31abc9d64a1c" />



