### PR TITLE
Add root CHANGELOG and PR template reminder for contract version changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+
+Describe the purpose of this PR and the changes included.
+
+## Checklist
+
+- [ ] I have updated `CHANGELOG.md` for any contract version or on-chain behavior changes.
+- [ ] I have confirmed the release entry matches the expected contract `Version` storage value.
+- [ ] I have included tests or documentation updates for new contract behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this repository are documented in this file.
+This changelog is tied to the vault contract `Version` storage value. Each released contract upgrade should add a new entry matching the stored version number.
+
+## [Unreleased]
+- Add pending contract changes here.
+- Include the target `Version` storage value for any upgrade.
+- Update the PR description and reviewer notes when contract behavior changes.
+
+## [1]
+- Initial vault implementation with ERC-4626-inspired share accounting.
+- `get_version()` returns the contract version from `DataKey::Version`.
+- `UpgradedEvent` emits both `old_version` and `new_version` for on-chain auditability.


### PR DESCRIPTION
Closes #200

- Adds root CHANGELOG.md with [Unreleased] section and version entries tied to contract Version storage.
- Adds .github/pull_request_template.md reminding contributors to update the changelog when contract behavior changes.
