### PR TITLE
feat: rebalance guards, protocol events, and Blend v2 interface (#149–#152)

### DIFF
--- a/BLEND_INTEGRATION_RESEARCH.md
+++ b/BLEND_INTEGRATION_RESEARCH.md
@@ -4,183 +4,104 @@
 
 This document contains research findings for integrating the NeuroWealth Vault with Blend Protocol's Soroban pool contract for on-chain yield generation.
 
-## Research Sources
+## Production Soroban Interface (Blend v2)
 
-### Primary Resources
+The vault integrates via **request-based** fund management (not legacy `deposit`/`redeem` names):
 
-1. **Blend Contracts Repository**: `blend-capital/blend-contracts-v2`
-   - Contains the Soroban implementation of Blend Protocol v2
-   - Location: https://github.com/blend-capital/blend-contracts-v2
+| Entrypoint | Purpose |
+|------------|---------|
+| `submit_with_allowance(from, spender, to, requests)` | Supply assets (request type `0`) after USDC `approve` |
+| `submit(from, to, requests)` | Withdraw assets (request type `1`) |
+| `balance(asset, user)` | Supplied balance for the vault position |
 
-2. **Blend Integration Documentation**: 
-   - Official integration guide: https://docs.blend.capital/tech-docs/integrations/integrate-pool
-   - Covers pool selection, configuration, and integration patterns
+Request struct (contract-local mirror):
 
-3. **Blend Lending Pool Documentation**:
-   - Core contract interface: https://docs.blend.capital/tech-docs/core-contracts/lending-pool
-   - Function signatures and usage patterns
-
-4. **Blend Utils Repository**: `blend-capital/blend-utils`
-   - Deployment and utility scripts
-   - Testnet deployment addresses
-
-## Key Functions Identified
-
-Based on typical lending pool patterns and Blend documentation, the following functions are expected:
-
-### Supply Function
 ```rust
-pub fn supply(
-    env: Env,
-    asset: Address,
+struct BlendRequest {
+    request_type: u32,  // 0 = supply, 1 = withdraw
+    address: Address,   // USDC token
     amount: i128,
-    to: Address
-) -> i128
+}
 ```
-- Supplies assets to the Blend pool
-- Returns the amount of pool tokens received
-- `to` parameter specifies who receives the pool tokens (vault address)
 
-### Withdraw Function
-```rust
-pub fn withdraw(
-    env: Env,
-    asset: Address,
-    amount: i128,
-    to: Address
-) -> i128
-```
-- Withdraws assets from the Blend pool
-- Returns the amount of assets actually withdrawn
-- `to` parameter specifies where withdrawn assets are sent (vault address)
+Implementation: `BlendPoolClient` in `neurowealth-vault/contracts/vault/src/lib.rs`.
 
-### Get Reserve Data Function
-```rust
-pub fn get_reserve_data(
-    env: Env,
-    asset: Address
-) -> ReserveData
-```
-- Returns reserve data including:
-  - Current balance
-  - Interest rate
-  - Liquidity index
-  - Other reserve metrics
+References:
 
-### Get User Balance Function
-```rust
-pub fn get_user_account_data(
-    env: Env,
-    user: Address,
-    asset: Address
-) -> i128
-```
-- Returns the user's supplied balance for a specific asset
-- Alternative function names may be used (e.g., `get_balance`, `get_supply_balance`)
+- https://docs.blend.capital/tech-docs/core-contracts/lending-pool/fund-management
+- https://github.com/blend-capital/blend-contracts-v2
 
-## Implementation Notes
-
-### Cross-Contract Call Pattern
-
-The implementation uses Soroban's `env.invoke_contract()` method for cross-contract calls:
+## Cross-Contract Call Pattern
 
 ```rust
-env.invoke_contract::<ReturnType>(
+env.invoke_contract::<Val>(
     &pool_address,
-    &function_name,
-    &arguments_vec
-)
+    &Symbol::new(env, "submit_with_allowance"),
+    args,
+);
 ```
 
-### Token Approval Pattern
+Supply flow:
 
-Before supplying to Blend, the vault must:
-1. Approve the Blend pool to spend USDC from the vault
-2. Call Blend's `supply()` function
-3. Blend handles the token transfer internally via the approval
+1. Vault `approve`s the Blend pool for the supply amount.
+2. Vault calls `submit_with_allowance` with a type-0 request.
+3. Blend pulls USDC via `transfer_from` (authorized sub-invocation).
 
-### Error Handling Strategy
+Withdraw flow:
 
-To prevent permanent fund lockup:
-- Blend call failures are handled gracefully
-- If a supply/withdraw fails, the transaction continues where possible
-- State is updated atomically to prevent inconsistencies
-- Withdrawals check vault balance and pull from Blend if needed
+1. Vault calls `submit` with a type-1 request.
+2. Blend transfers USDC back to the vault.
 
-## Verification Required
+## Testing
 
-⚠️ **CRITICAL**: The exact function signatures above are based on typical lending pool patterns and should be verified against Blend's actual contract interface before production deployment.
+| Layer | Command |
+|-------|---------|
+| Unit / mock pool | `cargo test -p neurowealth-vault` |
+| Blend interface (feature) | `cargo test -p neurowealth-vault --features blend-devnet` |
 
-### Items to Verify:
+Manual devnet smoke (replace addresses):
 
-1. **Function Names**: Confirm the exact function names (may be `deposit`/`redeem` instead of `supply`/`withdraw`)
-2. **Parameter Order**: Verify parameter order matches Blend's interface
-3. **Return Types**: Confirm return types (may return structs instead of i128)
-4. **Token Transfer Pattern**: Verify if Blend requires pre-approval or handles transfers differently
-5. **Error Handling**: Understand how Blend handles errors (panics vs. return values)
+```bash
+soroban contract invoke --id "$BLEND_POOL" --network testnet -- balance \
+  --asset "$USDC" --user "$VAULT"
+```
 
-## Testnet Deployment Addresses
+## Protocol Tracking
 
-Testnet deployment addresses should be obtained from:
-- Blend's official documentation
-- `blend-utils` repository deployment scripts
-- Blend team communication channels
+`DataKey::CurrentProtocol`:
 
-## Integration Architecture Decisions
-
-### Direct Pool Integration vs. Intermediate Contracts
-
-Blend supports both direct pool integration and intermediate contracts (fee vaults). For the NeuroWealth Vault:
-
-- **Decision**: Direct pool integration (simpler, lower gas costs)
-- **Rationale**: Vault doesn't need fee sharing features initially
-- **Future Consideration**: May migrate to intermediate contract if fee sharing becomes desirable
-
-### Protocol Tracking
-
-The vault tracks the current protocol using `DataKey::CurrentProtocol`:
-- `"none"`: Funds not deployed
+- `"none"`: Funds not deployed (or idle in vault only)
 - `"blend"`: Funds deployed to Blend
-- Future: Additional protocols can be added
 
-## Gas Cost Considerations
+`ProtocolChangedEvent` (`proto_chg`) is emitted whenever `CurrentProtocol` changes.
 
-Expected gas costs for operations:
-- `supply_to_blend()`: ~50,000-100,000 operations (approval + supply call)
-- `withdraw_from_blend()`: ~30,000-70,000 operations (withdraw call)
-- `rebalance()`: ~80,000-150,000 operations (withdraw + supply if switching)
-- `withdraw()` with Blend pull: ~100,000-200,000 operations (withdraw from Blend + transfer)
+## Rebalance API (agent)
 
-**Note**: Actual gas costs should be measured on testnet and documented in integration tests.
+```rust
+pub fn rebalance(env: Env, protocol: Symbol, expected_apy: i128, min_out: i128);
+```
+
+- `min_out`: minimum assets received per supply/withdraw leg; `0` disables slippage checks.
+- `RebalanceEvent.status == "noop"`: no funds moved (e.g. already in Blend with zero idle USDC).
 
 ## Security Considerations
 
-1. **Reentrancy**: Blend calls are made after state updates (CEI pattern)
-2. **Fund Lockup Prevention**: Errors in Blend calls don't prevent withdrawals
-3. **Balance Verification**: Vault verifies it has sufficient balance before user transfers
-4. **Approval Limits**: Token approvals are set with reasonable expiration times
+1. **Reentrancy**: Blend calls follow state updates where applicable (CEI on protocol transitions).
+2. **Incomplete exit**: Rebalance aborts if a protocol switch cannot withdraw the full deployed balance.
+3. **Slippage**: Optional `min_out` guard on supply/withdraw legs.
 
-## Testing Strategy
-
-1. **Unit Tests**: Mock Blend pool contract for basic functionality
-2. **Integration Tests**: Test against Blend testnet deployment
-3. **Failure Scenarios**: Test Blend call failures, insufficient balance, etc.
-4. **Gas Measurement**: Document actual gas costs for all operations
-
-## Next Steps
+## Status
 
 1. ✅ Research Blend interface (this document)
-2. ✅ Implement storage keys and configuration
-3. ✅ Implement Blend client interface
-4. ✅ Update rebalance() and withdraw() functions
-5. ⏳ Verify function signatures against actual Blend contract
-6. ⏳ Write integration tests against testnet
-7. ⏳ Document actual gas costs
-8. ⏳ Security review of cross-contract call patterns
+2. ✅ Implement `BlendPoolClient` with production entrypoints
+3. ✅ `ProtocolChangedEvent` for indexers
+4. ✅ Rebalance `min_out` slippage guard
+5. ✅ No-op rebalance semantics (`status: "noop"`)
+6. ⏳ Measure gas on testnet
+7. ⏳ Security review of cross-contract call patterns
 
 ## References
 
 - Blend GitHub: https://github.com/blend-capital
 - Blend Documentation: https://docs.blend.capital
 - Soroban SDK Documentation: https://soroban.stellar.org/docs
-- Stellar Testnet: https://developers.stellar.org/docs/encyclopedia/testnet

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -102,16 +102,35 @@ Emitted when the AI agent rebalances funds between yield strategies.
 pub struct RebalanceEvent {
     pub protocol: Symbol,         // Target protocol ("blend", "none")
     pub expected_apy: i128,       // Expected APY in basis points (850 = 8.5%)
-    pub status: Symbol,           // Status ("success", "failed", "partial")
+    pub status: Symbol,           // "success", "failed", "partial", or "noop"
     pub amount_attempted: i128,   // Amount attempted to be moved
     pub amount_moved: i128,       // Amount actually moved
 }
 ```
 
+**Agent / indexer notes:**
+- `"noop"`: target allocation already satisfied; no supply/withdraw leg ran (e.g. rebalance to Blend with zero idle USDC while already deployed).
+- Prefer `ProtocolChangedEvent` for authoritative protocol transitions (see below).
+
 **Usage:**
 - AI agents track rebalancing decisions
 - Frontend displays current strategy allocation
 - Indexers monitor strategy changes for risk analysis
+
+### 4a. ProtocolChangedEvent
+**Topic:** `"proto_chg"`
+
+Emitted when `CurrentProtocol` storage changes (supply to Blend, full withdraw, or explicit transition to `"none"`).
+
+```rust
+pub struct ProtocolChangedEvent {
+    pub old_protocol: Symbol,
+    pub new_protocol: Symbol,
+}
+```
+
+**Usage:**
+- Indexers record explicit protocol state transitions without inferring from rebalance events alone
 
 ## Administrative Events
 

--- a/PR_BODY_149-152.md
+++ b/PR_BODY_149-152.md
@@ -1,0 +1,28 @@
+Closes #149
+Closes #150
+Closes #151
+Closes #152
+
+## Summary
+
+- **#149** — Emit `ProtocolChangedEvent` (`proto_chg`) whenever `CurrentProtocol` updates (supply, withdraw, rebalance to `none`).
+- **#150** — Add `min_out` to `rebalance()`; panics when a supply/withdraw leg receives less than the floor (`0` disables the guard). Includes mock pool shortfall test.
+- **#151** — Rebalance with no fund movement sets `RebalanceEvent.status` to `"noop"`; documented in `EVENTS.md` for agents/indexers.
+- **#152** — Align `BlendPoolClient` and docs with production Blend v2 (`submit_with_allowance`, `submit`, `balance`); optional `blend-devnet` feature tests.
+
+## Migration
+
+`rebalance` now requires a third argument:
+
+```bash
+soroban contract invoke ... -- rebalance \
+  --protocol blend --expected_apy 850 --min_out 0
+```
+
+Pass `min_out > 0` to bound slippage on each supply/withdraw leg.
+
+## Test plan
+
+- [x] `cargo test -p neurowealth-vault`
+- [x] `cargo test -p neurowealth-vault --features blend-devnet`
+- [x] Event schema tests for `ProtocolChangedEvent` and noop rebalance status

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Key Functions
 | `deposit` | Any verified user | Deposit USDC into the vault |
 | `withdraw` | User (their own funds) | Withdraw USDC back to wallet |
 | `withdraw_all` | User (their own funds) | Withdraw all USDC by burning all shares |
-| `rebalance` | AI Agent only | Move funds between yield strategies (supported: `blend`, `none`) |
+| `rebalance` | AI Agent only | Move funds between yield strategies (`protocol`, `expected_apy`, `min_out`; supported: `blend`, `none`) |
 | `get_balance` | Anyone | Read a user's current balance |
 | `get_total_deposits` | Anyone | Read total vault TVL |
 | `get_exchange_rate` | Anyone | Read current exchange rate (assets per share * 10,000,000) |

--- a/neurowealth-vault/contracts/vault/Cargo.toml
+++ b/neurowealth-vault/contracts/vault/Cargo.toml
@@ -6,6 +6,11 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = []
+# Enable `cargo test -p neurowealth-vault --features blend-devnet`
+blend-devnet = []
+
 [dependencies]
 soroban-sdk = { workspace = true }
 

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -236,12 +236,25 @@ pub struct RebalanceEvent {
     pub protocol: Symbol,
     /// Expected APY in basis points (e.g., 850 = 8.5%)
     pub expected_apy: i128,
-    /// Status of the rebalance operation ("success", "failed", "partial")
+    /// Status: "success", "failed", "partial", or "noop" (no funds moved)
     pub status: Symbol,
     /// Amount attempted to be moved
     pub amount_attempted: i128,
     /// Amount actually moved
     pub amount_moved: i128,
+}
+
+/// Emitted when [`DataKey::CurrentProtocol`] changes.
+///
+/// Indexers should prefer this event over inferring protocol from rebalance
+/// events alone.
+///
+/// # Topics
+/// - `SymbolShort("proto_chg")` - Event identifier
+#[contracttype]
+pub struct ProtocolChangedEvent {
+    pub old_protocol: Symbol,
+    pub new_protocol: Symbol,
 }
 
 /// Emitted when the vault is paused or unpaused.
@@ -451,16 +464,15 @@ pub struct UserInfo {
 // BLEND POOL CLIENT INTERFACE
 // ============================================================================
 
-/// Helper functions for interacting with Blend pool contract.
+/// Helper functions for interacting with Blend Protocol v2 pool contract.
 ///
-/// Based on Blend's official interface documentation:
-/// - https://docs.rs/blend-interfaces/0.0.1/blend_interfaces/pool/trait.Pool.html
-/// - https://docs.blend.capital/tech-docs/core-contracts/lending-pool
+/// Production Blend Soroban pools use request-based fund management:
+/// - `submit_with_allowance(from, spender, to, requests)` — supply with token allowance
+/// - `submit(from, to, requests)` — withdraw (request type 1)
+/// - `balance(asset, user)` — supplied balance for the vault position
 ///
-/// Function names based on blend-interfaces crate:
-/// - `deposit` - Supplies assets to the pool
-/// - `redeem` - Withdraws assets from the pool
-/// - `get_user_reserve_data` - Gets user's reserve data including balance
+/// See `BLEND_INTEGRATION_RESEARCH.md` and
+/// https://docs.blend.capital/tech-docs/core-contracts/lending-pool/fund-management
 struct BlendPoolClient;
 
 #[derive(Clone)]
@@ -472,6 +484,7 @@ struct BlendRequest {
 }
 
 const BLEND_REQUEST_TYPE_SUPPLY: u32 = 0;
+const BLEND_REQUEST_TYPE_WITHDRAW: u32 = 1;
 #[allow(dead_code)]
 const DEFAULT_TVL_CAP: i128 = 100_000_000_000_i128;
 const DEFAULT_USER_DEPOSIT_CAP: i128 = 10_000_000_000_i128;
@@ -497,6 +510,7 @@ pub(crate) const TOPIC_ASSETS_UPDATED: Symbol = symbol_short!("assets");
 pub(crate) const TOPIC_UPGRADED: Symbol = symbol_short!("upgraded");
 pub(crate) const TOPIC_BLEND_SUPPLY: Symbol = symbol_short!("blend_sup");
 pub(crate) const TOPIC_BLEND_WITHDRAW: Symbol = symbol_short!("blend_wd");
+pub(crate) const TOPIC_PROTOCOL_CHANGED: Symbol = symbol_short!("proto_chg");
 
 impl BlendPoolClient {
     /// Deposits assets to the Blend pool.
@@ -580,7 +594,7 @@ impl BlendPoolClient {
 
         // Create withdraw request (type 1 = withdraw)
         let request = BlendRequest {
-            request_type: 1, // Withdraw request type
+            request_type: BLEND_REQUEST_TYPE_WITHDRAW,
             address: asset.clone(),
             amount,
         };
@@ -960,7 +974,7 @@ impl NeuroWealthVault {
 
                 // Attempt to withdraw from Blend
                 // If this returns less than needed, we will reconcile below
-                let _withdrawn = Self::withdraw_from_blend(&env, needed);
+                let _withdrawn = Self::withdraw_from_blend(&env, needed, 0);
 
                 // RECONCILIATION: Check actual available USDC after Blend withdrawal.
                 // We cap the withdrawal to what the vault actually has available.
@@ -1152,7 +1166,7 @@ impl NeuroWealthVault {
                 let needed = entitled_amount
                     .checked_sub(vault_balance)
                     .expect("vault: math error");
-                let _ = Self::withdraw_from_blend(&env, needed);
+                let _ = Self::withdraw_from_blend(&env, needed, 0);
 
                 // RECONCILIATION: Check actual available USDC after potential Blend withdrawal
                 let available_usdc = token_client.balance(&env.current_contract_address());
@@ -1261,6 +1275,8 @@ impl NeuroWealthVault {
     /// * `env` - The Soroban environment
     /// * `protocol` - The target protocol symbol. Supported values: "blend", "none"
     /// * `expected_apy` - Expected APY in basis points (e.g., 850 = 8.5%)
+    /// * `min_out` - Minimum assets that must be received on each supply/withdraw leg;
+    ///   pass `0` to disable slippage protection (breaking change vs. earlier two-arg API)
     ///
     /// # Returns
     /// Nothing. This function triggers rebalancing and returns nothing.
@@ -1269,21 +1285,29 @@ impl NeuroWealthVault {
     /// - If the vault is paused
     /// - If the caller is not the authorized agent
     /// - If Blend pool is not configured and protocol is "blend"
+    /// - If a leg moves fewer assets than `min_out` when `min_out > 0`
     ///
     /// # Events
-    /// Emits `RebalanceEvent` with:
-    /// - `protocol`: The target protocol
-    /// - `expected_apy`: Expected APY in basis points
+    /// Emits `RebalanceEvent` (status `"noop"` when no funds move) and
+    /// `ProtocolChangedEvent` when [`DataKey::CurrentProtocol`] updates.
+    ///
+    /// # Agent expectations (off-chain)
+    /// - `status == "noop"`: vault already at target allocation; no pool calls needed
+    /// - `ProtocolChangedEvent`: authoritative protocol transition for indexers
     ///
     /// # Security
     /// - `agent.require_auth()` ensures only the authorized AI agent can rebalance
     /// - Agent is set during initialization and can be updated by owner
     /// - Funds are moved on-chain via cross-contract calls
     /// - Errors in protocol calls are handled gracefully to prevent fund lockup
-    pub fn rebalance(env: Env, protocol: Symbol, expected_apy: i128) {
+    pub fn rebalance(env: Env, protocol: Symbol, expected_apy: i128, min_out: i128) {
         Self::require_initialized(&env);
         Self::require_not_paused(&env);
         Self::require_is_agent(&env);
+
+        if min_out < 0 {
+            panic!("vault: min_out must be non-negative");
+        }
 
         // Validate protocol against allowlist
         let supported_protocols = vec![&env, symbol_short!("blend"), symbol_short!("none")];
@@ -1297,16 +1321,17 @@ impl NeuroWealthVault {
             .get(&DataKey::CurrentProtocol)
             .unwrap_or(symbol_short!("none"));
 
+        let mut amount_attempted = 0_i128;
+        let mut amount_moved = 0_i128;
+
         // If switching protocols, withdraw from current protocol first
         if current_protocol != protocol && current_protocol != symbol_short!("none") {
-            // Get expected balance before withdrawal for verification
             let expected_withdrawal = Self::get_protocol_balance(&env, &current_protocol);
+            amount_attempted = amount_attempted.saturating_add(expected_withdrawal);
 
-            let withdrawn = Self::withdraw_from_protocol(&env, &current_protocol);
+            let withdrawn = Self::withdraw_from_protocol(&env, &current_protocol, min_out);
+            amount_moved = amount_moved.saturating_add(withdrawn);
 
-            // CRITICAL: Verify complete protocol exit before proceeding
-            // Check that: (1) we withdrew what was expected, AND (2) protocol balance is now 0
-            // This prevents partial transitions where funds get stuck in the old protocol
             if expected_withdrawal > 0 {
                 assert!(
                     withdrawn >= expected_withdrawal,
@@ -1315,7 +1340,6 @@ impl NeuroWealthVault {
                     withdrawn
                 );
 
-                // Double-check that protocol balance is actually 0
                 let remaining_balance = Self::get_protocol_balance(&env, &current_protocol);
                 assert!(
                     remaining_balance == 0,
@@ -1325,7 +1349,6 @@ impl NeuroWealthVault {
             }
         }
 
-        // Supply to new protocol if switching to Blend
         if protocol == symbol_short!("blend") {
             if !env.storage().instance().has(&DataKey::BlendPool) {
                 panic!("vault: blend pool not configured");
@@ -1335,24 +1358,20 @@ impl NeuroWealthVault {
             let token_client = token::Client::new(&env, &usdc_token);
             let vault_balance = token_client.balance(&env.current_contract_address());
 
-            let mut amount_attempted = 0;
-            let mut amount_moved = 0;
             let mut status = symbol_short!("success");
 
             if vault_balance > 0 {
-                amount_attempted = vault_balance;
-                let supplied = Self::supply_to_blend(&env, vault_balance);
-                amount_moved = supplied;
-
-                if supplied > 0 {
-                    let _total_assets = Self::get_total_assets_internal(&env);
-                }
+                amount_attempted = amount_attempted.saturating_add(vault_balance);
+                let supplied = Self::supply_to_blend(&env, vault_balance, min_out);
+                amount_moved = amount_moved.saturating_add(supplied);
 
                 if supplied == 0 {
                     status = symbol_short!("failed");
                 } else if supplied < vault_balance {
                     status = symbol_short!("partial");
                 }
+            } else if amount_moved == 0 {
+                status = symbol_short!("noop");
             }
 
             env.events().publish(
@@ -1366,19 +1385,15 @@ impl NeuroWealthVault {
                 },
             );
         } else if protocol == symbol_short!("none") {
-            let mut amount_attempted = 0;
-            let mut amount_moved = 0;
-            let status = symbol_short!("success");
+            let mut status = symbol_short!("success");
 
             if current_protocol != symbol_short!("none") {
-                // Get expected balance before withdrawal for verification
                 let expected_withdrawal = Self::get_protocol_balance(&env, &current_protocol);
-                amount_attempted = expected_withdrawal;
+                amount_attempted = amount_attempted.saturating_add(expected_withdrawal);
 
-                let withdrawn = Self::withdraw_from_protocol(&env, &current_protocol);
-                amount_moved = withdrawn;
+                let withdrawn = Self::withdraw_from_protocol(&env, &current_protocol, min_out);
+                amount_moved = amount_moved.saturating_add(withdrawn);
 
-                // CRITICAL: Verify complete protocol exit before clearing protocol state
                 if expected_withdrawal > 0 {
                     assert!(
                         withdrawn >= expected_withdrawal,
@@ -1387,7 +1402,6 @@ impl NeuroWealthVault {
                         withdrawn
                     );
 
-                    // Double-check that protocol balance is actually 0
                     let remaining_balance = Self::get_protocol_balance(&env, &current_protocol);
                     assert!(
                         remaining_balance == 0,
@@ -1395,10 +1409,11 @@ impl NeuroWealthVault {
                         remaining_balance
                     );
                 }
+                Self::set_current_protocol(&env, symbol_short!("none"));
+            } else if amount_moved == 0 {
+                status = symbol_short!("noop");
             }
-            env.storage()
-                .instance()
-                .set(&DataKey::CurrentProtocol, &symbol_short!("none"));
+
             env.events().publish(
                 (TOPIC_REBALANCE,),
                 RebalanceEvent {
@@ -2954,6 +2969,41 @@ impl NeuroWealthVault {
         }
     }
 
+    /// Updates [`DataKey::CurrentProtocol`] and emits [`ProtocolChangedEvent`] on change.
+    fn set_current_protocol(env: &Env, new_protocol: Symbol) {
+        let old_protocol: Symbol = env
+            .storage()
+            .instance()
+            .get(&DataKey::CurrentProtocol)
+            .unwrap_or(symbol_short!("none"));
+
+        if old_protocol == new_protocol {
+            return;
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::CurrentProtocol, &new_protocol);
+
+        env.events().publish(
+            (TOPIC_PROTOCOL_CHANGED,),
+            ProtocolChangedEvent {
+                old_protocol,
+                new_protocol,
+            },
+        );
+    }
+
+    /// Panics when `min_out > 0` and fewer assets were received than required.
+    fn require_min_out(actual: i128, min_out: i128, leg: &str) {
+        if min_out > 0 && actual < min_out {
+            panic!(
+                "vault: {} received {} below min_out {}",
+                leg, actual, min_out
+            );
+        }
+    }
+
     /// Internal helper: Supplies USDC to the Blend pool.
     ///
     /// This function handles the cross-contract call to Blend's supply function.
@@ -2962,6 +3012,7 @@ impl NeuroWealthVault {
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `amount` - Amount of USDC to supply
+    /// * `min_out` - Minimum amount that must be supplied (0 = no check)
     ///
     /// # Returns
     /// The amount actually supplied (may be less than requested)
@@ -2970,7 +3021,7 @@ impl NeuroWealthVault {
     /// - Returns 0 if amount <= 0
     /// - Panics if Blend pool address is not configured
     /// - Emits BlendSupplyEvent with success status
-    fn supply_to_blend(env: &Env, amount: i128) -> i128 {
+    fn supply_to_blend(env: &Env, amount: i128, min_out: i128) -> i128 {
         if amount <= 0 {
             return 0;
         }
@@ -3058,11 +3109,10 @@ impl NeuroWealthVault {
         let supplied =
             BlendPoolClient::supply(env, &pool_address, &usdc_token, amount, &vault_address);
 
-        // Update current protocol tracking only if supply was successful
+        Self::require_min_out(supplied, min_out, "blend supply");
+
         if supplied > 0 {
-            env.storage()
-                .instance()
-                .set(&DataKey::CurrentProtocol, &symbol_short!("blend"));
+            Self::set_current_protocol(env, symbol_short!("blend"));
         }
 
         // Emit event for supply
@@ -3085,6 +3135,7 @@ impl NeuroWealthVault {
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `amount` - Amount of USDC to withdraw (0 = withdraw all)
+    /// * `min_out` - Minimum amount that must be withdrawn (0 = no check)
     ///
     /// # Returns
     /// The amount actually withdrawn
@@ -3093,7 +3144,7 @@ impl NeuroWealthVault {
     /// - Returns 0 if amount_to_withdraw <= 0
     /// - Panics if Blend pool address is not configured
     /// - Emits BlendWithdrawEvent with success status and actual amount received
-    fn withdraw_from_blend(env: &Env, amount: i128) -> i128 {
+    fn withdraw_from_blend(env: &Env, amount: i128, min_out: i128) -> i128 {
         let pool_address: Address = env
             .storage()
             .instance()
@@ -3125,15 +3176,13 @@ impl NeuroWealthVault {
             &vault_address,
         );
 
-        // Update current protocol tracking if fully withdrawn
+        Self::require_min_out(withdrawn, min_out, "blend withdraw");
+
         if withdrawn > 0 && amount == 0 {
-            // Check if balance is now zero
             let remaining =
                 BlendPoolClient::get_balance(env, &pool_address, &usdc_token, &vault_address);
             if remaining == 0 {
-                env.storage()
-                    .instance()
-                    .set(&DataKey::CurrentProtocol, &symbol_short!("none"));
+                Self::set_current_protocol(env, symbol_short!("none"));
             }
         }
 
@@ -3161,7 +3210,7 @@ impl NeuroWealthVault {
     ///
     /// # Returns
     /// The amount withdrawn, or 0 if no funds were deployed to that protocol
-    fn withdraw_from_protocol(env: &Env, protocol: &Symbol) -> i128 {
+    fn withdraw_from_protocol(env: &Env, protocol: &Symbol, min_out: i128) -> i128 {
         let current_protocol: Symbol = env
             .storage()
             .instance()
@@ -3169,8 +3218,7 @@ impl NeuroWealthVault {
             .unwrap_or(symbol_short!("none"));
 
         if current_protocol == *protocol && *protocol == symbol_short!("blend") {
-            // Withdraw all funds from Blend
-            Self::withdraw_from_blend(env, 0)
+            Self::withdraw_from_blend(env, 0, min_out)
         } else {
             0
         }

--- a/neurowealth-vault/contracts/vault/src/test.rs
+++ b/neurowealth-vault/contracts/vault/src/test.rs
@@ -829,7 +829,7 @@ fn test_withdraw_reconciles_partial_blend_redemption() {
     client.deposit(&user, &deposit_amount);
 
     // 2. Rebalance to Blend
-    client.rebalance(&symbol_short!("blend"), &800_i128);
+    client.rebalance(&symbol_short!("blend"), &800_i128, &0_i128);
 
     // Verify funds moved to pool
     assert_eq!(token_client.balance(&contract_id), 0);
@@ -873,7 +873,7 @@ fn test_withdraw_all_reconciles_partial_blend_redemption() {
     client.deposit(&user, &deposit_amount);
 
     // 2. Rebalance to Blend
-    client.rebalance(&symbol_short!("blend"), &800_i128);
+    client.rebalance(&symbol_short!("blend"), &800_i128, &0_i128);
 
     // 3. User attempts to withdraw_all (entitled to 20 USDC)
     // MockBlendPool will only return 10 USDC (half of its 20 USDC balance)

--- a/neurowealth-vault/contracts/vault/src/tests/mod.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/mod.rs
@@ -14,6 +14,8 @@ mod test_math_limits;
 mod test_pause;
 mod test_rebalance;
 mod test_rebalance_integration;
+#[cfg(feature = "blend-devnet")]
+mod test_blend_devnet;
 mod test_rounding_math;
 mod test_shares;
 mod test_withdraw;

--- a/neurowealth-vault/contracts/vault/src/tests/test_access_control.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_access_control.rs
@@ -243,7 +243,7 @@ fn test_agent_can_rebalance() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     // "none" protocol is always safe — no external pool required
-    client.rebalance(&symbol_short!("none"), &500_i128);
+    client.rebalance(&symbol_short!("none"), &500_i128, &0_i128);
 
     assert_eq!(
         client.get_current_protocol(),
@@ -564,7 +564,7 @@ fn test_rebalance_blocked_while_paused() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     client.pause(&owner);
-    client.rebalance(&symbol_short!("none"), &500_i128);
+    client.rebalance(&symbol_short!("none"), &500_i128, &0_i128);
 }
 
 // ============================================================================

--- a/neurowealth-vault/contracts/vault/src/tests/test_auth.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_auth.rs
@@ -150,12 +150,12 @@ fn test_agent_rebalance_with_scoped_auth() {
         invoke: &MockAuthInvoke {
             contract: &contract_id,
             fn_name: "rebalance",
-            args: (symbol_short!("none"), 500_i128).into_val(&env),
+            args: (symbol_short!("none"), 500_i128, 0_i128).into_val(&env),
             sub_invokes: &[],
         },
     }]);
 
-    client.rebalance(&symbol_short!("none"), &500_i128);
+    client.rebalance(&symbol_short!("none"), &500_i128, &0_i128);
     assert_eq!(client.get_current_protocol(), symbol_short!("none"));
 }
 
@@ -168,7 +168,7 @@ fn test_rebalance_requires_agent_auth() {
 
     env.mock_auths(&[]);
 
-    let result = client.try_rebalance(&symbol_short!("none"), &500_i128);
+    let result = client.try_rebalance(&symbol_short!("none"), &500_i128, &0_i128);
     assert!(
         result.is_err(),
         "rebalance must fail without the agent's authorization"

--- a/neurowealth-vault/contracts/vault/src/tests/test_blend_devnet.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_blend_devnet.rs
@@ -1,0 +1,31 @@
+//! Blend production-interface tests (enabled with `--features blend-devnet`, #152).
+//!
+//! Uses the in-env mock pool that implements the same entrypoints as mainnet Blend v2.
+//! For a live network smoke test, invoke `balance`, `submit_with_allowance`, and `submit`
+//! against `BLEND_POOL_ADDRESS` via the Soroban CLI (see `BLEND_INTEGRATION_RESEARCH.md`).
+
+#![cfg(all(test, feature = "blend-devnet"))]
+
+use super::utils::*;
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+#[test]
+fn test_blend_production_entrypoints_on_mock_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, usdc_token, blend_pool) =
+        setup_vault_with_token_and_blend(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_blend_pool(&owner, &blend_pool);
+
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, 5_000_000_i128);
+
+    client.rebalance(&symbol_short!("blend"), &850_i128, &0_i128);
+    assert_eq!(client.get_current_protocol(), symbol_short!("blend"));
+
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
+    assert_eq!(client.get_current_protocol(), symbol_short!("none"));
+}

--- a/neurowealth-vault/contracts/vault/src/tests/test_blend_integration.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_blend_integration.rs
@@ -26,7 +26,7 @@ fn test_blend_integration_supply_via_rebalance() {
 
     // 3. Trigger rebalance to Blend
     let protocol = Symbol::new(&env, "blend");
-    vault_client.rebalance(&protocol, &850); // 8.5% expected APY
+    vault_client.rebalance(&protocol, &850, &0_i128); // 8.5% expected APY
 
     // 4. Verify results
     // - Vault USDC balance should be 0 (transferred to Blend)
@@ -57,11 +57,11 @@ fn test_blend_integration_withdraw_via_rebalance() {
     // 1. Supply to Blend first
     let amount = 50_000_000;
     token_client.mint(&vault_id, &amount);
-    vault_client.rebalance(&Symbol::new(&env, "blend"), &850);
+    vault_client.rebalance(&Symbol::new(&env, "blend"), &850, &0_i128);
     assert_eq!(token_client.balance(&blend_pool), amount);
 
     // 2. Withdraw from Blend by rebalancing to "none"
-    vault_client.rebalance(&Symbol::new(&env, "none"), &0);
+    vault_client.rebalance(&Symbol::new(&env, "none"), &0, &0_i128);
 
     // 3. Verify results
     // - Vault USDC balance should be restored
@@ -95,7 +95,7 @@ fn test_blend_integration_balance_read() {
     // 1. Supply some funds
     let amount = 75_000_000;
     token_client.mint(&vault_id, &amount);
-    vault_client.rebalance(&Symbol::new(&env, "blend"), &850);
+    vault_client.rebalance(&Symbol::new(&env, "blend"), &850, &0_i128);
 
     // 2. Check balance via vault's internal get_blend_pool getter
     // Note: The vault doesn't have a public get_blend_balance, but we can verify it indirectly

--- a/neurowealth-vault/contracts/vault/src/tests/test_event_schema.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_event_schema.rs
@@ -10,12 +10,12 @@ use super::utils::*;
 use crate::{
     AgentUpdatedEvent, AssetsUpdatedEvent, BlendSupplyEvent, BlendWithdrawEvent, DepositEvent,
     EmergencyPausedEvent, LimitsUpdatedEvent, OwnershipTransferInitiatedEvent,
-    OwnershipTransferredEvent, RebalanceEvent, TvlCapUpdatedEvent, UserDepositCapUpdatedEvent,
-    VaultInitializedEvent, VaultPausedEvent, VaultUnpausedEvent, WithdrawEvent,
-    TOPIC_AGENT_UPDATED, TOPIC_ASSETS_UPDATED, TOPIC_BLEND_SUPPLY, TOPIC_BLEND_WITHDRAW,
-    TOPIC_DEPOSIT, TOPIC_EMERGENCY_PAUSED, TOPIC_INIT, TOPIC_LIMITS_UPDATED,
-    TOPIC_OWNERSHIP_INITIATED, TOPIC_OWNERSHIP_TRANSFERRED, TOPIC_PAUSED, TOPIC_REBALANCE,
-    TOPIC_TVL_CAP_UPDATED, TOPIC_UNPAUSED, TOPIC_USER_CAP_UPDATED, TOPIC_WITHDRAW,
+    OwnershipTransferredEvent, ProtocolChangedEvent, RebalanceEvent, TvlCapUpdatedEvent,
+    UserDepositCapUpdatedEvent, VaultInitializedEvent, VaultPausedEvent, VaultUnpausedEvent,
+    WithdrawEvent, TOPIC_AGENT_UPDATED, TOPIC_ASSETS_UPDATED, TOPIC_BLEND_SUPPLY,
+    TOPIC_BLEND_WITHDRAW, TOPIC_DEPOSIT, TOPIC_EMERGENCY_PAUSED, TOPIC_INIT, TOPIC_LIMITS_UPDATED,
+    TOPIC_OWNERSHIP_INITIATED, TOPIC_OWNERSHIP_TRANSFERRED, TOPIC_PAUSED, TOPIC_PROTOCOL_CHANGED,
+    TOPIC_REBALANCE, TOPIC_TVL_CAP_UPDATED, TOPIC_UNPAUSED, TOPIC_USER_CAP_UPDATED, TOPIC_WITHDRAW,
 };
 use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, TryFromVal};
 
@@ -191,7 +191,7 @@ fn test_event_schema_rebalance_events() {
     // Test rebalance event
     let protocol = symbol_short!("none");
     let expected_apy = 850_i128;
-    client.rebalance(&protocol, &expected_apy);
+    client.rebalance(&protocol, &expected_apy, &0_i128);
 
     let rebalance_events = find_events_by_topic(env.events().all(), &env, TOPIC_REBALANCE);
     assert_eq!(
@@ -207,9 +207,57 @@ fn test_event_schema_rebalance_events() {
     // Verify payload structure
     assert_eq!(rebalance_event.protocol, protocol);
     assert_eq!(rebalance_event.expected_apy, expected_apy);
-    assert_eq!(rebalance_event.status, symbol_short!("success"));
+    assert_eq!(rebalance_event.status, symbol_short!("noop"));
     assert_eq!(rebalance_event.amount_attempted, 0);
     assert_eq!(rebalance_event.amount_moved, 0);
+}
+
+/// ProtocolChangedEvent is emitted when CurrentProtocol updates (#149).
+#[test]
+fn test_event_schema_protocol_changed_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, usdc_token, blend_pool) =
+        setup_vault_with_token_and_blend(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_blend_pool(&owner, &blend_pool);
+
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, 10_000_000_i128);
+
+    client.rebalance(&symbol_short!("blend"), &1200_i128, &0_i128);
+
+    let proto_events =
+        find_events_by_topic(env.events().all(), &env, TOPIC_PROTOCOL_CHANGED);
+    assert_eq!(
+        proto_events.len(),
+        1,
+        "Exactly one protocol changed event should be emitted"
+    );
+
+    let (_, _, data) = &proto_events[0];
+    let proto_event = ProtocolChangedEvent::try_from_val(&env, data)
+        .expect("Should be a valid ProtocolChangedEvent");
+    assert_eq!(proto_event.old_protocol, symbol_short!("none"));
+    assert_eq!(proto_event.new_protocol, symbol_short!("blend"));
+
+    client.rebalance(&symbol_short!("none"), &500_i128, &0_i128);
+
+    let proto_events =
+        find_events_by_topic(env.events().all(), &env, TOPIC_PROTOCOL_CHANGED);
+    assert_eq!(
+        proto_events.len(),
+        2,
+        "Second transition should emit another protocol changed event"
+    );
+
+    let (_, _, data) = &proto_events[1];
+    let proto_event = ProtocolChangedEvent::try_from_val(&env, data)
+        .expect("Should be a valid ProtocolChangedEvent");
+    assert_eq!(proto_event.old_protocol, symbol_short!("blend"));
+    assert_eq!(proto_event.new_protocol, symbol_short!("none"));
 }
 
 /// Test that ownership transfer events have correct topics and payload structure
@@ -364,7 +412,7 @@ fn test_event_schema_blend_events() {
     mint_and_deposit(&env, &client, &usdc_token, &user, 10_000_000_i128);
 
     // Test rebalance to blend (should emit BlendSupplyEvent)
-    client.rebalance(&symbol_short!("blend"), &1200_i128);
+    client.rebalance(&symbol_short!("blend"), &1200_i128, &0_i128);
 
     let supply_events = find_events_by_topic(env.events().all(), &env, TOPIC_BLEND_SUPPLY);
     assert_eq!(
@@ -383,7 +431,7 @@ fn test_event_schema_blend_events() {
     assert!(supply_event.success);
 
     // Test rebalance back to none (should emit BlendWithdrawEvent)
-    client.rebalance(&symbol_short!("none"), &500_i128);
+    client.rebalance(&symbol_short!("none"), &500_i128, &0_i128);
 
     let withdraw_events = find_events_by_topic(env.events().all(), &env, TOPIC_BLEND_WITHDRAW);
     assert_eq!(

--- a/neurowealth-vault/contracts/vault/src/tests/test_events.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_events.rs
@@ -425,7 +425,7 @@ fn test_rebalance_emits_rebalance_event_with_correct_payload() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     let expected_apy = 850_i128;
-    client.rebalance(&symbol_short!("none"), &expected_apy);
+    client.rebalance(&symbol_short!("none"), &expected_apy, &0_i128);
 
     let rebalance_events = find_events_by_topic(env.events().all(), &env, TOPIC_REBALANCE);
     assert!(
@@ -446,8 +446,8 @@ fn test_rebalance_emits_rebalance_event_with_correct_payload() {
     );
     assert_eq!(
         event.status,
-        symbol_short!("success"),
-        "Event status should be success"
+        symbol_short!("noop"),
+        "Event status should be noop when no funds move"
     );
     assert_eq!(
         event.amount_attempted, 0,
@@ -471,7 +471,7 @@ fn test_rebalance_with_blend_emits_correct_event() {
     mint_and_deposit(&env, &client, &usdc_token, &user, 10_000_000_i128);
 
     let expected_apy = 1200_i128;
-    client.rebalance(&symbol_short!("blend"), &expected_apy);
+    client.rebalance(&symbol_short!("blend"), &expected_apy, &0_i128);
 
     let rebalance_events = find_events_by_topic(env.events().all(), &env, TOPIC_REBALANCE);
     let last_event_data = &rebalance_events.last().unwrap().2;
@@ -520,7 +520,7 @@ fn test_rebalance_with_blend_partial_fill_emits_correct_event() {
     mint_and_deposit(&env, &client, &usdc_token, &user, 10_000_000_i128);
 
     let expected_apy = 1200_i128;
-    client.rebalance(&symbol_short!("blend"), &expected_apy);
+    client.rebalance(&symbol_short!("blend"), &expected_apy, &0_i128);
 
     let rebalance_events = find_events_by_topic(env.events().all(), &env, TOPIC_REBALANCE);
     let last_event_data = &rebalance_events.last().unwrap().2;
@@ -565,7 +565,7 @@ fn test_rebalance_with_blend_failed_fill_emits_correct_event() {
     mint_and_deposit(&env, &client, &usdc_token, &user, 10_000_000_i128);
 
     let expected_apy = 1200_i128;
-    client.rebalance(&symbol_short!("blend"), &expected_apy);
+    client.rebalance(&symbol_short!("blend"), &expected_apy, &0_i128);
 
     let rebalance_events = find_events_by_topic(env.events().all(), &env, TOPIC_REBALANCE);
     let last_event_data = &rebalance_events.last().unwrap().2;
@@ -598,7 +598,7 @@ fn test_all_events_have_correct_topics() {
 
     client.set_deposit_limits(&1_000_000_i128, &10_000_000_000_i128);
     client.set_caps(&10_000_000_i128, &100_000_000_i128);
-    client.rebalance(&symbol_short!("none"), &500_i128);
+    client.rebalance(&symbol_short!("none"), &500_i128, &0_i128);
     client.pause(&owner);
     client.unpause(&owner);
     client.emergency_pause(&owner);
@@ -656,7 +656,7 @@ fn test_withdraw_all_partial_liquidity_emits_burned_shares() {
     let _total_shares_before = client.get_total_shares();
     let _total_assets_before = client.get_total_assets();
 
-    client.rebalance(&symbol_short!("blend"), &900_i128);
+    client.rebalance(&symbol_short!("blend"), &900_i128, &0_i128);
 
     // After rebalance: 90% in blend (9M), 10% in vault (1M)
     // Vault balance is 1,000,000
@@ -747,7 +747,7 @@ fn test_blend_supply_event_reports_actual_supplied_with_shortfall() {
     mint_and_deposit(&env, &client, &usdc_token, &user, 10_000_000_i128);
 
     // Rebalance 90% to blend - vault tries to supply 9M, but pool only accepts 3M
-    client.rebalance(&symbol_short!("blend"), &900_i128);
+    client.rebalance(&symbol_short!("blend"), &900_i128, &0_i128);
 
     // Verify actual supplied was less than requested
     let pool_supplied = blend_client.supplied(&usdc_token);
@@ -804,7 +804,7 @@ fn test_blend_withdraw_event_reports_actual_withdrawn_with_shortfall() {
     mint_and_deposit(&env, &client, &usdc_token, &user, 10_000_000_i128);
 
     // Rebalance to blend - 100% of vault balance (10M) goes to pool
-    client.rebalance(&symbol_short!("blend"), &500_i128);
+    client.rebalance(&symbol_short!("blend"), &500_i128, &0_i128);
 
     // Verify pool has 10M (entire vault balance was supplied)
     assert_eq!(

--- a/neurowealth-vault/contracts/vault/src/tests/test_legacy_inline.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_legacy_inline.rs
@@ -319,5 +319,5 @@ fn test_rebalance_basic() {
     let protocol = soroban_sdk::symbol_short!("none");
     let expected_apy = 850_i128;
 
-    client.rebalance(&protocol, &expected_apy);
+    client.rebalance(&protocol, &expected_apy, &0_i128);
 }

--- a/neurowealth-vault/contracts/vault/src/tests/test_pause.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_pause.rs
@@ -135,7 +135,7 @@ fn test_rebalance_blocked_while_paused() {
     assert!(client.is_paused());
 
     // require_not_paused fires before any blend check
-    client.rebalance(&soroban_sdk::symbol_short!("blend"), &500_i128);
+    client.rebalance(&soroban_sdk::symbol_short!("blend"), &500_i128, &0_i128);
 }
 
 #[test]

--- a/neurowealth-vault/contracts/vault/src/tests/test_rebalance.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_rebalance.rs
@@ -20,7 +20,7 @@ fn test_agent_can_rebalance_with_custom_protocol() {
     let expected_apy = 500_i128; // 5% APY in basis points
 
     // Should succeed with mock_all_auths (require_is_agent passes)
-    client.rebalance(&protocol, &expected_apy);
+    client.rebalance(&protocol, &expected_apy, &0_i128);
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn test_rebalance_emits_event() {
     let deposit_amount = 10_000_000_i128;
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
 
-    client.rebalance(&symbol_short!("blend"), &500_i128);
+    client.rebalance(&symbol_short!("blend"), &500_i128, &0_i128);
 
     let rebalance_events =
         find_events_by_topic(env.events().all(), &env, symbol_short!("rebalance"));
@@ -79,7 +79,7 @@ fn test_rebalance_storage_current_protocol_changes() {
     mint_and_deposit(&env, &client, &usdc_token, &user, 10_000_000_i128);
 
     // Rebalance to blend
-    client.rebalance(&symbol_short!("blend"), &500_i128);
+    client.rebalance(&symbol_short!("blend"), &500_i128, &0_i128);
 
     // Assert storage state changed
     assert_eq!(
@@ -104,7 +104,7 @@ fn test_rebalance_storage_current_protocol_changes_to_none() {
     mint_and_deposit(&env, &client, &usdc_token, &user, 10_000_000_i128);
 
     // First rebalance to blend
-    client.rebalance(&symbol_short!("blend"), &500_i128);
+    client.rebalance(&symbol_short!("blend"), &500_i128, &0_i128);
     assert_eq!(
         client.get_current_protocol(),
         symbol_short!("blend"),
@@ -112,7 +112,7 @@ fn test_rebalance_storage_current_protocol_changes_to_none() {
     );
 
     // Then rebalance to none
-    client.rebalance(&symbol_short!("none"), &0_i128);
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
 
     // Assert storage state changed to none
     assert_eq!(
@@ -157,7 +157,7 @@ fn test_rebalance_with_none_protocol_succeeds() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     // "none" protocol just sets current protocol to "none" — always safe to call
-    client.rebalance(&symbol_short!("none"), &0_i128);
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
 }
 
 #[test]
@@ -175,7 +175,7 @@ fn test_rebalance_with_blend_after_deposit() {
     let deposit_amount = 10_000_000_i128;
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
 
-    client.rebalance(&symbol_short!("blend"), &500_i128);
+    client.rebalance(&symbol_short!("blend"), &500_i128, &0_i128);
 
     let token_client = TestTokenClient::new(&env, &usdc_token);
     let blend_client = MockBlendPoolClient::new(&env, &blend_pool);
@@ -195,9 +195,9 @@ fn test_rebalance_apy_parameter_accepted() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     // Various APY values should be accepted without panicking
-    client.rebalance(&symbol_short!("none"), &0_i128);
-    client.rebalance(&symbol_short!("none"), &850_i128);
-    client.rebalance(&symbol_short!("none"), &2000_i128);
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
+    client.rebalance(&symbol_short!("none"), &850_i128, &0_i128);
+    client.rebalance(&symbol_short!("none"), &2000_i128, &0_i128);
 }
 
 #[test]
@@ -213,7 +213,7 @@ fn test_rebalance_while_paused_panics() {
     client.pause(&owner);
     assert!(client.is_paused());
 
-    client.rebalance(&symbol_short!("none"), &500_i128);
+    client.rebalance(&symbol_short!("none"), &500_i128, &0_i128);
 }
 
 #[test]
@@ -231,7 +231,7 @@ fn test_blend_rebalance_without_pool_panics() {
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
 
     // blend pool not set → should panic
-    client.rebalance(&symbol_short!("blend"), &500_i128);
+    client.rebalance(&symbol_short!("blend"), &500_i128, &0_i128);
 }
 
 #[test]
@@ -268,7 +268,7 @@ fn test_rebalance_with_unsupported_protocol_panics() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     // "balanced" is not a supported protocol — should panic
-    client.rebalance(&symbol_short!("balanced"), &500_i128);
+    client.rebalance(&symbol_short!("balanced"), &500_i128, &0_i128);
 }
 
 #[test]
@@ -280,7 +280,7 @@ fn test_rebalance_unsupported_protocol_emits_no_events() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     // try_rebalance captures the panic but doesn't crash the test
-    let _result = client.try_rebalance(&symbol_short!("invalid"), &0_i128);
+    let _result = client.try_rebalance(&symbol_short!("invalid"), &0_i128, &0_i128);
 
     // Verify no rebalance events were published
     let rebalance_events = find_events_by_topic(env.events().all(), &env, symbol_short!("rebalance"));
@@ -316,7 +316,7 @@ fn test_blend_supply_and_withdraw_with_events() {
     assert_eq!(blend_client.supplied(&usdc_token), 0);
 
     // Rebalance to Blend (supply)
-    client.rebalance(&symbol_short!("blend"), &850_i128);
+    client.rebalance(&symbol_short!("blend"), &850_i128, &0_i128);
 
     // Verify funds moved to Blend
     assert_eq!(
@@ -362,7 +362,7 @@ fn test_blend_supply_and_withdraw_with_events() {
     );
 
     // Rebalance back to none (withdraw all from Blend)
-    client.rebalance(&symbol_short!("none"), &0_i128);
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
 
     // Verify all funds withdrawn from Blend
     assert_eq!(client.get_current_protocol(), symbol_short!("none"));
@@ -403,7 +403,7 @@ fn test_rebalance_blend_to_none_withdraws_all_and_updates_state_and_events() {
     let deposit_amount = 30_000_000_i128;
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
 
-    client.rebalance(&symbol_short!("blend"), &900_i128);
+    client.rebalance(&symbol_short!("blend"), &900_i128, &0_i128);
 
     assert_eq!(
         client.get_current_protocol(),
@@ -422,7 +422,7 @@ fn test_rebalance_blend_to_none_withdraws_all_and_updates_state_and_events() {
     );
 
     let none_apy = 0_i128;
-    client.rebalance(&symbol_short!("none"), &none_apy);
+    client.rebalance(&symbol_short!("none"), &none_apy, &0_i128);
 
     assert_eq!(
         client.get_current_protocol(),
@@ -505,7 +505,7 @@ fn test_rebalance_fails_on_incomplete_protocol_exit() {
     let user = Address::generate(&env);
     let deposit_amount = 10_000_000_i128;
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
-    client.rebalance(&symbol_short!("blend"), &500_i128);
+    client.rebalance(&symbol_short!("blend"), &500_i128, &0_i128);
 
     // Verify funds are in blend
     assert_eq!(
@@ -528,7 +528,7 @@ fn test_rebalance_fails_on_incomplete_protocol_exit() {
     // - But pool can only return 1M per transaction
     // - 9M remains stuck in the protocol
     // - This is an incomplete exit and should fail
-    client.rebalance(&symbol_short!("none"), &0_i128);
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
 
     // If we reach here, the test failed (rebalance should have panicked)
     panic!("Expected rebalance to panic on incomplete protocol exit, but it succeeded");
@@ -553,7 +553,7 @@ fn test_rebalance_fails_when_switching_protocols_with_partial_exit() {
     let user = Address::generate(&env);
     let deposit_amount = 10_000_000_i128;
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
-    client.rebalance(&symbol_short!("blend"), &500_i128);
+    client.rebalance(&symbol_short!("blend"), &500_i128, &0_i128);
 
     // Verify funds are in blend
     assert_eq!(
@@ -573,8 +573,29 @@ fn test_rebalance_fails_when_switching_protocols_with_partial_exit() {
 
     // Attempt to switch protocols (blend -> none) with limited withdrawal capacity
     // This should fail because we can't withdraw all funds from blend
-    client.rebalance(&symbol_short!("none"), &0_i128);
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
 
     // If we reach here, the test failed
     panic!("Expected rebalance to panic on incomplete protocol exit when switching protocols");
+}
+
+/// When `min_out > 0`, a pool that supplies less than requested must panic (#150).
+#[test]
+#[should_panic(expected = "vault: blend supply received")]
+fn test_rebalance_min_out_panics_when_pool_returns_less_than_requested() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, usdc_token, blend_pool) =
+        setup_vault_with_token_and_blend(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let blend_client = MockBlendPoolClient::new(&env, &blend_pool);
+
+    client.set_blend_pool(&owner, &blend_pool);
+    blend_client.set_max_supply_limit(&5_000_000_i128);
+
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, 10_000_000_i128);
+
+    client.rebalance(&symbol_short!("blend"), &500_i128, &10_000_000_i128);
 }

--- a/neurowealth-vault/contracts/vault/src/tests/test_rebalance_integration.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_rebalance_integration.rs
@@ -96,7 +96,7 @@ fn test_integration_rebalance_to_blend_with_pool_configured() {
 
     // Rebalance to Blend
     let apy = 700_i128; // 7%
-    client.rebalance(&symbol_short!("blend"), &apy);
+    client.rebalance(&symbol_short!("blend"), &apy, &0_i128);
 
     // ---- CurrentProtocol ----
     assert_eq!(
@@ -162,12 +162,19 @@ fn test_integration_rebalance_to_blend_already_in_blend_is_idempotent() {
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
 
     // First rebalance to Blend
-    client.rebalance(&symbol_short!("blend"), &500_i128);
+    client.rebalance(&symbol_short!("blend"), &500_i128, &0_i128);
     assert_eq!(client.get_current_protocol(), symbol_short!("blend"));
     assert_eq!(blend_client.supplied(&usdc_token), deposit_amount);
 
     // Second rebalance to Blend — no vault idle balance, nothing more to supply
-    client.rebalance(&symbol_short!("blend"), &500_i128);
+    client.rebalance(&symbol_short!("blend"), &500_i128, &0_i128);
+
+    let rebalance_events = collect_rebalance_events(&env);
+    assert_eq!(
+        rebalance_events.last().unwrap().status,
+        symbol_short!("noop"),
+        "Redundant blend rebalance with zero idle should be noop"
+    );
 
     // State should remain consistent
     assert_eq!(client.get_current_protocol(), symbol_short!("blend"));
@@ -206,7 +213,7 @@ fn test_integration_rebalance_to_blend_without_pool_panics_with_balance() {
     mint_and_deposit(&env, &client, &usdc_token, &user, 5_000_000_i128);
 
     // No blend pool set → must panic
-    client.rebalance(&symbol_short!("blend"), &500_i128);
+    client.rebalance(&symbol_short!("blend"), &500_i128, &0_i128);
 }
 
 /// Rebalancing to Blend without a pool configured must panic even when the
@@ -221,7 +228,7 @@ fn test_integration_rebalance_to_blend_without_pool_panics_zero_balance() {
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
     // No deposit, no pool — still panics because pool check comes first
-    client.rebalance(&symbol_short!("blend"), &500_i128);
+    client.rebalance(&symbol_short!("blend"), &500_i128, &0_i128);
 }
 
 // ============================================================================
@@ -250,11 +257,11 @@ fn test_integration_rebalance_from_blend_to_none_withdraws_all() {
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
 
     // Move funds into Blend
-    client.rebalance(&symbol_short!("blend"), &800_i128);
+    client.rebalance(&symbol_short!("blend"), &800_i128, &0_i128);
     assert_eq!(blend_client.supplied(&usdc_token), deposit_amount);
 
     // Switch back to none
-    client.rebalance(&symbol_short!("none"), &0_i128);
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
 
     // ---- CurrentProtocol ----
     assert_eq!(
@@ -307,7 +314,7 @@ fn test_integration_rebalance_none_to_none_is_noop() {
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
 
     // Rebalance none → none
-    client.rebalance(&symbol_short!("none"), &0_i128);
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
 
     assert_eq!(client.get_current_protocol(), symbol_short!("none"));
     assert_eq!(
@@ -317,11 +324,12 @@ fn test_integration_rebalance_none_to_none_is_noop() {
     );
     assert_eq!(client.get_total_assets(), deposit_amount);
 
-    // A RebalanceEvent should still be emitted
     let rebalance_events = collect_rebalance_events(&env);
-    assert!(
-        !rebalance_events.is_empty(),
-        "RebalanceEvent must always be emitted"
+    assert_eq!(rebalance_events.len(), 1, "Expected one RebalanceEvent");
+    assert_eq!(
+        rebalance_events[0].status,
+        symbol_short!("noop"),
+        "none→none with no fund movement should be a noop rebalance"
     );
 }
 
@@ -343,13 +351,13 @@ fn test_integration_full_protocol_round_trip() {
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
 
     // Step 1: none → blend
-    client.rebalance(&symbol_short!("blend"), &600_i128);
+    client.rebalance(&symbol_short!("blend"), &600_i128, &0_i128);
     assert_eq!(client.get_current_protocol(), symbol_short!("blend"));
     assert_eq!(blend_client.supplied(&usdc_token), deposit_amount);
     assert_eq!(vault_usdc_balance(&env, &usdc_token, &contract_id), 0);
 
     // Step 2: blend → none
-    client.rebalance(&symbol_short!("none"), &0_i128);
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
     assert_eq!(client.get_current_protocol(), symbol_short!("none"));
     assert_eq!(blend_client.supplied(&usdc_token), 0);
     assert_eq!(
@@ -358,7 +366,7 @@ fn test_integration_full_protocol_round_trip() {
     );
 
     // Step 3: none → blend again
-    client.rebalance(&symbol_short!("blend"), &550_i128);
+    client.rebalance(&symbol_short!("blend"), &550_i128, &0_i128);
     assert_eq!(client.get_current_protocol(), symbol_short!("blend"));
     assert_eq!(blend_client.supplied(&usdc_token), deposit_amount);
     assert_eq!(vault_usdc_balance(&env, &usdc_token, &contract_id), 0);
@@ -389,7 +397,7 @@ fn test_integration_rebalance_blend_zero_vault_balance_no_panic() {
     client.set_blend_pool(&owner, &blend_pool);
 
     // No deposit — vault has zero balance; this must NOT panic
-    client.rebalance(&symbol_short!("blend"), &400_i128);
+    client.rebalance(&symbol_short!("blend"), &400_i128, &0_i128);
 
     // With zero vault balance the supply branch is skipped entirely, so
     // CurrentProtocol remains "none" — still deterministic and safe.
@@ -399,11 +407,12 @@ fn test_integration_rebalance_blend_zero_vault_balance_no_panic() {
         "CurrentProtocol stays 'none' when vault_balance == 0 and no supply occurs"
     );
 
-    // A RebalanceEvent should still be emitted (it is always emitted at end)
     let rebalance_events = collect_rebalance_events(&env);
-    assert!(
-        !rebalance_events.is_empty(),
-        "RebalanceEvent must be emitted regardless of supplied amount"
+    assert_eq!(rebalance_events.len(), 1, "Expected one RebalanceEvent");
+    assert_eq!(
+        rebalance_events[0].status,
+        symbol_short!("noop"),
+        "blend rebalance with zero idle balance should be a noop"
     );
 }
 
@@ -418,7 +427,7 @@ fn test_integration_rebalance_unknown_protocol_is_explicit_failure() {
     let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
 
-    client.rebalance(&symbol_short!("aave"), &1200_i128);
+    client.rebalance(&symbol_short!("aave"), &1200_i128, &0_i128);
 }
 
 /// Paused-vault rebalance must fail with an explicit "vault: paused" panic
@@ -437,7 +446,7 @@ fn test_integration_rebalance_while_paused_explicit_failure() {
     client.pause(&owner);
     assert!(client.is_paused());
 
-    client.rebalance(&symbol_short!("blend"), &500_i128);
+    client.rebalance(&symbol_short!("blend"), &500_i128, &0_i128);
 }
 
 // ============================================================================
@@ -470,7 +479,7 @@ fn test_integration_asset_accounting_invariant_across_full_cycle() {
     assert_eq!(client.get_total_assets(), total);
 
     // Rebalance to Blend
-    client.rebalance(&symbol_short!("blend"), &700_i128);
+    client.rebalance(&symbol_short!("blend"), &700_i128, &0_i128);
     assert_eq!(client.get_current_protocol(), symbol_short!("blend"));
     assert_eq!(blend_client.supplied(&usdc_token), total);
     assert_eq!(vault_usdc_balance(&env, &usdc_token, &contract_id), 0);
@@ -485,7 +494,7 @@ fn test_integration_asset_accounting_invariant_across_full_cycle() {
     assert_eq!(client.get_total_assets(), amount_b);
 
     // Rebalance back to none
-    client.rebalance(&symbol_short!("none"), &0_i128);
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
     assert_eq!(client.get_current_protocol(), symbol_short!("none"));
     assert_eq!(blend_client.supplied(&usdc_token), 0);
     assert_eq!(
@@ -517,11 +526,11 @@ fn test_integration_rebalance_event_schema_correctness() {
     mint_and_deposit(&env, &client, &usdc_token, &user, 10_000_000_i128);
 
     // Rebalance 1: none (initial state → none)
-    client.rebalance(&symbol_short!("none"), &0_i128);
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
     // Rebalance 2: none → blend
-    client.rebalance(&symbol_short!("blend"), &850_i128);
+    client.rebalance(&symbol_short!("blend"), &850_i128, &0_i128);
     // Rebalance 3: blend → none
-    client.rebalance(&symbol_short!("none"), &0_i128);
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
 
     let events = collect_rebalance_events(&env);
     assert_eq!(events.len(), 3, "Expected exactly 3 RebalanceEvents");
@@ -553,7 +562,7 @@ fn test_integration_blend_supply_event_fields_are_correct() {
     let user = Address::generate(&env);
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
 
-    client.rebalance(&symbol_short!("blend"), &900_i128);
+    client.rebalance(&symbol_short!("blend"), &900_i128, &0_i128);
 
     let supply_events = collect_blend_supply_events(&env);
     assert_eq!(
@@ -589,8 +598,8 @@ fn test_integration_blend_withdraw_event_fields_on_protocol_switch() {
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
 
     // Move to Blend then away
-    client.rebalance(&symbol_short!("blend"), &600_i128);
-    client.rebalance(&symbol_short!("none"), &0_i128);
+    client.rebalance(&symbol_short!("blend"), &600_i128, &0_i128);
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
 
     let wd_events = collect_blend_withdraw_events(&env);
     assert!(!wd_events.is_empty(), "BlendWithdrawEvent must be emitted");

--- a/scripts/e2e-devnet.sh
+++ b/scripts/e2e-devnet.sh
@@ -422,7 +422,8 @@ REBALANCE_OUTPUT=$(run_soroban "Rebalance to 'none' protocol" \
   -- \
   rebalance \
   --protocol "none" \
-  --expected_apy "0" 2>&1) || {
+  --expected_apy "0" \
+  --min_out "0" 2>&1) || {
   record_fail "rebalance_none" "Rebalance failed: $REBALANCE_OUTPUT"
   REBALANCE_OUTPUT="FAILED: $REBALANCE_OUTPUT"
 }


### PR DESCRIPTION
Closes #149
Closes #150
Closes #151
Closes #152

## Summary

- **#149** — Emit `ProtocolChangedEvent` (`proto_chg`) whenever `CurrentProtocol` updates (supply, withdraw, rebalance to `none`).
- **#150** — Add `min_out` to `rebalance()`; panics when a supply/withdraw leg receives less than the floor (`0` disables the guard). Includes mock pool shortfall test.
- **#151** — Rebalance with no fund movement sets `RebalanceEvent.status` to `"noop"`; documented in `EVENTS.md` for agents/indexers.
- **#152** — Align `BlendPoolClient` and docs with production Blend v2 (`submit_with_allowance`, `submit`, `balance`); optional `blend-devnet` feature tests.

## Migration

`rebalance` now requires a third argument:

```bash
soroban contract invoke ... -- rebalance \
  --protocol blend --expected_apy 850 --min_out 0
```

Pass `min_out > 0` to bound slippage on each supply/withdraw leg.

## Test plan

- [x] `cargo test -p neurowealth-vault`
- [x] `cargo test -p neurowealth-vault --features blend-devnet`
- [x] Event schema tests for `ProtocolChangedEvent` and noop rebalance status
