### PR TITLE
Restore recovered vault fixes and tests

### DIFF
--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -2171,23 +2171,40 @@ impl NeuroWealthVault {
 
     /// Updates the total assets tracked by the vault.
     ///
-    /// This function allows the authorized AI agent to update the total
-    /// assets value to reflect realized yield from external strategies.
-    /// Total assets are expected to be monotonically non-decreasing except
-    /// for user deposits/withdrawals.
+    /// The agent calls this to reflect realized yield (increase) or a confirmed
+    /// strategy loss / bad-debt write-down (decrease).
+    ///
+    /// ## Decrease policy
+    ///
+    /// Decreases are permitted only when **all** of the following hold:
+    ///
+    /// 1. `allow_decrease` is `true` — the caller explicitly opts in.
+    /// 2. The **owner** has co-signed this transaction (`owner.require_auth()`).
+    ///    A rogue agent cannot unilaterally slash user value; the loss must be
+    ///    countersigned by the vault operator.
+    /// 3. The decrease does not exceed `max_decrease_bps` basis points of the
+    ///    current total (minimum floor: 100 bps = 1%). This caps the worst-case
+    ///    loss any single call can commit, limiting damage from a compromised key.
+    ///
+    /// Typical values: `allow_decrease = true`, `max_decrease_bps = 1000` (10 %).
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `agent` - The authorized AI agent address (must authorize)
     /// * `new_total` - New total assets value in USDC units (7 decimal places)
+    /// * `allow_decrease` - Must be `true` when `new_total < current total`
+    /// * `max_decrease_bps` - Per-call decrease cap in basis points (100–10 000);
+    ///   values below 100 are clamped to 100
     ///
     /// # Returns
     /// Nothing. This function updates total assets and returns nothing.
     ///
     /// # Panics
     /// - If the caller is not the authorized agent
-    /// - If new_total is less than old_total
-    /// - If vault USDC balance is insufficient to cover new_total
+    /// - If `new_total < old_total` and `allow_decrease` is `false`
+    /// - If `new_total < old_total` and the owner has not co-signed
+    /// - If the decrease exceeds `max_decrease_bps` of the current total
+    /// - If vault USDC balance is insufficient to cover `new_total`
     ///
     /// # Events
     /// Emits `AssetsUpdatedEvent` with:
@@ -2195,11 +2212,10 @@ impl NeuroWealthVault {
     /// - `new_total`: New total assets
     ///
     /// # Security
-    /// - Only the agent can update total assets
-    /// - Verifies vault actually holds sufficient USDC to back the reported assets
-    /// - Prevents agent from inflating asset values beyond actual holdings
-    /// - Allows controlled decreases for legitimate loss reporting (strategy loss/bad debt)
-    /// - Decrease is bounded: cannot exceed max_decrease_bps (default 10% per call)
+    /// - Only the agent can call this function
+    /// - Decreases additionally require the owner's authorization (2-of-2)
+    /// - Per-call decrease is capped at `max_decrease_bps` to limit key-compromise blast radius
+    /// - Verifies vault holds sufficient USDC to back the reported assets (inflation guard)
     pub fn update_total_assets(
         env: Env,
         agent: Address,
@@ -2208,7 +2224,6 @@ impl NeuroWealthVault {
         max_decrease_bps: u32,
     ) {
         Self::require_initialized(&env);
-        // Agent-controlled yield update
         let stored_agent: Address = env.storage().instance().get(&DataKey::Agent).unwrap();
         assert_eq!(
             agent, stored_agent,
@@ -2218,17 +2233,17 @@ impl NeuroWealthVault {
 
         let old_total = Self::get_total_assets_internal(&env);
 
-        // Handle decrease case - only allowed with explicit authorization
         if new_total < old_total {
-            // Require explicit authorization to allow decreases
             assert!(allow_decrease, "vault: total assets decrease not allowed");
 
-            // Bound the decrease to prevent abuse
-            // max_decrease_bps is in basis points (1/100 of 1%)
-            // Default 1000 bps = 10% maximum decrease per call
-            let max_decrease_bps = max_decrease_bps.max(100); // Minimum 1% bound
+            // Owner must co-sign any loss report. A single compromised key
+            // cannot unilaterally reduce user asset values.
+            Self::require_is_owner(&env);
+
+            // Cap the per-call decrease (minimum floor: 100 bps = 1 %).
+            let effective_cap_bps = max_decrease_bps.max(100);
             let max_decrease = old_total
-                .checked_mul(max_decrease_bps as i128)
+                .checked_mul(effective_cap_bps as i128)
                 .expect("vault: max decrease mul overflow")
                 / 10_000;
             let actual_decrease = old_total
@@ -2237,8 +2252,7 @@ impl NeuroWealthVault {
 
             assert!(
                 actual_decrease <= max_decrease,
-                "vault: decrease exceeds maximum allowed ({} bps)",
-                max_decrease_bps
+                "vault: decrease exceeds maximum allowed bps"
             );
         }
 
@@ -2874,8 +2888,13 @@ impl NeuroWealthVault {
 
     /// Validates that a deposit is within the user's cap.
     ///
+    /// The cap is enforced against the user's current **asset value** (shares ×
+    /// share price, which includes accrued yield), not just deposited principal.
+    /// This makes the per-user cap a true exposure limit: once yield pushes a
+    /// user's position to or above the cap, further deposits are rejected.
+    ///
     /// # Panics
-    /// - If user's new balance would exceed the deposit cap
+    /// - If user's new asset value (current assets + deposit amount) would exceed the cap
     #[inline]
     fn require_within_deposit_cap(env: &Env, user: &Address, amount: i128) {
         let cap: i128 = env
@@ -2884,13 +2903,14 @@ impl NeuroWealthVault {
             .get(&DataKey::UserDepositCap)
             .unwrap_or(0_i128);
         if cap > 0 {
-            let current_balance: i128 = env
+            let user_shares: i128 = env
                 .storage()
                 .persistent()
-                .get(&DataKey::Balance(user.clone()))
+                .get(&DataKey::Shares(user.clone()))
                 .unwrap_or(0_i128);
+            let current_assets = Self::convert_to_assets_internal(env, user_shares);
             assert!(
-                current_balance
+                current_assets
                     .checked_add(amount)
                     .expect("vault: cap check overflow")
                     <= cap,

--- a/neurowealth-vault/contracts/vault/src/tests/mod.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod test_access_control;
+mod test_update_total_assets_blend;
 mod test_auth;
 #[cfg(feature = "blend-devnet")]
 mod test_blend_devnet;

--- a/neurowealth-vault/contracts/vault/src/tests/test_auth.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_auth.rs
@@ -332,3 +332,41 @@ fn test_withdraw_requires_user_auth() {
         "withdraw must fail without the user's authorization"
     );
 }
+
+// ============================================================================
+// LOSS REPORTING — OWNER CO-SIGN REQUIREMENT
+// ============================================================================
+
+/// Negative: with only the agent's auth present, a decrease must fail because
+/// `require_is_owner` cannot be satisfied. Guards against a removed auth check.
+#[test]
+fn test_decrease_requires_owner_cosign() {
+    let env = Env::default();
+    let (contract_id, agent, _owner, usdc_token) = setup(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 10_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
+
+    let new_total = deposit_amount - 500_000_i128; // 5% loss, within 10% cap
+
+    // Only the agent's auth is available — the owner has NOT signed.
+    env.mock_auths(&[MockAuth {
+        address: &agent,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "update_total_assets",
+            args: (agent.clone(), new_total, true, 1000u32).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_update_total_assets(&agent, &new_total, &true, &1000u32);
+    assert!(
+        result.is_err(),
+        "decrease must fail when owner has not co-signed"
+    );
+    // Total assets must be unchanged.
+    assert_eq!(client.get_total_assets(), deposit_amount);
+}

--- a/neurowealth-vault/contracts/vault/src/tests/test_limits.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_limits.rs
@@ -348,3 +348,105 @@ fn test_set_limits_accepts_zero_values() {
     assert_eq!(client.get_user_deposit_cap(), 0);
     assert_eq!(client.get_tvl_cap(), 0);
 }
+
+// ============================================================================
+// DEPOSIT CAP — ASSETS-BASED SEMANTICS (includes accrued yield)
+// ============================================================================
+
+/// After yield pushes the user's asset value to the cap, any further deposit
+/// must be rejected even though the user's principal is still below the cap.
+#[test]
+#[should_panic(expected = "vault: exceeds user deposit cap")]
+fn test_deposit_cap_blocks_deposit_when_yield_fills_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    // Cap = 10 USDC; user deposits 8 USDC (2 USDC headroom by principal).
+    let cap = 10_000_000_i128;
+    let deposit = 8_000_000_i128;
+    client.set_user_deposit_cap(&cap);
+
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit);
+
+    // Accrue 2 USDC yield — user's asset value is now exactly 10 USDC (= cap).
+    let yield_amount = 2_000_000_i128;
+    token_client.mint(&contract_id, &yield_amount);
+    client.update_total_assets(&agent, &(deposit + yield_amount), &false, &0);
+
+    assert_eq!(client.get_balance(&user), cap);
+
+    // Any further deposit must be rejected (assets + amount > cap).
+    let extra = 1_000_000_i128;
+    token_client.mint(&user, &extra);
+    client.deposit(&user, &extra);
+}
+
+/// Yield accrual alone (without a deposit) does not block a user whose asset
+/// value still has room under the cap.
+#[test]
+fn test_deposit_cap_allows_deposit_when_assets_still_under_cap_after_yield() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    // Cap = 12 USDC; user deposits 8 USDC.
+    let cap = 12_000_000_i128;
+    let deposit = 8_000_000_i128;
+    client.set_user_deposit_cap(&cap);
+
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit);
+
+    // Accrue 2 USDC yield — user's asset value is now 10 USDC (2 USDC headroom).
+    let yield_amount = 2_000_000_i128;
+    token_client.mint(&contract_id, &yield_amount);
+    client.update_total_assets(&agent, &(deposit + yield_amount), &false, &0);
+
+    assert_eq!(client.get_balance(&user), deposit + yield_amount);
+
+    // A 2 USDC deposit fits exactly: assets(10) + amount(2) = cap(12).
+    let top_up = 2_000_000_i128;
+    token_client.mint(&user, &top_up);
+    client.deposit(&user, &top_up);
+
+    assert!(client.get_balance(&user) >= cap - 1_000_i128);
+}
+
+/// Yield that only partially closes the gap still blocks a deposit that would
+/// push total asset value over the cap.
+#[test]
+#[should_panic(expected = "vault: exceeds user deposit cap")]
+fn test_deposit_cap_blocks_when_yield_partially_fills_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    // Cap = 10 USDC; user deposits 8 USDC.
+    let cap = 10_000_000_i128;
+    let deposit = 8_000_000_i128;
+    client.set_user_deposit_cap(&cap);
+
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit);
+
+    // Accrue 1 USDC yield — user's asset value is now 9 USDC (1 USDC headroom).
+    let yield_amount = 1_000_000_i128;
+    token_client.mint(&contract_id, &yield_amount);
+    client.update_total_assets(&agent, &(deposit + yield_amount), &false, &0);
+
+    // Attempting to deposit 2 USDC would put assets at 11 > cap(10) — must fail.
+    let over_limit = 2_000_000_i128;
+    token_client.mint(&user, &over_limit);
+    client.deposit(&user, &over_limit);
+}

--- a/neurowealth-vault/contracts/vault/src/tests/test_update_total_assets_blend.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_update_total_assets_blend.rs
@@ -1,0 +1,310 @@
+//! Tests for update_total_assets() backing check with funds deployed to Blend (Issue #128).
+//!
+//! Prior to this fix the security check only considered the vault's idle token
+//! balance, so calling update_total_assets() when all (or part of) the USDC
+//! was deployed to Blend would always panic with "insufficient balance for
+//! reported assets" even when the reported value was perfectly legitimate.
+//!
+//! These tests verify:
+//!   1. Backing check passes when ALL funds are in Blend (idle balance = 0).
+//!   2. Backing check passes when funds are PARTIALLY in Blend.
+//!   3. Yield accrued inside Blend is counted towards available backing.
+//!   4. The security check still rejects inflation beyond idle + deployed.
+//!   5. No regression: idle-only (no Blend) path continues to work.
+
+extern crate std;
+
+use super::utils::*;
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/// Deposit `amount`, configure the Blend pool, and rebalance everything into
+/// Blend in one step.  Returns the vault client and token client.
+fn setup_all_in_blend(
+    env: &Env,
+    amount: i128,
+) -> (
+    Address, // contract_id
+    Address, // agent
+    Address, // usdc_token
+    Address, // blend_pool
+    NeuroWealthVaultClient<'_>,
+    TestTokenClient<'_>,
+) {
+    let (contract_id, agent, owner, usdc_token, blend_pool) =
+        setup_vault_with_token_and_blend(env);
+    let client = NeuroWealthVaultClient::new(env, &contract_id);
+    let token_client = TestTokenClient::new(env, &usdc_token);
+
+    client.set_blend_pool(&owner, &blend_pool);
+
+    let user = Address::generate(env);
+    mint_and_deposit(env, &client, &usdc_token, &user, amount);
+
+    // Rebalance: vault idle → Blend
+    client.rebalance(&symbol_short!("blend"), &700_i128, &0_i128);
+
+    // Sanity: all USDC is now in the pool
+    assert_eq!(token_client.balance(&contract_id), 0);
+    assert_eq!(token_client.balance(&blend_pool), amount);
+
+    (contract_id, agent, usdc_token, blend_pool, client, token_client)
+}
+
+// ============================================================================
+// 1. ALL FUNDS IN BLEND — SAME TOTAL (no-op report)
+// ============================================================================
+
+/// When all USDC is in Blend (vault idle balance = 0) the backing check must
+/// include the deployed position.  Reporting the same total should succeed.
+#[test]
+fn test_update_total_assets_all_in_blend_same_total_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deposit = 10_000_000_i128;
+    let (_, agent, _, _, client, _) = setup_all_in_blend(&env, deposit);
+
+    // Idle = 0, deployed = 10 USDC → total_available = 10 USDC
+    // Reporting the same total should pass.
+    client.update_total_assets(&agent, &deposit, &false, &0);
+    assert_eq!(client.get_total_assets(), deposit);
+}
+
+// ============================================================================
+// 2. ALL FUNDS IN BLEND — YIELD ACCRUAL
+// ============================================================================
+
+/// Blend earns yield → pool balance grows.  Agent should be able to report
+/// the new (higher) total including the yield without being rejected.
+#[test]
+fn test_update_total_assets_blend_yield_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deposit = 20_000_000_i128;
+    let yield_amount = 2_000_000_i128; // 10% yield
+
+    let (_, agent, usdc_token, blend_pool, client, token_client) =
+        setup_all_in_blend(&env, deposit);
+
+    // Simulate Blend accruing yield by minting directly to the pool.
+    token_client.mint(&blend_pool, &yield_amount);
+    assert_eq!(token_client.balance(&blend_pool), deposit + yield_amount);
+
+    // Idle = 0, deployed (pool reports) = deposit + yield_amount
+    // total_available = deposit + yield_amount → new_total should pass.
+    let new_total = deposit + yield_amount;
+    client.update_total_assets(&agent, &new_total, &false, &0);
+
+    assert_eq!(client.get_total_assets(), new_total);
+    // Token is still in pool (agent didn't withdraw)
+    assert_eq!(token_client.balance(&usdc_token), 0_i128.max(0)); // pool still holds it
+    drop(token_client); // suppress unused warning
+}
+
+// ============================================================================
+// 3. PARTIAL DEPLOYMENT — IDLE + BLEND
+// ============================================================================
+
+/// When only part of the vault's USDC is in Blend (the rest is idle), the
+/// backing check must sum both portions.
+#[test]
+fn test_update_total_assets_partial_blend_deployment_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, owner, usdc_token, blend_pool) =
+        setup_vault_with_token_and_blend(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+    let blend_client = MockBlendPoolClient::new(&env, &blend_pool);
+
+    client.set_blend_pool(&owner, &blend_pool);
+
+    // Deposit 30 USDC total
+    let deposit_total = 30_000_000_i128;
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_total);
+
+    // Limit the Blend pool to accepting only 20 USDC → 10 stays idle
+    let blend_limit = 20_000_000_i128;
+    blend_client.set_max_supply_limit(&blend_limit);
+
+    client.rebalance(&symbol_short!("blend"), &700_i128, &0_i128);
+
+    let idle = token_client.balance(&contract_id);
+    let deployed = token_client.balance(&blend_pool);
+
+    // Partial deployment: 20 in Blend, 10 idle
+    assert_eq!(deployed, blend_limit, "blend pool should have 20 USDC");
+    assert_eq!(idle, deposit_total - blend_limit, "vault should have 10 USDC idle");
+
+    // total_available = 10 + 20 = 30 → reporting 30 must succeed
+    client.update_total_assets(&agent, &deposit_total, &false, &0);
+    assert_eq!(client.get_total_assets(), deposit_total);
+}
+
+// ============================================================================
+// 4. PARTIAL DEPLOYMENT WITH YIELD
+// ============================================================================
+
+/// Partial deployment: 20 in Blend earns 1 USDC yield.
+/// Agent reports new total (31 USDC).  Available = 10 idle + 21 in Blend = 31.
+#[test]
+fn test_update_total_assets_partial_blend_plus_yield_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, owner, usdc_token, blend_pool) =
+        setup_vault_with_token_and_blend(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+    let blend_client = MockBlendPoolClient::new(&env, &blend_pool);
+
+    client.set_blend_pool(&owner, &blend_pool);
+
+    let deposit_total = 30_000_000_i128;
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_total);
+
+    blend_client.set_max_supply_limit(&20_000_000_i128);
+    client.rebalance(&symbol_short!("blend"), &700_i128, &0_i128);
+
+    // Yield: 1 USDC minted to pool
+    let yield_amount = 1_000_000_i128;
+    token_client.mint(&blend_pool, &yield_amount);
+
+    // Available = 10 (idle) + 21 (blend) = 31
+    let new_total = deposit_total + yield_amount;
+    client.update_total_assets(&agent, &new_total, &false, &0);
+    assert_eq!(client.get_total_assets(), new_total);
+}
+
+// ============================================================================
+// 5. SECURITY: REJECT INFLATION BEYOND AVAILABLE BACKING
+// ============================================================================
+
+/// The security check must still reject a report where new_total exceeds the
+/// sum of idle balance + deployed Blend position.
+#[test]
+#[should_panic(expected = "vault: insufficient balance for reported assets")]
+fn test_update_total_assets_rejects_inflation_beyond_idle_plus_blend() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deposit = 10_000_000_i128;
+    let (_, agent, _, _, client, _) = setup_all_in_blend(&env, deposit);
+
+    // Try to report 200 USDC when only 10 USDC is available (all in Blend)
+    let inflated_total = 200_000_000_i128;
+    client.update_total_assets(&agent, &inflated_total, &false, &0);
+}
+
+/// Partial deployment: total available = 10 idle + 20 blend = 30.
+/// Attempting to report 31 must be rejected.
+#[test]
+#[should_panic(expected = "vault: insufficient balance for reported assets")]
+fn test_update_total_assets_rejects_inflation_beyond_partial_deployment() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, owner, usdc_token, blend_pool) =
+        setup_vault_with_token_and_blend(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+    let blend_client = MockBlendPoolClient::new(&env, &blend_pool);
+
+    client.set_blend_pool(&owner, &blend_pool);
+
+    let deposit_total = 30_000_000_i128;
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_total);
+
+    blend_client.set_max_supply_limit(&20_000_000_i128);
+    client.rebalance(&symbol_short!("blend"), &700_i128, &0_i128);
+
+    // Available = 10 + 20 = 30; reporting 31 must fail
+    let over_total = deposit_total + 1_i128;
+    client.update_total_assets(&agent, &over_total, &false, &0);
+
+    drop(token_client);
+}
+
+// ============================================================================
+// 6. REGRESSION: IDLE-ONLY (NO BLEND) PATH STILL WORKS
+// ============================================================================
+
+/// No Blend configured.  The original idle-only backing check must continue
+/// to work for vaults that never deploy to a protocol.
+#[test]
+fn test_update_total_assets_idle_only_no_blend_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    let deposit = 10_000_000_i128;
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit);
+
+    // Simulate yield minted directly to vault (no Blend)
+    let yield_amount = 1_000_000_i128;
+    token_client.mint(&contract_id, &yield_amount);
+
+    let new_total = deposit + yield_amount;
+    client.update_total_assets(&agent, &new_total, &false, &0);
+    assert_eq!(client.get_total_assets(), new_total);
+}
+
+/// Idle-only: attempting to report more than the vault holds must be rejected.
+#[test]
+#[should_panic(expected = "vault: insufficient balance for reported assets")]
+fn test_update_total_assets_idle_only_rejects_over_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let deposit = 10_000_000_i128;
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit);
+
+    // No yield minted; vault holds exactly 10 USDC.
+    // Reporting 11 must fail.
+    client.update_total_assets(&agent, &(deposit + 1_i128), &false, &0);
+}
+
+// ============================================================================
+// 7. PROTOCOL RESET: AFTER REBALANCE TO NONE BACKING IS IDLE ONLY
+// ============================================================================
+
+/// After rebalancing back to "none" (all funds returned from Blend),
+/// the backing check reverts to idle-only and must correctly accept/reject.
+#[test]
+fn test_update_total_assets_after_rebalance_to_none_uses_idle() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deposit = 10_000_000_i128;
+    let (contract_id, agent, usdc_token, _blend_pool, client, token_client) =
+        setup_all_in_blend(&env, deposit);
+
+    // Rebalance back to none (all funds return to vault)
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
+
+    assert_eq!(token_client.balance(&contract_id), deposit);
+    assert_eq!(client.get_current_protocol(), symbol_short!("none"));
+
+    // Idle = deposit, deployed = 0 → reporting deposit must pass
+    client.update_total_assets(&agent, &deposit, &false, &0);
+    assert_eq!(client.get_total_assets(), deposit);
+
+    drop(usdc_token);
+}

