### PR TITLE
Fix: Prevent confusing version state on failed WASM upgrade

### DIFF
--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -2343,14 +2343,17 @@ impl NeuroWealthVault {
         let stored_owner: Address = env.storage().instance().get(&DataKey::Owner).unwrap();
         assert!(owner == stored_owner, "vault: caller is not the owner");
 
+        // Soroban will trap/panic here if the hash is not installed on the network.
+        // We perform the upgrade first to ensure a bad hash does not leave us with
+        // an incremented version but failed upgrade.
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+
         let old_version: u32 = env.storage().instance().get(&DataKey::Version).unwrap_or(1);
 
         let new_version = old_version.checked_add(1).expect("vault: version overflow");
         env.storage()
             .instance()
             .set(&DataKey::Version, &new_version);
-
-        env.deployer().update_current_contract_wasm(new_wasm_hash);
 
         env.events().publish(
             (TOPIC_UPGRADED,),

--- a/neurowealth-vault/contracts/vault/src/test.rs
+++ b/neurowealth-vault/contracts/vault/src/test.rs
@@ -669,6 +669,27 @@ fn test_version_increments_correctly() {
 }
 
 #[test]
+fn test_invalid_hash_does_not_increment_version() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner) = setup_vault(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let owner = client.get_owner();
+    let initial_version = client.get_version();
+
+    let fake_wasm_hash = BytesN::from_array(&env, &[0u8; 32]);
+
+    // This should fail because the hash is invalid
+    let result = client.try_upgrade(&owner, &fake_wasm_hash);
+    assert!(result.is_err());
+
+    // The version should remain unchanged
+    assert_eq!(client.get_version(), initial_version);
+}
+
+#[test]
 fn test_upgrade_emits_upgraded_event() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Description
This PR addresses **Issue #194**. Previously, the `upgrade()` function incremented and saved the new contract version to storage before executing `env.deployer().update_current_contract_wasm()`. If the provided `new_wasm_hash` was not installed on the network or was otherwise invalid, the transaction would fail late, leaving the storage state theoretically bumped in certain error-handling or local test environments before the rollback. 

To ensure the contract version only increments upon a genuinely successful upgrade, this PR swaps the execution order. `update_current_contract_wasm` is now called first, acting as a pre-check since Soroban will trap/panic if the hash is not valid. Only after a successful update does the version increment.

## Changes Made
* **`neurowealth-vault/contracts/vault/src/lib.rs`**: Reordered `upgrade()` to perform the WASM update before the version increment and storage write.
* **`neurowealth-vault/contracts/vault/src/test.rs`**: Added a new unit test `test_invalid_hash_does_not_increment_version` which explicitly verifies that a bad/dummy hash does not modify the version counter.

## Acceptance Criteria Met
- [x] Pre-check hash is installed on network (we utilize Soroban's native trap behavior prior to state updates).
- [x] Test invalid hash does not increment version.
- [x] All existing unit tests pass cleanly.

## Related Issues
Fixes #194