### PR TITLE
fix: protect initialize() from front-running & add indexed user topic to events

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -40,9 +40,12 @@ pub struct VaultInitializedEvent {
 - Indexers record vault deployment details
 
 ### 2. DepositEvent
-**Topic:** `"deposit"`
+**Topics:** `("deposit", <user: Address>)`
 
 Emitted when a user deposits USDC into the vault.
+
+The user address is published as a second **indexed topic** so that indexers
+and AI agents can filter deposit events by user without scanning full payloads.
 
 ```rust
 pub struct DepositEvent {
@@ -52,15 +55,24 @@ pub struct DepositEvent {
 }
 ```
 
+**Topic tuple (position → value):**
+| Position | Type    | Value                  |
+|----------|---------|------------------------|
+| 0        | Symbol  | `"deposit"`            |
+| 1        | Address | depositing user address |
+
 **Usage:**
 - AI agents detect new deposits to deploy yield strategies
 - Frontend updates user balances in real-time
-- Indexers track deposit history for analytics
+- Indexers filter deposit history by user via topic[1]
 
 ### 3. WithdrawEvent
-**Topic:** `"withdraw"`
+**Topics:** `("withdraw", <user: Address>)`
 
-Emitted when a user withdraws USDC from the vault.
+Emitted when a user withdraws USDC from the vault (both `withdraw` and `withdraw_all`).
+
+The user address is published as a second **indexed topic** so that indexers
+and AI agents can filter withdrawal events by user without scanning full payloads.
 
 ```rust
 pub struct WithdrawEvent {
@@ -70,10 +82,16 @@ pub struct WithdrawEvent {
 }
 ```
 
+**Topic tuple (position → value):**
+| Position | Type    | Value                   |
+|----------|---------|-------------------------|
+| 0        | Symbol  | `"withdraw"`            |
+| 1        | Address | withdrawing user address |
+
 **Usage:**
 - AI agents update internal records after withdrawals
 - Frontend updates user balances
-- Indexers track withdrawal history
+- Indexers filter withdrawal history by user via topic[1]
 
 ### 4. RebalanceEvent
 **Topic:** `"rebalance"`

--- a/README.md
+++ b/README.md
@@ -192,6 +192,66 @@ Two-step ownership transfer prevents accidental ownership loss
 Vault balance verification ensures reported assets match actual holdings
 TTL extension on critical storage prevents data expiration
 
+Secure Deployment Sequence
+
+`initialize()` is protected against front-running: the contract verifies that the `deployer`
+argument + `salt` cryptographically reproduce the deployed contract address, **and** requires
+a live authorization signature from that deployer keypair. This means no third party can
+seize ownership even if they observe the deployment transaction in the mempool.
+
+Follow these steps in order to safely initialize a new vault:
+
+1. **Generate a deployer keypair** (one-time use, only for initialization):
+   ```bash
+   stellar keys generate deployer --network testnet
+   stellar keys address deployer   # note the deployer address
+   ```
+
+2. **Choose a salt** (32 bytes; any fixed value works — must be the same across steps):
+   ```bash
+   # example: all-zero salt
+   SALT="0000000000000000000000000000000000000000000000000000000000000000"
+   ```
+
+3. **Deploy the contract** using the deployer keypair and the chosen salt:
+   ```bash
+   stellar contract deploy \
+     --wasm target/wasm32-unknown-unknown/release/neurowealth_vault.wasm \
+     --source deployer \
+     --network testnet \
+     --salt $SALT
+   # save the output as VAULT_CONTRACT_ID
+   ```
+
+4. **Immediately call `initialize()`** from the same deployer keypair:
+   ```bash
+   stellar contract invoke \
+     --id $VAULT_CONTRACT_ID \
+     --source deployer \
+     --network testnet \
+     -- \
+     initialize \
+     --deployer $(stellar keys address deployer) \
+     --owner  $OWNER_ADDRESS \
+     --agent  $AGENT_ADDRESS \
+     --usdc_token $USDC_TOKEN_ADDRESS \
+     --salt   $SALT
+   ```
+   The contract rejects any caller whose `deployer` argument does not reproduce
+   `VAULT_CONTRACT_ID`, and additionally requires a valid signature from that
+   address via `deployer.require_auth()`.
+
+5. **Verify initialization** (read-only, no auth needed):
+   ```bash
+   stellar contract invoke --id $VAULT_CONTRACT_ID --source deployer \
+     --network testnet -- get_owner
+   stellar contract invoke --id $VAULT_CONTRACT_ID --source deployer \
+     --network testnet -- get_agent
+   ```
+
+6. **Secure or discard the deployer keypair** — it has no further privileged role
+   after initialization. The `owner` keypair is now the administrator.
+
 
 AI Agent
 The agent runs as a persistent background service with two main loops.

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -878,7 +878,7 @@ impl NeuroWealthVault {
         );
 
         env.events().publish(
-            (TOPIC_DEPOSIT,),
+            (TOPIC_DEPOSIT, user.clone()),
             DepositEvent {
                 user,
                 amount,
@@ -1060,7 +1060,7 @@ impl NeuroWealthVault {
         token_client.transfer(&env.current_contract_address(), &user, &usdc_to_return);
 
         env.events().publish(
-            (TOPIC_WITHDRAW,),
+            (TOPIC_WITHDRAW, user.clone()),
             WithdrawEvent {
                 user,
                 amount: usdc_to_return,
@@ -1228,7 +1228,7 @@ impl NeuroWealthVault {
         token_client.transfer(&env.current_contract_address(), &user, &usdc_to_return);
 
         env.events().publish(
-            (TOPIC_WITHDRAW,),
+            (TOPIC_WITHDRAW, user.clone()),
             WithdrawEvent {
                 user,
                 amount: usdc_to_return,

--- a/neurowealth-vault/contracts/vault/src/tests/test_event_schema.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_event_schema.rs
@@ -565,6 +565,58 @@ fn test_event_payload_field_types() {
     let _shares_val: i128 = event.shares;
 }
 
+/// Test that Deposit and Withdraw events carry the user address as an indexed topic.
+///
+/// Indexers and AI agents can efficiently filter events by user without scanning
+/// full payloads by using the second topic (user address) directly.
+#[test]
+fn test_deposit_withdraw_user_indexed_topic() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 5_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
+
+    let deposit_events = find_events_by_topic(env.events().all(), &env, TOPIC_DEPOSIT);
+    assert_eq!(deposit_events.len(), 1, "One deposit event expected");
+
+    let (_, topics, _) = &deposit_events[0];
+    let user_in_deposit_topics = (0..topics.len()).any(|j| {
+        topics
+            .get(j)
+            .and_then(|t| Address::try_from_val(&env, &t).ok())
+            .map(|a| a == user)
+            .unwrap_or(false)
+    });
+    assert!(
+        user_in_deposit_topics,
+        "DepositEvent must carry user address as an indexed topic"
+    );
+
+    let withdraw_amount = 2_000_000_i128;
+    client.withdraw(&user, &withdraw_amount);
+
+    let withdraw_events = find_events_by_topic(env.events().all(), &env, TOPIC_WITHDRAW);
+    assert_eq!(withdraw_events.len(), 1, "One withdraw event expected");
+
+    let (_, topics, _) = &withdraw_events[0];
+    let user_in_withdraw_topics = (0..topics.len()).any(|j| {
+        topics
+            .get(j)
+            .and_then(|t| Address::try_from_val(&env, &t).ok())
+            .map(|a| a == user)
+            .unwrap_or(false)
+    });
+    assert!(
+        user_in_withdraw_topics,
+        "WithdrawEvent must carry user address as an indexed topic"
+    );
+}
+
 /// Test event emission consistency across multiple operations
 #[test]
 fn test_event_emission_consistency() {

--- a/neurowealth-vault/contracts/vault/src/tests/test_initialize.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_initialize.rs
@@ -149,3 +149,73 @@ fn test_unauthorized_deployer_initialize_fails() {
     // This must fail because the attacker's expected contract address doesn't match contract_id
     client.initialize(&attacker, &owner, &agent, &usdc_token, &salt);
 }
+
+/// Regression test: a front-runner who knows the correct deployer address and salt
+/// but does NOT hold the deployer's keypair must be rejected.
+///
+/// `deployer.require_auth()` inside initialize() enforces that only the deployer's
+/// own signed invocation can succeed. Without a valid auth entry for the deployer,
+/// the call panics before any state is written.
+#[test]
+#[should_panic]
+fn test_front_runner_without_deployer_auth_is_rejected() {
+    let env = Env::default();
+    // Deliberately do NOT call env.mock_all_auths().
+    // A front-runner may know the deployer address and salt (both are public on-chain),
+    // but cannot produce the deployer's authorization signature.
+
+    let deployer = Address::generate(&env);
+    let salt = BytesN::from_array(&env, &[0u8; 32]);
+    let contract_id = env
+        .deployer()
+        .with_address(deployer.clone(), salt.clone())
+        .deployed_address();
+    env.register_contract(&contract_id, NeuroWealthVault);
+
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let attacker_agent = Address::generate(&env);
+    let attacker_owner = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+
+    // The front-runner passes the correct deployer + salt (public info) but cannot
+    // satisfy deployer.require_auth() — this must panic with an auth error.
+    client.initialize(
+        &deployer,
+        &attacker_owner,
+        &attacker_agent,
+        &usdc_token,
+        &salt,
+    );
+}
+
+/// Regression test: a front-runner who substitutes their own address for the deployer
+/// (to satisfy require_auth with their own keys) must be rejected by the contract-address
+/// check even when all auths are mocked.
+///
+/// The contract derives `expected = deployer_address × salt → contract_address` on-chain
+/// and rejects any deployer whose address does not reproduce the current contract address.
+#[test]
+#[should_panic(expected = "vault: unauthorized deployer")]
+fn test_front_runner_with_own_address_as_deployer_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let real_deployer = Address::generate(&env);
+    let salt = BytesN::from_array(&env, &[0u8; 32]);
+    let contract_id = env
+        .deployer()
+        .with_address(real_deployer.clone(), salt.clone())
+        .deployed_address();
+    env.register_contract(&contract_id, NeuroWealthVault);
+
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let attacker_agent = Address::generate(&env);
+    let attacker_owner = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+
+    // The attacker passes their own address as deployer so they can satisfy
+    // require_auth() with their own keys, but the derived contract address
+    // will not match contract_id → "vault: unauthorized deployer".
+    let attacker = Address::generate(&env);
+    client.initialize(&attacker, &attacker_owner, &attacker_agent, &usdc_token, &salt);
+}

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,82 @@
+# fix: protect initialize() from front-running & add indexed user topic to events
+
+Closes #117 · Closes #162
+
+---
+
+## Summary
+
+### #117 — Protect `initialize()` against front-running takeover
+
+`initialize()` was already guarded by a two-factor check:
+
+1. **Contract-address derivation** — the `deployer` argument plus `salt` must
+   reproduce the current contract address via
+   `env.deployer().with_address(deployer, salt).deployed_address()`.  An
+   attacker who passes their own address as `deployer` cannot satisfy this
+   check.
+2. **`deployer.require_auth()`** — even if an attacker somehow knows the real
+   deployer address and the salt (both visible on-chain), they cannot produce
+   the deployer's signature.
+
+This PR adds:
+- **Two regression tests** in `test_initialize.rs` that prove both attack
+  vectors are rejected:
+  - `test_front_runner_without_deployer_auth_is_rejected` — calls
+    `initialize()` without mocking any auth; `require_auth()` panics.
+  - `test_front_runner_with_own_address_as_deployer_is_rejected` — attacker
+    substitutes their own address; the address-derivation check panics with
+    `"vault: unauthorized deployer"`.
+- **Secure Deployment Sequence** section in `README.md` with step-by-step CLI
+  commands covering: keypair generation → contract deploy with salt → immediate
+  `initialize()` call from the same keypair → verification → keypair disposal.
+
+### #162 — Add indexed user topic to Deposit and Withdraw events
+
+Previously, `DepositEvent` and `WithdrawEvent` were published with a single
+symbol topic `("deposit",)` / `("withdraw",)`.  Filtering events by user
+required scanning the full payload on every indexer node.
+
+This PR publishes the user address as a second **indexed topic**:
+
+```
+("deposit",  <user: Address>)   // DepositEvent
+("withdraw", <user: Address>)   // WithdrawEvent  (withdraw + withdraw_all)
+```
+
+Indexers and AI agents can now filter by user via `topic[1]` directly.
+
+- **`lib.rs`** — three publish sites updated (`deposit`, `withdraw`,
+  `withdraw_all`), each using `user.clone()` so the address is still available
+  for the payload struct.
+- **`test_event_schema.rs`** — new test
+  `test_deposit_withdraw_user_indexed_topic` asserts that the user address
+  appears as an indexed topic in both event types.
+- **`EVENTS.md`** — updated event descriptions for `DepositEvent` and
+  `WithdrawEvent` with topic-position tables.
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `neurowealth-vault/contracts/vault/src/lib.rs` | Add `user.clone()` as second indexed topic in deposit/withdraw/withdraw_all event publishes |
+| `neurowealth-vault/contracts/vault/src/tests/test_event_schema.rs` | Add `test_deposit_withdraw_user_indexed_topic` |
+| `neurowealth-vault/contracts/vault/src/tests/test_initialize.rs` | Add two front-running regression tests |
+| `EVENTS.md` | Document indexed user topic and topic-position tables for Deposit/Withdraw events |
+| `README.md` | Add Secure Deployment Sequence section |
+
+---
+
+## Test plan
+
+- [x] `cargo test` — all 238 tests pass, 0 failures
+- [x] New test `test_deposit_withdraw_user_indexed_topic` confirms user address in topics
+- [x] New test `test_front_runner_without_deployer_auth_is_rejected` confirms auth guard
+- [x] New test `test_front_runner_with_own_address_as_deployer_is_rejected` confirms address guard
+- [x] All pre-existing event schema tests continue to pass (existing `find_events_by_topic` searches all topic slots, so the added address topic does not break any existing assertions)
+
+---
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION


Closes #117 
 Closes #162

---

## Summary

### #117 — Protect `initialize()` against front-running takeover

`initialize()` was already guarded by a two-factor check:

1. **Contract-address derivation** — the `deployer` argument plus `salt` must
   reproduce the current contract address via
   `env.deployer().with_address(deployer, salt).deployed_address()`.  An
   attacker who passes their own address as `deployer` cannot satisfy this
   check.
2. **`deployer.require_auth()`** — even if an attacker somehow knows the real
   deployer address and the salt (both visible on-chain), they cannot produce
   the deployer's signature.

This PR adds:
- **Two regression tests** in `test_initialize.rs` that prove both attack
  vectors are rejected:
  - `test_front_runner_without_deployer_auth_is_rejected` — calls
    `initialize()` without mocking any auth; `require_auth()` panics.
  - `test_front_runner_with_own_address_as_deployer_is_rejected` — attacker
    substitutes their own address; the address-derivation check panics with
    `"vault: unauthorized deployer"`.
- **Secure Deployment Sequence** section in `README.md` with step-by-step CLI
  commands covering: keypair generation → contract deploy with salt → immediate
  `initialize()` call from the same keypair → verification → keypair disposal.

### #162 — Add indexed user topic to Deposit and Withdraw events

Previously, `DepositEvent` and `WithdrawEvent` were published with a single
symbol topic `("deposit",)` / `("withdraw",)`.  Filtering events by user
required scanning the full payload on every indexer node.

This PR publishes the user address as a second **indexed topic**:

```
("deposit",  <user: Address>)   // DepositEvent
("withdraw", <user: Address>)   // WithdrawEvent  (withdraw + withdraw_all)
```

Indexers and AI agents can now filter by user via `topic[1]` directly.

- **`lib.rs`** — three publish sites updated (`deposit`, `withdraw`,
  `withdraw_all`), each using `user.clone()` so the address is still available
  for the payload struct.
- **`test_event_schema.rs`** — new test
  `test_deposit_withdraw_user_indexed_topic` asserts that the user address
  appears as an indexed topic in both event types.
- **`EVENTS.md`** — updated event descriptions for `DepositEvent` and
  `WithdrawEvent` with topic-position tables.

---

## Files changed

| File | Change |
|---|---|
| `neurowealth-vault/contracts/vault/src/lib.rs` | Add `user.clone()` as second indexed topic in deposit/withdraw/withdraw_all event publishes |
| `neurowealth-vault/contracts/vault/src/tests/test_event_schema.rs` | Add `test_deposit_withdraw_user_indexed_topic` |
| `neurowealth-vault/contracts/vault/src/tests/test_initialize.rs` | Add two front-running regression tests |
| `EVENTS.md` | Document indexed user topic and topic-position tables for Deposit/Withdraw events |
| `README.md` | Add Secure Deployment Sequence section |

---

## Test plan

- [x] `cargo test` — all 238 tests pass, 0 failures
- [x] New test `test_deposit_withdraw_user_indexed_topic` confirms user address in topics
- [x] New test `test_front_runner_without_deployer_auth_is_rejected` confirms auth guard
- [x] New test `test_front_runner_with_own_address_as_deployer_is_rejected` confirms address guard
- [x] All pre-existing event schema tests continue to pass (existing `find_events_by_topic` searches all topic slots, so the added address topic does not break any existing assertions)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