--- a/neurowealth-vault/contracts/vault/src/tests/test_yield.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_yield.rs
@@ -156,3 +156,88 @@ fn test_yield_emits_event() {
         "Assets update should emit an event"
     );
 }
+
+// ============================================================================
+// LOSS REPORTING — ALLOWED DECREASE
+// ============================================================================
+
+/// Agent + owner both present: a decrease within the cap succeeds and the new
+/// (lower) total is persisted.
+#[test]
+fn test_decrease_allowed_with_owner_cosign_within_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 10_000_000_i128; // 10 USDC
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
+
+    // Loss of 5% — within default 10% cap.
+    let loss_amount = 500_000_i128; // 0.5 USDC
+    let new_total = deposit_amount - loss_amount;
+    client.update_total_assets(&agent, &new_total, &true, &1000);
+
+    assert_eq!(client.get_total_assets(), new_total);
+}
+
+/// Decrease is capped per-call: 10 % of 10 USDC = 1 USDC max. A 20 % loss in
+/// one call must be rejected.
+#[test]
+#[should_panic(expected = "vault: decrease exceeds maximum allowed bps")]
+fn test_decrease_blocked_exceeding_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 10_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
+
+    // 20% loss (2 USDC) with a 10% cap (1000 bps) — must panic.
+    let new_total = deposit_amount - 2_000_000_i128;
+    client.update_total_assets(&agent, &new_total, &true, &1000);
+}
+
+/// Passing allow_decrease=false while new_total < old_total must always panic,
+/// regardless of whether the owner is present.
+#[test]
+#[should_panic(expected = "vault: total assets decrease not allowed")]
+fn test_decrease_blocked_without_allow_decrease_flag() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 10_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
+
+    // allow_decrease=false but new_total is lower — must panic.
+    let new_total = deposit_amount - 500_000_i128;
+    client.update_total_assets(&agent, &new_total, &false, &1000);
+}
+
+/// A same-value update (new_total == old_total) is an increase-or-equal case
+/// and must succeed without owner co-sign.
+#[test]
+fn test_no_change_does_not_require_owner_cosign() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 10_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
+
+    // Same total — no decrease path, no owner co-sign needed.
+    client.update_total_assets(&agent, &deposit_amount, &false, &0);
+    assert_eq!(client.get_total_assets(), deposit_amount);
+}


### PR DESCRIPTION
### Summary
- Restore recovered vault changes for assets-based deposit cap and owner co-sign requirement for loss reporting
- Restore regression test coverage for update_total_assets backing validation
**Linked issues**

Closes #133
Closes #137
Closes #129
Closes #128