### PR TITLE
#186 Add deployed amount to RebalanceEvent payload

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,9 +167,11 @@ struct WithdrawEvent {
 pub struct RebalanceEvent {
     pub protocol: Symbol,           // Target protocol ("blend", "none")
     pub expected_apy: i128,         // Expected APY in basis points (850 = 8.5%)
-    pub status: Symbol,             // Status ("success", "failed", "partial")
+    pub status: Symbol,             // Status ("success", "failed", "partial", "noop")
     pub amount_attempted: i128,     // Amount attempted to be moved
     pub amount_moved: i128,          // Amount actually moved
+    pub amount_supplied: i128,      // Amount supplied into the target protocol
+    pub amount_withdrawn: i128,     // Amount withdrawn from the prior protocol
 }
 ```
 

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -105,11 +105,15 @@ pub struct RebalanceEvent {
     pub status: Symbol,           // "success", "failed", "partial", or "noop"
     pub amount_attempted: i128,   // Amount attempted to be moved
     pub amount_moved: i128,       // Amount actually moved
+    pub amount_supplied: i128,    // Amount supplied into the target protocol
+    pub amount_withdrawn: i128,   // Amount withdrawn from the prior protocol
 }
 ```
 
 **Agent / indexer notes:**
 - `"noop"`: target allocation already satisfied; no supply/withdraw leg ran (e.g. rebalance to Blend with zero idle USDC while already deployed).
+- `amount_supplied` captures the deployment size when moving into Blend.
+- `amount_withdrawn` captures the exit size when leaving Blend.
 - Prefer `ProtocolChangedEvent` for authoritative protocol transitions (see below).
 
 **Usage:**

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -257,6 +257,10 @@ pub struct RebalanceEvent {
     pub amount_attempted: i128,
     /// Amount actually moved
     pub amount_moved: i128,
+    /// Amount supplied into the target protocol
+    pub amount_supplied: i128,
+    /// Amount withdrawn from the current protocol
+    pub amount_withdrawn: i128,
 }
 
 /// Emitted when [`DataKey::CurrentProtocol`] changes.
@@ -1357,6 +1361,8 @@ impl NeuroWealthVault {
 
         let mut amount_attempted = 0_i128;
         let mut amount_moved = 0_i128;
+        let mut amount_supplied = 0_i128;
+        let mut amount_withdrawn = 0_i128;
 
         // If switching protocols, exit the current one first.
         // On incomplete exit, emit RebalanceFailedEvent and abort — no further
@@ -1366,6 +1372,7 @@ impl NeuroWealthVault {
             amount_attempted = amount_attempted.saturating_add(expected_withdrawal);
 
             let withdrawn = Self::withdraw_from_protocol(&env, &current_protocol, min_out);
+            amount_withdrawn = amount_withdrawn.saturating_add(withdrawn);
             amount_moved = amount_moved.saturating_add(withdrawn);
 
             if expected_withdrawal > 0 {
@@ -1399,6 +1406,7 @@ impl NeuroWealthVault {
             if vault_balance > 0 {
                 amount_attempted = amount_attempted.saturating_add(vault_balance);
                 let supplied = Self::supply_to_blend(&env, vault_balance, min_out);
+                amount_supplied = amount_supplied.saturating_add(supplied);
                 amount_moved = amount_moved.saturating_add(supplied);
 
                 if supplied == 0 {
@@ -1421,6 +1429,8 @@ impl NeuroWealthVault {
                     status,
                     amount_attempted,
                     amount_moved,
+                    amount_supplied,
+                    amount_withdrawn,
                 },
             );
         } else if protocol == symbol_short!("none") {
@@ -1431,6 +1441,7 @@ impl NeuroWealthVault {
                 amount_attempted = amount_attempted.saturating_add(expected_withdrawal);
 
                 let withdrawn = Self::withdraw_from_protocol(&env, &current_protocol, min_out);
+                amount_withdrawn = amount_withdrawn.saturating_add(withdrawn);
                 amount_moved = amount_moved.saturating_add(withdrawn);
 
                 if expected_withdrawal > 0 {
@@ -1460,6 +1471,8 @@ impl NeuroWealthVault {
                     status,
                     amount_attempted,
                     amount_moved,
+                    amount_supplied,
+                    amount_withdrawn,
                 },
             );
         }

--- a/neurowealth-vault/contracts/vault/src/tests/test_event_schema.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_event_schema.rs
@@ -210,6 +210,8 @@ fn test_event_schema_rebalance_events() {
     assert_eq!(rebalance_event.status, symbol_short!("noop"));
     assert_eq!(rebalance_event.amount_attempted, 0);
     assert_eq!(rebalance_event.amount_moved, 0);
+    assert_eq!(rebalance_event.amount_supplied, 0);
+    assert_eq!(rebalance_event.amount_withdrawn, 0);
 }
 
 /// ProtocolChangedEvent is emitted when CurrentProtocol updates (#149).

--- a/neurowealth-vault/contracts/vault/src/tests/test_events.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_events.rs
@@ -454,6 +454,8 @@ fn test_rebalance_emits_rebalance_event_with_correct_payload() {
         "Event amount_attempted should be 0"
     );
     assert_eq!(event.amount_moved, 0, "Event amount_moved should be 0");
+    assert_eq!(event.amount_supplied, 0, "Event amount_supplied should be 0");
+    assert_eq!(event.amount_withdrawn, 0, "Event amount_withdrawn should be 0");
 }
 
 #[test]
@@ -499,6 +501,11 @@ fn test_rebalance_with_blend_emits_correct_event() {
         event.amount_moved, 10_000_000_i128,
         "Event amount_moved should match supplied balance"
     );
+    assert_eq!(
+        event.amount_supplied, 10_000_000_i128,
+        "Event amount_supplied should match supplied balance"
+    );
+    assert_eq!(event.amount_withdrawn, 0, "Event amount_withdrawn should be 0");
 }
 
 #[test]
@@ -544,6 +551,11 @@ fn test_rebalance_with_blend_partial_fill_emits_correct_event() {
         event.amount_moved, 3_000_000_i128,
         "Event amount_moved should be 3M"
     );
+    assert_eq!(
+        event.amount_supplied, 3_000_000_i128,
+        "Event amount_supplied should be 3M"
+    );
+    assert_eq!(event.amount_withdrawn, 0, "Event amount_withdrawn should be 0");
 }
 
 #[test]
@@ -586,6 +598,8 @@ fn test_rebalance_with_blend_failed_fill_emits_correct_event() {
         "Event amount_attempted should be 10M"
     );
     assert_eq!(event.amount_moved, 0, "Event amount_moved should be 0");
+    assert_eq!(event.amount_supplied, 0, "Event amount_supplied should be 0");
+    assert_eq!(event.amount_withdrawn, 0, "Event amount_withdrawn should be 0");
 }
 
 #[test]

--- a/neurowealth-vault/contracts/vault/src/tests/test_rebalance.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_rebalance.rs
@@ -480,6 +480,14 @@ fn test_rebalance_blend_to_none_withdraws_all_and_updates_state_and_events() {
         rebalance_event.expected_apy, none_apy,
         "rebalance event APY should match provided value"
     );
+    assert_eq!(
+        rebalance_event.amount_supplied, 0,
+        "rebalance event should not report supplied amount on none transition"
+    );
+    assert_eq!(
+        rebalance_event.amount_withdrawn, deposit_amount,
+        "rebalance event should report the withdrawn amount on none transition"
+    );
 }
 
 /// When a protocol exit is incomplete (funds remain in blend after withdrawal),

--- a/neurowealth-vault/contracts/vault/src/tests/test_rebalance_integration.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_rebalance_integration.rs
@@ -537,12 +537,18 @@ fn test_integration_rebalance_event_schema_correctness() {
 
     assert_eq!(events[0].protocol, symbol_short!("none"));
     assert_eq!(events[0].expected_apy, 0_i128);
+    assert_eq!(events[0].amount_supplied, 0);
+    assert_eq!(events[0].amount_withdrawn, 0);
 
     assert_eq!(events[1].protocol, symbol_short!("blend"));
     assert_eq!(events[1].expected_apy, 850_i128);
+    assert_eq!(events[1].amount_supplied, 10_000_000_i128);
+    assert_eq!(events[1].amount_withdrawn, 0);
 
     assert_eq!(events[2].protocol, symbol_short!("none"));
     assert_eq!(events[2].expected_apy, 0_i128);
+    assert_eq!(events[2].amount_supplied, 0);
+    assert_eq!(events[2].amount_withdrawn, 10_000_000_i128);
 }
 
 /// Validates that a Blend supply emits BlendSupplyEvent with the correct


### PR DESCRIPTION
## Summary

Closes #186 

Updated `RebalanceEvent` to include deployment amount information, allowing indexers to reconstruct deployment activity directly from emitted events.

### Changes

* Added amount supplied/withdrawn fields to `RebalanceEvent`
* Updated event emission logic in rebalance flow
* Updated `EVENTS.md` documentation
* Updated event schema and related tests




#186 