### PR TITLE
Fix vault init roles and configuration validation

### DIFF
--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -271,6 +271,26 @@ pub struct EmergencyPausedEvent {
     pub owner: Address,
 }
 
+/// Emitted when the TVL cap is updated.
+///
+/// # Topics
+/// - `SymbolShort("tvl_cap_updated")` - Event identifier
+#[contracttype]
+pub struct TvlCapUpdatedEvent {
+    pub old_cap: i128,
+    pub new_cap: i128,
+}
+
+/// Emitted when the per-user deposit cap is updated.
+///
+/// # Topics
+/// - `SymbolShort("user_cap_updated")` - Event identifier
+#[contracttype]
+pub struct UserDepositCapUpdatedEvent {
+    pub old_cap: i128,
+    pub new_cap: i128,
+}
+
 /// Emitted when deposit limits are updated.
 ///
 /// # Topics
@@ -564,7 +584,7 @@ impl NeuroWealthVault {
     /// - The deployer should verify the agent and token addresses are correct
     /// - After initialization, the deployer should transfer ownership or destroy
     ///   the deployer key to prevent re-initialization
-    pub fn initialize(env: Env, agent: Address, usdc_token: Address) {
+    pub fn initialize(env: Env, owner: Address, agent: Address, usdc_token: Address) {
         if env.storage().instance().has(&DataKey::Agent) {
             panic!("vault: already initialized");
         }
@@ -581,7 +601,7 @@ impl NeuroWealthVault {
         env.storage().instance().set(&DataKey::TotalShares, &0_i128);
         env.storage().instance().set(&DataKey::TotalAssets, &0_i128);
         env.storage().instance().set(&DataKey::Paused, &false);
-        env.storage().instance().set(&DataKey::Owner, &agent);
+        env.storage().instance().set(&DataKey::Owner, &owner);
         env.storage().instance().set(&DataKey::TvLCap, &tvl_cap);
         env.storage()
             .instance()
@@ -640,6 +660,7 @@ impl NeuroWealthVault {
     /// - Checks are performed before state updates (checks-effects-interactions pattern)
     /// - Balance is updated after successful token transfer
     pub fn deposit(env: Env, user: Address, amount: i128) {
+        Self::require_initialized(&env);
         user.require_auth();
 
         Self::require_not_paused(&env);
@@ -751,6 +772,7 @@ impl NeuroWealthVault {
     /// - Uses checks-effects-interactions pattern: balance updated before transfer
     /// - Funds are pulled from Blend if necessary before user transfer
     pub fn withdraw(env: Env, user: Address, amount: i128) {
+        Self::require_initialized(&env);
         user.require_auth();
 
         Self::require_not_paused(&env);
@@ -916,6 +938,7 @@ impl NeuroWealthVault {
     /// - Uses checks-effects-interactions pattern
     /// - Funds are pulled from Blend if necessary before user transfer
     pub fn withdraw_all(env: Env, user: Address) -> i128 {
+        Self::require_initialized(&env);
         user.require_auth();
 
         Self::require_not_paused(&env);
@@ -1073,6 +1096,7 @@ impl NeuroWealthVault {
     /// - Funds are moved on-chain via cross-contract calls
     /// - Errors in protocol calls are handled gracefully to prevent fund lockup
     pub fn rebalance(env: Env, protocol: Symbol, expected_apy: i128) {
+        Self::require_initialized(&env);
         Self::require_not_paused(&env);
         Self::require_is_agent(&env);
 
@@ -1172,6 +1196,7 @@ impl NeuroWealthVault {
     /// - There is no automatic unpause - owner must explicitly call unpause()
     /// - Users' funds remain safe and can be withdrawn after unpause
     pub fn pause(env: Env, owner: Address) {
+        Self::require_initialized(&env);
         owner.require_auth();
         let stored_owner: Address = env.storage().instance().get(&DataKey::Owner).unwrap();
         assert_eq!(owner, stored_owner, "vault: only owner can pause");
@@ -1203,6 +1228,7 @@ impl NeuroWealthVault {
     /// # Security
     /// - Only the owner can unpause the vault (verified via require_auth)
     pub fn unpause(env: Env, owner: Address) {
+        Self::require_initialized(&env);
         owner.require_auth();
         let stored_owner: Address = env.storage().instance().get(&DataKey::Owner).unwrap();
         assert_eq!(owner, stored_owner, "vault: only owner can unpause");
@@ -1243,6 +1269,7 @@ impl NeuroWealthVault {
     /// # Security
     /// - Only the owner can emergency pause the vault (verified via require_auth)
     pub fn emergency_pause(env: Env, owner: Address) {
+        Self::require_initialized(&env);
         owner.require_auth();
         let stored_owner: Address = env.storage().instance().get(&DataKey::Owner).unwrap();
         assert_eq!(owner, stored_owner, "vault: only owner can emergency pause");
@@ -1274,30 +1301,24 @@ impl NeuroWealthVault {
     /// - If the caller is not the owner
     ///
     /// # Events
-    /// Emits `LimitsUpdatedEvent` with old and new values for both limits
+    /// Emits `TvlCapUpdatedEvent`
     ///
     /// # Security
     /// - Only the owner can modify the TVL cap
     /// - Reducing the cap below current total deposits does not affect existing deposits
     pub fn set_tvl_cap(env: Env, cap: i128) {
+        Self::require_initialized(&env);
         Self::require_is_owner(&env);
 
         let old_tvl_cap = env.storage().instance().get(&DataKey::TvLCap).unwrap_or(0);
-        let old_user_cap = env
-            .storage()
-            .instance()
-            .get(&DataKey::UserDepositCap)
-            .unwrap_or(0);
 
         env.storage().instance().set(&DataKey::TvLCap, &cap);
 
         env.events().publish(
-            (symbol_short!("limits"),),
-            LimitsUpdatedEvent {
-                old_min: old_user_cap,
-                new_min: old_user_cap,
-                old_max: old_tvl_cap,
-                new_max: cap,
+            (symbol_short!("tvl_cap"),),
+            TvlCapUpdatedEvent {
+                old_cap: old_tvl_cap,
+                new_cap: cap,
             },
         );
     }
@@ -1318,15 +1339,15 @@ impl NeuroWealthVault {
     /// - If the caller is not the owner
     ///
     /// # Events
-    /// Emits `LimitsUpdatedEvent` with old and new values for both limits
+    /// Emits `UserDepositCapUpdatedEvent`
     ///
     /// # Security
     /// - Only the owner can modify the user deposit cap
     /// - Reducing the cap below a user's current balance does not affect them
     pub fn set_user_deposit_cap(env: Env, cap: i128) {
+        Self::require_initialized(&env);
         Self::require_is_owner(&env);
 
-        let old_tvl_cap = env.storage().instance().get(&DataKey::TvLCap).unwrap_or(0);
         let old_user_cap = env
             .storage()
             .instance()
@@ -1336,12 +1357,10 @@ impl NeuroWealthVault {
         env.storage().instance().set(&DataKey::UserDepositCap, &cap);
 
         env.events().publish(
-            (symbol_short!("limits"),),
-            LimitsUpdatedEvent {
-                old_min: old_user_cap,
-                new_min: cap,
-                old_max: old_tvl_cap,
-                new_max: old_tvl_cap,
+            (symbol_short!("user_cap"),),
+            UserDepositCapUpdatedEvent {
+                old_cap: old_user_cap,
+                new_cap: cap,
             },
         );
     }
@@ -1372,6 +1391,7 @@ impl NeuroWealthVault {
     /// # Security
     /// - Only the owner can modify the limits
     pub fn set_limits(env: Env, min: i128, max: i128) {
+        Self::require_initialized(&env);
         Self::require_is_owner(&env);
 
         let old_user_cap = env
@@ -1423,6 +1443,7 @@ impl NeuroWealthVault {
     /// # Security
     /// - Only the owner can modify the deposit limits
     pub fn set_deposit_limits(env: Env, min: i128, max: i128) {
+        Self::require_initialized(&env);
         Self::require_is_owner(&env);
 
         // Validate limits
@@ -1462,6 +1483,7 @@ impl NeuroWealthVault {
     /// # Returns
     /// The current TVL cap in USDC units (7 decimal places), or 0 if no cap
     pub fn get_tvl_cap(env: Env) -> i128 {
+        Self::require_initialized(&env);
         env.storage().instance().get(&DataKey::TvLCap).unwrap_or(0)
     }
 
@@ -1473,6 +1495,7 @@ impl NeuroWealthVault {
     /// # Returns
     /// The current per-user deposit cap in USDC units (7 decimal places), or 0 if no cap
     pub fn get_user_deposit_cap(env: Env) -> i128 {
+        Self::require_initialized(&env);
         env.storage()
             .instance()
             .get(&DataKey::UserDepositCap)
@@ -1487,6 +1510,7 @@ impl NeuroWealthVault {
     /// # Returns
     /// The current minimum deposit limit in USDC units (7 decimal places)
     pub fn get_min_deposit(env: Env) -> i128 {
+        Self::require_initialized(&env);
         env.storage()
             .instance()
             .get(&DataKey::MinDeposit)
@@ -1501,6 +1525,7 @@ impl NeuroWealthVault {
     /// # Returns
     /// The current maximum deposit limit in USDC units (7 decimal places)
     pub fn get_max_deposit(env: Env) -> i128 {
+        Self::require_initialized(&env);
         env.storage()
             .instance()
             .get(&DataKey::MaxDeposit)
@@ -1531,6 +1556,7 @@ impl NeuroWealthVault {
     /// - Only the owner can update the agent
     /// - The old agent will immediately lose access to rebalance()
     pub fn update_agent(env: Env, new_agent: Address) {
+        Self::require_initialized(&env);
         Self::require_is_owner(&env);
 
         let old_agent: Address = env.storage().instance().get(&DataKey::Agent).unwrap();
@@ -1566,9 +1592,18 @@ impl NeuroWealthVault {
     /// - Only the owner can set the Blend pool address
     /// - The pool address should be verified against Blend's official deployments
     pub fn set_blend_pool(env: Env, owner: Address, pool_address: Address) {
+        Self::require_initialized(&env);
         owner.require_auth();
         let stored_owner: Address = env.storage().instance().get(&DataKey::Owner).unwrap();
         assert_eq!(owner, stored_owner, "vault: only owner can set blend pool");
+
+        let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
+        let _ = BlendPoolClient::get_balance(
+            &env,
+            &pool_address,
+            &usdc_token,
+            &env.current_contract_address(),
+        );
 
         env.storage()
             .instance()
@@ -1612,6 +1647,7 @@ impl NeuroWealthVault {
     /// - New owner must explicitly accept (prevents accidental transfers)
     /// - Can be cancelled by calling with zero address or initiating new transfer
     pub fn transfer_ownership(env: Env, new_owner: Address) {
+        Self::require_initialized(&env);
         Self::require_is_owner(&env);
 
         let current_owner: Address = env.storage().instance().get(&DataKey::Owner).unwrap();
@@ -1656,6 +1692,7 @@ impl NeuroWealthVault {
     /// - Requires explicit authorization from new owner
     /// - Clears pending owner after successful transfer
     pub fn accept_ownership(env: Env, new_owner: Address) {
+        Self::require_initialized(&env);
         new_owner.require_auth();
 
         let pending: Address = env
@@ -1703,6 +1740,7 @@ impl NeuroWealthVault {
     /// # Security
     /// - Only current owner can cancel
     pub fn cancel_ownership_transfer(env: Env) {
+        Self::require_initialized(&env);
         Self::require_is_owner(&env);
 
         let pending: Address = env
@@ -1732,6 +1770,7 @@ impl NeuroWealthVault {
     /// # Returns
     /// The pending owner address, or None if no transfer is pending
     pub fn get_pending_owner(env: Env) -> Option<Address> {
+        Self::require_initialized(&env);
         env.storage().instance().get(&DataKey::PendingOwner)
     }
 
@@ -1765,6 +1804,7 @@ impl NeuroWealthVault {
     /// - Verifies vault actually holds sufficient USDC to back the reported assets
     /// - Prevents agent from inflating asset values beyond actual holdings
     pub fn update_total_assets(env: Env, agent: Address, new_total: i128) {
+        Self::require_initialized(&env);
         // Agent-controlled yield update
         let stored_agent: Address = env.storage().instance().get(&DataKey::Agent).unwrap();
         assert_eq!(
@@ -1836,6 +1876,7 @@ impl NeuroWealthVault {
     /// - The version counter increments atomically with the WASM swap
     /// - All user balances and state are preserved across upgrades
     pub fn upgrade(env: Env, owner: Address, new_wasm_hash: BytesN<32>) {
+        Self::require_initialized(&env);
         owner.require_auth();
 
         let stored_owner: Address = env.storage().instance().get(&DataKey::Owner).unwrap();
@@ -1882,6 +1923,7 @@ impl NeuroWealthVault {
     /// # Events
     /// None
     pub fn get_balance(env: Env, user: Address) -> i128 {
+        Self::require_initialized(&env);
         // Extend TTL for user's share balance to prevent expiration
         let shares_key = DataKey::Shares(user.clone());
         if env.storage().persistent().has(&shares_key) {
@@ -1922,6 +1964,7 @@ impl NeuroWealthVault {
     /// # Events
     /// None
     pub fn get_total_deposits(env: Env) -> i128 {
+        Self::require_initialized(&env);
         env.storage()
             .instance()
             .get(&DataKey::TotalDeposits)
@@ -1933,6 +1976,7 @@ impl NeuroWealthVault {
     /// This value is used for share pricing and reflects the full value
     /// backing all outstanding shares.
     pub fn get_total_assets(env: Env) -> i128 {
+        Self::require_initialized(&env);
         Self::get_total_assets_internal(&env)
     }
 
@@ -1941,6 +1985,7 @@ impl NeuroWealthVault {
     /// This is the sum of all user shares and represents proportional ownership
     /// of the vault's total assets.
     pub fn get_total_shares(env: Env) -> i128 {
+        Self::require_initialized(&env);
         Self::get_total_shares_internal(&env)
     }
 
@@ -1948,6 +1993,7 @@ impl NeuroWealthVault {
     ///
     /// This is the number of vault shares the user owns.
     pub fn get_shares(env: Env, user: Address) -> i128 {
+        Self::require_initialized(&env);
         // Extend TTL for user's share balance to prevent expiration
         let shares_key = DataKey::Shares(user.clone());
         if env.storage().persistent().has(&shares_key) {
@@ -1958,6 +2004,7 @@ impl NeuroWealthVault {
     }
 
     pub fn get_user_info(env: Env, user: Address) -> UserInfo {
+        Self::require_initialized(&env);
         let principal: i128 = env
             .storage()
             .persistent()
@@ -1969,22 +2016,26 @@ impl NeuroWealthVault {
     }
 
     pub fn preview_deposit_to_shares(env: Env, assets: i128) -> i128 {
+        Self::require_initialized(&env);
         Self::convert_to_shares_internal(&env, assets)
     }
 
     pub fn preview_shares_to_assets(env: Env, shares: i128) -> i128 {
+        Self::require_initialized(&env);
         Self::convert_to_assets_internal(&env, shares)
     }
 
     /// Converts an asset amount (USDC) to the corresponding number of shares,
     /// using the current share price.
     pub fn convert_to_shares(env: Env, assets: i128) -> i128 {
+        Self::require_initialized(&env);
         Self::convert_to_shares_internal(&env, assets)
     }
 
     /// Converts a share amount to the corresponding asset amount (USDC),
     /// using the current share price.
     pub fn convert_to_assets(env: Env, shares: i128) -> i128 {
+        Self::require_initialized(&env);
         Self::convert_to_assets_internal(&env, shares)
     }
 
@@ -2005,6 +2056,7 @@ impl NeuroWealthVault {
     /// # Events
     /// None
     pub fn get_agent(env: Env) -> Address {
+        Self::require_initialized(&env);
         env.storage().instance().get(&DataKey::Agent).unwrap()
     }
 
@@ -2024,6 +2076,7 @@ impl NeuroWealthVault {
     /// # Events
     /// None
     pub fn get_owner(env: Env) -> Address {
+        Self::require_initialized(&env);
         env.storage().instance().get(&DataKey::Owner).unwrap()
     }
 
@@ -2041,6 +2094,7 @@ impl NeuroWealthVault {
     /// # Events
     /// None
     pub fn is_paused(env: Env) -> bool {
+        Self::require_initialized(&env);
         env.storage()
             .instance()
             .get(&DataKey::Paused)
@@ -2063,6 +2117,7 @@ impl NeuroWealthVault {
     /// # Events
     /// None
     pub fn get_version(env: Env) -> u32 {
+        Self::require_initialized(&env);
         env.storage().instance().get(&DataKey::Version).unwrap_or(1)
     }
 
@@ -2080,6 +2135,7 @@ impl NeuroWealthVault {
     /// # Events
     /// None
     pub fn get_usdc_token(env: Env) -> Address {
+        Self::require_initialized(&env);
         env.storage().instance().get(&DataKey::UsdcToken).unwrap()
     }
 
@@ -2100,6 +2156,7 @@ impl NeuroWealthVault {
     /// # Events
     /// None
     pub fn get_current_protocol(env: Env) -> Symbol {
+        Self::require_initialized(&env);
         env.storage()
             .instance()
             .get(&DataKey::CurrentProtocol)
@@ -2123,6 +2180,7 @@ impl NeuroWealthVault {
     /// # Events
     /// None
     pub fn get_blend_pool(env: Env) -> Option<Address> {
+        Self::require_initialized(&env);
         env.storage().instance().get(&DataKey::BlendPool)
     }
 
@@ -2144,12 +2202,27 @@ impl NeuroWealthVault {
         assert!(!paused, "vault: paused");
     }
 
+    /// Validates that the vault has been initialized.
+    ///
+    /// # Panics
+    /// - If the vault has not been initialized yet
+    #[inline]
+    fn require_initialized(env: &Env) {
+        assert!(
+            env.storage().instance().has(&DataKey::Agent)
+                && env.storage().instance().has(&DataKey::UsdcToken)
+                && env.storage().instance().has(&DataKey::Owner),
+            "vault: not initialized"
+        );
+    }
+
     /// Validates that the caller is the contract owner.
     ///
     /// # Panics
     /// - If the caller is not the owner
     #[inline]
     fn require_is_owner(env: &Env) {
+        Self::require_initialized(env);
         let owner: Address = env.storage().instance().get(&DataKey::Owner).unwrap();
         owner.require_auth();
     }
@@ -2160,6 +2233,7 @@ impl NeuroWealthVault {
     /// - If the caller is not the agent
     #[inline]
     fn require_is_agent(env: &Env) {
+        Self::require_initialized(env);
         let agent: Address = env.storage().instance().get(&DataKey::Agent).unwrap();
         agent.require_auth();
     }
@@ -2539,9 +2613,9 @@ mod tests {
 
         let agent = Address::generate(env);
         let usdc_token = Address::generate(env);
-        let owner = agent.clone();
+        let owner = Address::generate(env);
 
-        client.initialize(&agent, &usdc_token);
+        client.initialize(&owner, &agent, &usdc_token);
 
         (contract_id, agent, owner)
     }
@@ -2556,8 +2630,9 @@ mod tests {
 
         let agent = Address::generate(&env);
         let usdc_token = Address::generate(&env);
+        let owner = Address::generate(&env);
 
-        client.initialize(&agent, &usdc_token);
+        client.initialize(&owner, &agent, &usdc_token);
 
         // Verify initialization
         assert_eq!(client.get_agent(), agent);
@@ -2725,8 +2800,9 @@ mod tests {
         let agent = Address::generate(&env);
         let user = Address::generate(&env);
         let usdc_token = Address::generate(&env);
+        let owner = Address::generate(&env);
 
-        client.initialize(&agent, &usdc_token);
+        client.initialize(&owner, &agent, &usdc_token);
 
         // Verify initial state
         assert_eq!(client.get_balance(&user), 0);
@@ -2800,8 +2876,9 @@ mod tests {
         let agent = Address::generate(&env);
         let _user = Address::generate(&env);
         let usdc_token = Address::generate(&env);
+        let owner = Address::generate(&env);
 
-        client.initialize(&agent, &usdc_token);
+        client.initialize(&owner, &agent, &usdc_token);
 
         // The withdraw() function implements CEI pattern:
         // CHECKS: user.require_auth(), require_not_paused(), require_positive_amount(), balance check
@@ -2956,9 +3033,9 @@ mod tests {
 
         let usdc_token = env.register_contract(None, MockToken);
         let agent = Address::generate(&env);
-        let owner = agent.clone();
+        let owner = Address::generate(&env);
 
-        client.initialize(&agent, &usdc_token);
+        client.initialize(&owner, &agent, &usdc_token);
 
         let blend_pool_id = env.register_contract(None, MockBlendPool);
 

--- a/neurowealth-vault/contracts/vault/src/test.rs
+++ b/neurowealth-vault/contracts/vault/src/test.rs
@@ -84,9 +84,9 @@ fn setup_vault_with_token(env: &Env) -> (Address, Address, Address, Address) {
     let client = NeuroWealthVaultClient::new(env, &contract_id);
     let agent = Address::generate(env);
     let usdc_token = env.register_contract(None, TestToken);
-    let owner = agent.clone();
+    let owner = Address::generate(env);
 
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 
     (contract_id, agent, owner, usdc_token)
 }
@@ -338,9 +338,10 @@ fn test_vault_initialized_event() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     let agent = Address::generate(&env);
+    let owner = Address::generate(&env);
     let usdc_token = Address::generate(&env);
 
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 
     let events = env.events().all();
     assert!(
@@ -464,10 +465,11 @@ fn test_pause_by_non_owner_fails() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     let agent = Address::generate(&env);
+    let owner = Address::generate(&env);
     let usdc_token = Address::generate(&env);
     let _non_owner = Address::generate(&env);
 
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 
     // Verify vault starts unpaused
     assert!(!client.is_paused(), "Vault should start unpaused");
@@ -610,13 +612,13 @@ fn test_agent_can_trigger_emergency_pause() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     let agent = Address::generate(&env);
+    let owner = Address::generate(&env);
     let usdc_token = Address::generate(&env);
 
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 
-    // Agent is the owner by default (set in initialize)
-    // Agent can trigger emergency pause
-    client.emergency_pause(&agent);
+    // Owner and agent are distinct; owner can trigger emergency pause
+    client.emergency_pause(&owner);
     assert!(client.is_paused());
 }
 
@@ -629,12 +631,13 @@ fn test_only_owner_can_unpause() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     let agent = Address::generate(&env);
+    let owner = Address::generate(&env);
     let usdc_token = Address::generate(&env);
 
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 
     // Owner pauses
-    client.pause(&agent);
+    client.pause(&owner);
     assert!(client.is_paused());
 
     // Only owner can unpause
@@ -886,4 +889,3 @@ fn test_withdraw_all_reconciles_partial_blend_redemption() {
     // Vault accounting should be consistent
     assert_eq!(client.get_total_assets(), 10_000_000_i128);
 }
-

--- a/neurowealth-vault/contracts/vault/src/tests/test_access_control.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_access_control.rs
@@ -185,10 +185,11 @@ fn test_non_owner_cannot_emergency_pause() {
     let contract_id = env.register_contract(None, NeuroWealthVault);
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
     let agent = Address::generate(&env);
+    let owner = Address::generate(&env);
     let usdc_token = Address::generate(&env);
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 
-    // owner == agent by default; use a fresh address as non-owner
+    // owner and agent are distinct; use a fresh address as non-owner
     let non_owner = Address::generate(&env);
     client.emergency_pause(&non_owner);
 }

--- a/neurowealth-vault/contracts/vault/src/tests/test_events.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_events.rs
@@ -16,9 +16,10 @@ fn test_initialize_emits_init_event_with_correct_payload() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     let agent = Address::generate(&env);
+    let owner = Address::generate(&env);
     let usdc_token = Address::generate(&env);
     let expected_tvl_cap = 100_000_000_000_i128;
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 
     let init_events = find_events_by_topic(env.events().all(), &env, symbol_short!("init"));
     assert_eq!(

--- a/neurowealth-vault/contracts/vault/src/tests/test_initialize.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_initialize.rs
@@ -12,14 +12,15 @@ fn test_initialize_happy_path() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     let agent = Address::generate(&env);
+    let owner = Address::generate(&env);
     let usdc_token = Address::generate(&env);
 
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 
     // Verify initialization
     assert_eq!(client.get_agent(), agent);
     assert_eq!(client.get_usdc_token(), usdc_token);
-    assert_eq!(client.get_owner(), agent); // Owner defaults to agent
+    assert_eq!(client.get_owner(), owner);
     assert!(!client.is_paused());
     assert_eq!(client.get_version(), 1u32);
     assert_eq!(client.get_total_deposits(), 0);
@@ -36,11 +37,12 @@ fn test_double_initialize_panics() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     let agent = Address::generate(&env);
+    let owner = Address::generate(&env);
     let usdc_token = Address::generate(&env);
 
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
     // Second call should panic with "vault: already initialized"
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 }
 
 #[test]
@@ -91,9 +93,10 @@ fn test_initialize_emits_event() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     let agent = Address::generate(&env);
+    let owner = Address::generate(&env);
     let usdc_token = Address::generate(&env);
 
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 
     let events = env.events().all();
     assert!(!events.is_empty(), "Initialization should emit an event");

--- a/neurowealth-vault/contracts/vault/src/tests/test_legacy_inline.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_legacy_inline.rs
@@ -7,9 +7,9 @@ fn setup_vault(env: &Env) -> (Address, Address, Address) {
 
     let agent = Address::generate(env);
     let usdc_token = Address::generate(env);
-    let owner = agent.clone();
+    let owner = Address::generate(env);
 
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 
     (contract_id, agent, owner)
 }
@@ -23,9 +23,10 @@ fn test_vault_initialization() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     let agent = Address::generate(&env);
+    let owner = Address::generate(&env);
     let usdc_token = Address::generate(&env);
 
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 
     assert_eq!(client.get_agent(), agent);
     assert_eq!(client.get_usdc_token(), usdc_token);
@@ -172,8 +173,9 @@ fn test_withdraw_checks_effects_interactions_pattern() {
     let agent = Address::generate(&env);
     let user = Address::generate(&env);
     let usdc_token = Address::generate(&env);
+    let owner = Address::generate(&env);
 
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 
     assert_eq!(client.get_balance(&user), 0);
     assert_eq!(client.get_total_deposits(), 0);
@@ -232,8 +234,9 @@ fn test_withdraw_reentrancy_protection() {
 
     let agent = Address::generate(&env);
     let usdc_token = Address::generate(&env);
+    let owner = Address::generate(&env);
 
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 }
 
 #[test]

--- a/neurowealth-vault/contracts/vault/src/tests/utils.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/utils.rs
@@ -288,9 +288,9 @@ pub fn setup_vault_with_token(env: &Env) -> (Address, Address, Address, Address)
     let client = NeuroWealthVaultClient::new(env, &contract_id);
     let agent = Address::generate(env);
     let usdc_token = env.register_contract(None, TestToken);
-    let owner = agent.clone();
+    let owner = Address::generate(env);
 
-    client.initialize(&agent, &usdc_token);
+    client.initialize(&owner, &agent, &usdc_token);
 
     (contract_id, agent, owner, usdc_token)
 }


### PR DESCRIPTION
Split owner/agent initialization, add explicit cap update events, validate Blend pool configuration, and add a shared init guard.

Closes #85
Closes #100
Closes #101
Closes #102