### PR TITLE
fix: vault hardening — init guard, auth tests, inflation audit, checked math (#124, #125, #126, #127)

### DIFF
--- a/ERROR_STYLE_GUIDE.md
+++ b/ERROR_STYLE_GUIDE.md
@@ -61,7 +61,7 @@ Used for:
 Examples:
 - `vault: already initialized`
 - `vault: paused`
-- `vault: not initialized`
+- `vault: not initialized.`
 
 ### Validation Errors
 Format: `vault: <field> <description>`

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -2515,7 +2515,7 @@ impl NeuroWealthVault {
             env.storage().instance().has(&DataKey::Agent)
                 && env.storage().instance().has(&DataKey::UsdcToken)
                 && env.storage().instance().has(&DataKey::Owner),
-            "vault: not initialized"
+            "vault: not initialized."
         );
     }
 

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -2082,8 +2082,13 @@ impl NeuroWealthVault {
             // max_decrease_bps is in basis points (1/100 of 1%)
             // Default 1000 bps = 10% maximum decrease per call
             let max_decrease_bps = max_decrease_bps.max(100); // Minimum 1% bound
-            let max_decrease = old_total * (max_decrease_bps as i128) / 10_000;
-            let actual_decrease = old_total - new_total;
+            let max_decrease = old_total
+                .checked_mul(max_decrease_bps as i128)
+                .expect("vault: max decrease mul overflow")
+                / 10_000;
+            let actual_decrease = old_total
+                .checked_sub(new_total)
+                .expect("vault: decrease underflow");
 
             assert!(
                 actual_decrease <= max_decrease,
@@ -2117,7 +2122,9 @@ impl NeuroWealthVault {
                 &usdc_token,
                 &env.current_contract_address(),
             );
-            total_available += deployed_balance;
+            total_available = total_available
+                .checked_add(deployed_balance)
+                .expect("vault: total available overflow");
         }
 
         assert!(
@@ -2750,8 +2757,15 @@ impl NeuroWealthVault {
             // Ceiling division: (a + b - 1) / b
             // shares = ceil(assets * total_shares / total_assets)
             let product = assets.checked_mul(total_shares).expect("vault: conversion mul overflow");
-            // Safe addition: total_assets >= 1 in this branch, so (product + total_assets - 1) won't overflow if product didn't
-            let numerator = product.checked_add(total_assets - 1).expect("vault: conversion add overflow");
+            // total_assets >= 1 in this branch, so the subtraction cannot underflow;
+            // use checked ops throughout for a consistent, explicit failure mode.
+            let numerator = product
+                .checked_add(
+                    total_assets
+                        .checked_sub(1)
+                        .expect("vault: conversion sub underflow"),
+                )
+                .expect("vault: conversion add overflow");
             numerator.checked_div(total_assets).expect("vault: conversion div error")
         }
     }

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -762,6 +762,27 @@ impl NeuroWealthVault {
     /// - `user.require_auth()` ensures only the user can deposit to their own account
     /// - Checks are performed before state updates (checks-effects-interactions pattern)
     /// - Balance is updated after successful token transfer
+    ///
+    /// # First-Depositor / Donation Inflation Attack
+    /// ERC-4626-style vaults can be vulnerable to a share-price inflation attack
+    /// when the share supply is tiny: an attacker becomes the first depositor for
+    /// a negligible amount, "donates" a large amount to inflate the price per
+    /// share, and a subsequent victim deposit rounds down to zero shares —
+    /// letting the attacker redeem the victim's funds.
+    ///
+    /// This vault mitigates the attack without virtual shares by combining three
+    /// properties (see also [`Self::convert_to_shares_internal`]):
+    /// 1. **Storage-based asset accounting.** Share pricing uses the stored
+    ///    `TotalAssets`, which only changes via deposit, withdraw, and the
+    ///    agent's balance-verified `update_total_assets`. A direct token transfer
+    ///    ("donation") to the vault address does NOT change `TotalAssets`, so it
+    ///    cannot inflate the share price. This neutralizes the donation step.
+    /// 2. **Minimum deposit floor.** `MinDeposit` (default 1_000_000 base units)
+    ///    prevents a 1-unit first deposit, so the share supply is never small
+    ///    enough for rounding to be weaponized.
+    /// 3. **Non-zero mint guard.** A deposit that would mint zero shares reverts
+    ///    (`vault: shares to mint must be positive`), so a victim can never
+    ///    silently receive 0 shares for a non-zero deposit.
     pub fn deposit(env: Env, user: Address, amount: i128) {
         Self::require_initialized(&env);
         user.require_auth();
@@ -802,7 +823,11 @@ impl NeuroWealthVault {
                 .expect("vault: total deposits overflow")),
         );
 
-        // Mint shares based on current share price and update total assets
+        // Mint shares based on current share price and update total assets.
+        // Inflation-attack mitigation: reject any deposit that would round down
+        // to zero shares. Together with storage-based asset accounting (donations
+        // can't move the price) and the minimum-deposit floor, this defeats the
+        // first-depositor/donation inflation attack. See `deposit` docs.
         let shares_to_mint = Self::convert_to_shares_internal(&env, amount);
         assert!(shares_to_mint > 0, "vault: shares to mint must be positive");
 
@@ -2674,6 +2699,16 @@ impl NeuroWealthVault {
 
     /// Internal helper: convert assets (USDC) to shares using current totals.
     /// Uses floor division - safe for deposits (user gets fewer shares, vault benefits).
+    ///
+    /// # Inflation-attack note
+    /// Pricing reads the stored `TotalAssets` (see [`Self::get_total_assets_internal`]),
+    /// NOT the vault's live token balance. Direct "donations" (token transfers to
+    /// the vault that bypass `deposit`) therefore do not move the share price, so
+    /// the classic first-depositor/donation inflation attack does not apply here.
+    /// Virtual-share / dead-share offsets (common mitigations for balance-based
+    /// vaults) are unnecessary as a result. The `deposit` entrypoint additionally
+    /// rejects zero-share mints and enforces a minimum deposit; see [`Self::deposit`]
+    /// for the full mitigation rationale.
     #[inline]
     fn convert_to_shares_internal(env: &Env, assets: i128) -> i128 {
         if assets == 0 {

--- a/neurowealth-vault/contracts/vault/src/tests/mod.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod test_access_control;
 mod test_auth;
 mod test_blend_integration;
+mod test_checked_arithmetic;
 mod test_deposit;
 mod test_event_schema;
 mod test_events;

--- a/neurowealth-vault/contracts/vault/src/tests/mod.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/mod.rs
@@ -5,6 +5,7 @@ mod test_deposit;
 mod test_event_schema;
 mod test_events;
 mod test_initialize;
+mod test_inflation_attack;
 mod test_legacy_inline;
 mod test_limits;
 mod test_math_limits;

--- a/neurowealth-vault/contracts/vault/src/tests/mod.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod test_access_control;
+mod test_auth;
 mod test_blend_integration;
 mod test_deposit;
 mod test_event_schema;

--- a/neurowealth-vault/contracts/vault/src/tests/test_auth.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_auth.rs
@@ -1,0 +1,334 @@
+//! Targeted authorization tests that reduce reliance on `mock_all_auths`.
+//!
+//! ## Why this file exists
+//!
+//! `env.mock_all_auths()` makes **every** `require_auth()` succeed. That is
+//! convenient, but it also *hides* missing authorization checks: if a
+//! `require_auth()` were accidentally removed from an entrypoint, a test that
+//! mocks all auths would still pass, because the (now absent) check was never
+//! the thing keeping the call honest.
+//!
+//! The tests below exercise authorization explicitly using two stricter tools:
+//!
+//! - [`Env::mock_auths`] with a precise [`MockAuth`] / [`MockAuthInvoke`] tree.
+//!   Only the listed address is authorized for the listed invocation (and its
+//!   declared sub-invocations). Anything else fails. This proves the entrypoint
+//!   requires *exactly* the expected signer.
+//! - `mock_auths(&[])` (an empty authorization set) followed by `try_*`. With no
+//!   authorization available, a present `require_auth()` makes the call error.
+//!   If the `require_auth()` were missing, the call would instead succeed and
+//!   the assertion would fail — so these tests actively guard against a dropped
+//!   auth check.
+//!
+//! ## When is `mock_all_auths` acceptable?
+//!
+//! `mock_all_auths` remains the right tool for tests whose purpose is **not**
+//! authorization — e.g. share-math, rounding, event schema, limit, and
+//! happy-path lifecycle tests. In those cases auth is incidental setup noise and
+//! mocking it wholesale keeps the test focused on the behavior under scrutiny.
+//!
+//! Use the stricter `mock_auths` / negative-auth style here whenever the test's
+//! subject *is* access control: confirming an entrypoint requires the owner,
+//! the agent, or the acting user, and rejects everyone else.
+
+use super::utils::*;
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal,
+};
+
+/// Sets up an initialized vault while `mock_all_auths` is active.
+///
+/// Initialization legitimately requires the deployer's signature; mocking it is
+/// incidental setup, not the behavior under test. Callers switch to scoped or
+/// empty auths *after* this returns to exercise the actual access control.
+fn setup(env: &Env) -> (Address, Address, Address, Address) {
+    env.mock_all_auths();
+    setup_vault_with_token(env)
+}
+
+// ============================================================================
+// OWNER ROLE
+// ============================================================================
+
+/// Positive: with auth scoped to *only* the owner for *only* `pause`, the call
+/// succeeds. Proves `pause` accepts the owner's authorization.
+#[test]
+fn test_owner_pause_with_scoped_auth() {
+    let env = Env::default();
+    let (contract_id, _agent, owner, _usdc_token) = setup(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    env.mock_auths(&[MockAuth {
+        address: &owner,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "pause",
+            args: (owner.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.pause(&owner);
+    assert!(client.is_paused());
+}
+
+/// Negative: with no authorization available, `pause` must error because
+/// `owner.require_auth()` cannot be satisfied. Guards against a removed check.
+#[test]
+fn test_pause_requires_owner_auth() {
+    let env = Env::default();
+    let (contract_id, _agent, owner, _usdc_token) = setup(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    env.mock_auths(&[]);
+
+    let result = client.try_pause(&owner);
+    assert!(
+        result.is_err(),
+        "pause must fail without the owner's authorization"
+    );
+    assert!(!client.is_paused(), "vault must remain unpaused");
+}
+
+/// Negative: an owner-only config setter must error without owner auth. Covers
+/// the `require_is_owner()` path (which performs the `require_auth` internally).
+#[test]
+fn test_set_tvl_cap_requires_owner_auth() {
+    let env = Env::default();
+    let (contract_id, _agent, _owner, _usdc_token) = setup(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    env.mock_auths(&[]);
+
+    let result = client.try_set_tvl_cap(&50_000_000_000_i128);
+    assert!(
+        result.is_err(),
+        "set_tvl_cap must fail without the owner's authorization"
+    );
+}
+
+/// Negative: a non-owner that *does* hold a valid signature for `pause` is still
+/// rejected by the identity check. Auth is scoped to the attacker only.
+#[test]
+#[should_panic(expected = "vault: only owner can pause")]
+fn test_non_owner_with_own_auth_cannot_pause() {
+    let env = Env::default();
+    let (contract_id, _agent, _owner, _usdc_token) = setup(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let attacker = Address::generate(&env);
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "pause",
+            args: (attacker.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    // attacker.require_auth() passes (scoped), but attacker != stored owner.
+    client.pause(&attacker);
+}
+
+// ============================================================================
+// AGENT ROLE
+// ============================================================================
+
+/// Positive: with auth scoped to *only* the agent for *only* `rebalance`, the
+/// call succeeds. The "none" protocol needs no external pool.
+#[test]
+fn test_agent_rebalance_with_scoped_auth() {
+    let env = Env::default();
+    let (contract_id, agent, _owner, _usdc_token) = setup(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    env.mock_auths(&[MockAuth {
+        address: &agent,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "rebalance",
+            args: (symbol_short!("none"), 500_i128).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.rebalance(&symbol_short!("none"), &500_i128);
+    assert_eq!(client.get_current_protocol(), symbol_short!("none"));
+}
+
+/// Negative: `rebalance` must error without the agent's authorization.
+#[test]
+fn test_rebalance_requires_agent_auth() {
+    let env = Env::default();
+    let (contract_id, _agent, _owner, _usdc_token) = setup(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    env.mock_auths(&[]);
+
+    let result = client.try_rebalance(&symbol_short!("none"), &500_i128);
+    assert!(
+        result.is_err(),
+        "rebalance must fail without the agent's authorization"
+    );
+}
+
+/// Negative: `update_total_assets` must error without the agent's authorization.
+/// The real agent is passed so the identity check passes and the failure is due
+/// to the missing `agent.require_auth()`.
+#[test]
+fn test_update_total_assets_requires_agent_auth() {
+    let env = Env::default();
+    let (contract_id, agent, _owner, _usdc_token) = setup(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    env.mock_auths(&[]);
+
+    let result = client.try_update_total_assets(&agent, &0_i128, &false, &0_u32);
+    assert!(
+        result.is_err(),
+        "update_total_assets must fail without the agent's authorization"
+    );
+}
+
+// ============================================================================
+// USER ROLE
+// ============================================================================
+
+/// Positive: a user deposit succeeds when auth is scoped to the user for
+/// `deposit` *and* its `transfer` sub-invocation on the token contract. This
+/// proves both the entrypoint and the funds-pull are authorized by the user.
+#[test]
+fn test_user_deposit_with_scoped_auth() {
+    let env = Env::default();
+    let (contract_id, _agent, _owner, usdc_token) = setup(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    let user = Address::generate(&env);
+    let amount = 5_000_000_i128;
+    token_client.mint(&user, &amount); // mint needs no auth
+
+    env.mock_auths(&[MockAuth {
+        address: &user,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "deposit",
+            args: (user.clone(), amount).into_val(&env),
+            sub_invokes: &[MockAuthInvoke {
+                contract: &usdc_token,
+                fn_name: "transfer",
+                args: (user.clone(), contract_id.clone(), amount).into_val(&env),
+                sub_invokes: &[],
+            }],
+        },
+    }]);
+
+    client.deposit(&user, &amount);
+    // Bootstrap deposit mints shares 1:1 with assets.
+    assert_eq!(client.get_shares(&user), amount);
+}
+
+/// Negative: `deposit` must error without the depositing user's authorization,
+/// even when funds are available.
+#[test]
+fn test_deposit_requires_user_auth() {
+    let env = Env::default();
+    let (contract_id, _agent, _owner, usdc_token) = setup(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    let user = Address::generate(&env);
+    let amount = 5_000_000_i128;
+    token_client.mint(&user, &amount);
+
+    env.mock_auths(&[]);
+
+    let result = client.try_deposit(&user, &amount);
+    assert!(
+        result.is_err(),
+        "deposit must fail without the user's authorization"
+    );
+}
+
+/// Negative: another address holding its own valid signature cannot deposit on
+/// the victim's behalf — `deposit` requires the *acting user's* auth.
+#[test]
+fn test_deposit_rejects_wrong_signer() {
+    let env = Env::default();
+    let (contract_id, _agent, _owner, usdc_token) = setup(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    let user = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let amount = 5_000_000_i128;
+    token_client.mint(&user, &amount);
+
+    // Authorize the attacker for a deposit call, but the call names `user`.
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "deposit",
+            args: (user.clone(), amount).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_deposit(&user, &amount);
+    assert!(
+        result.is_err(),
+        "deposit must require the named user's authorization, not another signer's"
+    );
+}
+
+/// Positive: a user withdrawal succeeds with auth scoped to the user for
+/// `withdraw`. The vault's outbound token transfer is authorized automatically
+/// as the current contract, so no token sub-invoke is needed from the user.
+#[test]
+fn test_user_withdraw_with_scoped_auth() {
+    let env = Env::default();
+    let (contract_id, _agent, _owner, usdc_token) = setup(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let amount = 5_000_000_i128;
+    // Fund and deposit under full mock; the withdraw is what we scope.
+    mint_and_deposit(&env, &client, &usdc_token, &user, amount);
+
+    env.mock_auths(&[MockAuth {
+        address: &user,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "withdraw",
+            args: (user.clone(), amount).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.withdraw(&user, &amount);
+    assert_eq!(client.get_shares(&user), 0);
+}
+
+/// Negative: `withdraw` must error without the user's authorization.
+#[test]
+fn test_withdraw_requires_user_auth() {
+    let env = Env::default();
+    let (contract_id, _agent, _owner, usdc_token) = setup(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let amount = 5_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &user, amount);
+
+    env.mock_auths(&[]);
+
+    let result = client.try_withdraw(&user, &amount);
+    assert!(
+        result.is_err(),
+        "withdraw must fail without the user's authorization"
+    );
+}

--- a/neurowealth-vault/contracts/vault/src/tests/test_checked_arithmetic.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_checked_arithmetic.rs
@@ -1,0 +1,163 @@
+//! Boundary tests for checked arithmetic in the critical accounting paths.
+//!
+//! Scope (issue #127): deposit, withdraw, share conversion, and cap checks must
+//! use checked ops that fail with explicit messages rather than silently
+//! wrapping or panicking opaquely. These tests push state to values near
+//! `i128::MAX` to actually exercise those guards.
+
+use super::utils::*;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+/// A single very large deposit (well within `i128`) succeeds and books shares
+/// exactly 1:1 on bootstrap — confirming the checked math handles large operands
+/// without spurious failure.
+#[test]
+fn test_large_deposit_within_range_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token = TestTokenClient::new(&env, &usdc_token);
+
+    // Disable per-user / TVL caps and raise the per-deposit max to allow a huge deposit.
+    client.set_limits(&0, &0);
+    client.set_deposit_limits(&1_000_000_i128, &i128::MAX);
+
+    let user = Address::generate(&env);
+    let amount = 1_000_000_000_000_000_000_i128; // 1e18, far below i128::MAX (~1.7e38)
+    token.mint(&user, &amount);
+    client.deposit(&user, &amount);
+
+    assert_eq!(client.get_shares(&user), amount, "bootstrap mints 1:1");
+    assert_eq!(client.get_total_assets(), amount);
+    assert_eq!(client.get_total_deposits(), amount);
+}
+
+/// Share conversion multiplies `assets * total_shares`. With a large existing
+/// share supply, converting a near-max asset amount overflows that product; the
+/// checked_mul must surface the explicit message rather than a silent wrap.
+///
+/// (The deposit/balance accumulator guards are belt-and-suspenders: because the
+/// vault holds tokens 1:1 with booked principal, the token's own balance math
+/// reaches `i128::MAX` at the same point, so those guards can't be isolated
+/// through the public deposit path. The conversion guard below is the reachable
+/// boundary on the share-conversion path.)
+#[test]
+#[should_panic(expected = "vault: conversion mul overflow")]
+fn test_convert_to_shares_mul_overflow_is_checked() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token = TestTokenClient::new(&env, &usdc_token);
+
+    client.set_limits(&0, &0);
+    client.set_deposit_limits(&1_000_000_i128, &i128::MAX);
+
+    // Bootstrap a large share supply: total_shares == total_assets == 1e18.
+    let user = Address::generate(&env);
+    let amount = 1_000_000_000_000_000_000_i128; // 1e18
+    token.mint(&user, &amount);
+    client.deposit(&user, &amount);
+
+    // convert_to_shares(i128::MAX) computes i128::MAX * total_shares → overflow.
+    client.convert_to_shares(&i128::MAX);
+}
+
+/// The per-user deposit cap is an exact boundary: depositing right up to the cap
+/// succeeds; one unit over is rejected with the explicit cap message.
+#[test]
+fn test_user_deposit_cap_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token = TestTokenClient::new(&env, &usdc_token);
+
+    let cap = 100_000_000_i128;
+    client.set_user_deposit_cap(&cap);
+    client.set_deposit_limits(&1_000_000_i128, &i128::MAX);
+
+    let user = Address::generate(&env);
+    token.mint(&user, &(cap + 1_000_000));
+
+    // Exactly at the cap: allowed.
+    client.deposit(&user, &cap);
+    assert_eq!(client.get_shares(&user), cap);
+
+    // One more (above the cap) must be rejected.
+    let over = client.try_deposit(&user, &1_000_000_i128);
+    assert!(over.is_err(), "deposit above user cap must be rejected");
+}
+
+/// Withdrawing more than the user holds must fail via the checked share path
+/// rather than underflowing the share accounting.
+#[test]
+#[should_panic(expected = "vault: insufficient shares for requested amount")]
+fn test_withdraw_share_underflow_is_checked() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, 10_000_000_i128);
+
+    // Request more than deposited; share conversion exceeds the user's holdings.
+    client.withdraw(&user, &11_000_000_i128);
+}
+
+/// A large balance can be fully withdrawn, confirming the withdraw-side checked
+/// subtractions (shares, totals, principal) handle near-max operands correctly.
+#[test]
+fn test_large_balance_full_withdraw() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token = TestTokenClient::new(&env, &usdc_token);
+
+    client.set_limits(&0, &0);
+    client.set_deposit_limits(&1_000_000_i128, &i128::MAX);
+
+    let user = Address::generate(&env);
+    let amount = 5_000_000_000_000_000_000_i128; // 5e18
+    token.mint(&user, &amount);
+    client.deposit(&user, &amount);
+
+    let returned = client.withdraw_all(&user);
+    assert_eq!(returned, amount, "full large balance withdrawn");
+    assert_eq!(client.get_shares(&user), 0);
+    assert_eq!(client.get_total_shares(), 0);
+    assert_eq!(token.balance(&user), amount);
+}
+
+/// `update_total_assets` computes `old_total * max_decrease_bps` when bounding a
+/// decrease. With `old_total == i128::MAX` this would overflow; the checked_mul
+/// must surface the explicit message instead of an opaque panic.
+#[test]
+#[should_panic(expected = "vault: max decrease mul overflow")]
+fn test_update_total_assets_decrease_bound_overflow_is_checked() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token = TestTokenClient::new(&env, &usdc_token);
+
+    client.set_limits(&0, &0);
+    client.set_deposit_limits(&1_000_000_i128, &i128::MAX);
+
+    // Drive stored TotalAssets to i128::MAX via a max-sized deposit.
+    let user = Address::generate(&env);
+    token.mint(&user, &i128::MAX);
+    client.deposit(&user, &i128::MAX);
+
+    // Request a decrease: max_decrease = old_total(MAX) * bps(>=100) overflows.
+    client.update_total_assets(&agent, &(i128::MAX - 1), &true, &100);
+}

--- a/neurowealth-vault/contracts/vault/src/tests/test_inflation_attack.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_inflation_attack.rs
@@ -1,0 +1,193 @@
+//! First-depositor / donation inflation-attack scenario tests.
+//!
+//! ## The attack (on a vulnerable, balance-based vault)
+//! 1. Attacker is the first depositor for a negligible amount and receives a
+//!    tiny number of shares.
+//! 2. Attacker "donates" a large amount by transferring tokens directly to the
+//!    vault. On a vault that prices shares off its live token balance, this
+//!    inflates the price per share.
+//! 3. A victim deposits; with the price inflated, their assets round DOWN to
+//!    zero shares. The attacker then redeems the victim's funds.
+//!
+//! ## Why this vault is safe (audit conclusion)
+//! Share pricing reads the **stored** `TotalAssets`, which is only mutated by
+//! `deposit`, `withdraw`, and the agent's balance-verified `update_total_assets`.
+//! A direct token transfer to the vault does not change `TotalAssets`, so the
+//! donation step (2) is a no-op for pricing. Combined with the minimum-deposit
+//! floor and the non-zero-share-mint guard, the attack is neutralized. These
+//! tests assert that behavior.
+
+use super::utils::*;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+/// A direct token transfer to the vault (a "donation") must NOT change
+/// `TotalAssets` or the share price. This is the core mitigation.
+#[test]
+fn test_direct_donation_does_not_inflate_share_price() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token = TestTokenClient::new(&env, &usdc_token);
+
+    let attacker = Address::generate(&env);
+    let seed = 10_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &attacker, seed);
+
+    let assets_before = client.get_total_assets();
+    let shares_before = client.get_total_shares();
+
+    // Attacker donates a large amount straight to the vault, bypassing deposit.
+    let donation = 1_000_000_000_i128;
+    token.mint(&attacker, &donation);
+    token.transfer(&attacker, &contract_id, &donation);
+
+    // Share price = TotalAssets / TotalShares. Both are storage-tracked and must
+    // be unchanged by a direct donation, so the price is unchanged.
+    assert_eq!(
+        client.get_total_assets(),
+        assets_before,
+        "donation must not change stored TotalAssets"
+    );
+    assert_eq!(
+        client.get_total_shares(),
+        shares_before,
+        "donation must not change TotalShares"
+    );
+}
+
+/// Full scenario: attacker seeds, donates, then a victim deposits. The victim
+/// must receive fair (non-zero, proportional) shares, and the attacker must not
+/// profit from the donation.
+#[test]
+fn test_donation_then_victim_deposit_is_fair() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token = TestTokenClient::new(&env, &usdc_token);
+
+    // 1. Attacker becomes first depositor (must clear the minimum deposit).
+    let attacker = Address::generate(&env);
+    let attacker_deposit = 10_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &attacker, attacker_deposit);
+    let attacker_value_before = client.get_balance(&attacker);
+
+    // 2. Attacker donates a large amount directly to the vault.
+    let donation = 1_000_000_000_i128;
+    token.mint(&attacker, &donation);
+    token.transfer(&attacker, &contract_id, &donation);
+
+    // 3. Victim deposits.
+    let victim = Address::generate(&env);
+    let victim_deposit = 10_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &victim, victim_deposit);
+
+    // Victim received non-zero, fair shares (1:1 since the donation is ignored).
+    let victim_shares = client.get_shares(&victim);
+    assert!(victim_shares > 0, "victim must receive shares, not zero");
+    assert_eq!(
+        victim_shares, victim_deposit,
+        "victim shares must be proportional (1:1) — donation ignored"
+    );
+
+    // Victim's redeemable value equals their deposit; nothing was stolen.
+    assert_eq!(
+        client.get_balance(&victim),
+        victim_deposit,
+        "victim must be able to reclaim ~their full deposit"
+    );
+
+    // Attacker did not gain from the donation: their claim is still their seed.
+    assert_eq!(
+        client.get_balance(&attacker),
+        attacker_value_before,
+        "attacker's claim must not grow from the donation"
+    );
+}
+
+/// End-to-end: the victim can actually withdraw their full deposit after the
+/// attacker's donation, proving funds were never at risk.
+#[test]
+fn test_victim_can_withdraw_full_deposit_after_donation() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token = TestTokenClient::new(&env, &usdc_token);
+
+    let attacker = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &attacker, 10_000_000_i128);
+
+    let donation = 5_000_000_000_i128;
+    token.mint(&attacker, &donation);
+    token.transfer(&attacker, &contract_id, &donation);
+
+    let victim = Address::generate(&env);
+    let victim_deposit = 25_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &victim, victim_deposit);
+
+    let returned = client.withdraw_all(&victim);
+    assert_eq!(
+        returned, victim_deposit,
+        "victim must withdraw their full deposit despite the donation"
+    );
+    assert_eq!(token.balance(&victim), victim_deposit);
+}
+
+/// Property-style sweep: across a range of seed / donation / victim sizes, the
+/// victim always receives non-zero shares and a fair claim.
+#[test]
+fn test_inflation_resistance_across_sizes() {
+    let cases = [
+        (1_000_000_i128, 1_000_000_000_i128, 1_000_000_i128),
+        (10_000_000_i128, 50_000_000_000_i128, 2_000_000_i128),
+        (5_000_000_i128, 1_000_000_i128, 100_000_000_i128),
+        (1_000_000_i128, 999_999_999_999_i128, 1_000_000_i128),
+    ];
+
+    for (seed, donation, victim_deposit) in cases {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+        let client = NeuroWealthVaultClient::new(&env, &contract_id);
+        let token = TestTokenClient::new(&env, &usdc_token);
+
+        let attacker = Address::generate(&env);
+        mint_and_deposit(&env, &client, &usdc_token, &attacker, seed);
+
+        token.mint(&attacker, &donation);
+        token.transfer(&attacker, &contract_id, &donation);
+
+        let victim = Address::generate(&env);
+        mint_and_deposit(&env, &client, &usdc_token, &victim, victim_deposit);
+
+        // The inflation attack's payoff is the victim minting ZERO shares; a
+        // non-zero share balance is the decisive proof the attack fails.
+        let victim_shares = client.get_shares(&victim);
+        assert!(
+            victim_shares > 0,
+            "victim must receive non-zero shares (seed={}, donation={}, victim={})",
+            seed,
+            donation,
+            victim_deposit
+        );
+        // The donation is ignored, so the victim's claim tracks their deposit up
+        // to ERC-4626 floor-division dust (never more than deposited, and at most
+        // a negligible amount less). This rules out value theft.
+        let claim = client.get_balance(&victim);
+        let tolerance = victim_deposit / 100_000 + 10; // 0.001% + dust
+        assert!(
+            claim <= victim_deposit && claim >= victim_deposit - tolerance,
+            "victim claim must be within dust of deposit (claim={}, deposit={}, seed={}, donation={})",
+            claim,
+            victim_deposit,
+            seed,
+            donation
+        );
+    }
+}


### PR DESCRIPTION
Bundles four Stellar Wave vault hardening issues into one PR.

Closes #124
Closes #125
Closes #126
Closes #127

## #124 — Explicit `require_initialized()` guard for public API
The shared `require_initialized()` helper guards all public entrypoints (only `initialize` is exempt). Aligned its panic message to the issue's specified wording `vault: not initialized.` and updated `ERROR_STYLE_GUIDE.md` to match.

## #125 — Strengthen auth tests, reduce `mock_all_auths` reliance
Added `tests/test_auth.rs`:
- Scoped positive tests via `mock_auths` + `MockAuthInvoke` for owner, agent, and user.
- Negative tests via empty-auth (`mock_auths(&[])`) + `try_*` that catch a removed `require_auth()` (which `mock_all_auths` would hide).
- Wrong-signer rejection tests.
- Module docs explaining when full `mock_all_auths` is acceptable.

## #126 — Audit first-depositor / donation inflation on share price
Audit conclusion: the vault is **not** vulnerable, because share pricing reads storage-tracked `TotalAssets` (direct token donations don't move the price), reinforced by the minimum-deposit floor and the zero-share-mint revert. Documented the rationale on `deposit`, `convert_to_shares_internal`, and the mint guard, and added `tests/test_inflation_attack.rs` with donation→victim scenario tests plus a size sweep.

## #127 — Checked arithmetic in critical accounting paths
Replaced remaining unchecked `i128` math with `checked_*` ops carrying explicit `vault:` messages:
- `update_total_assets`: `checked_mul`/`checked_sub` for the decrease bound, `checked_add` for vault + Blend-deployed balance.
- `convert_to_shares_internal_ceil`: `checked_sub` for the ceiling numerator.

Added `tests/test_checked_arithmetic.rs` with boundary tests near `i128::MAX` covering deposit, withdraw, share conversion, and cap checks.

## Testing
Full suite: **222 passed, 0 failed**.