### PR TITLE
Feat/187 configurable blend approval expiry

### DIFF
--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -214,6 +214,10 @@ pub enum VaultError {
     MinOutNotMet = 42,
     /// Rebalance called before the configured cooldown has elapsed.
     RebalanceCooldownActive = 43,
+    /// Approval TTL is below the allowed floor.
+    ApprovalTtlTooLow = 44,
+    /// Approval TTL is above the allowed ceiling.
+    ApprovalTtlTooHigh = 45,
 }
 
 // ============================================================================
@@ -290,6 +294,8 @@ pub enum DataKey {
     /// Written at the end of every successful rebalance.
     /// (Issue #59)
     LastRebalanceLedger,
+    /// Number of ledgers added to the current ledger for Blend token approvals.
+    ApprovalTtl,
 }
 
 // ============================================================================
@@ -640,6 +646,11 @@ const DEFAULT_TVL_CAP: i128 = 100_000_000_000_i128;
 const DEFAULT_USER_DEPOSIT_CAP: i128 = 10_000_000_000_i128;
 const DEFAULT_MIN_DEPOSIT: i128 = 1_000_000_i128;
 const DEFAULT_MAX_DEPOSIT: i128 = 10_000_000_000_i128;
+/// Default Blend token approval lifetime.
+/// 100_000 ledgers × ~5s per ledger ≈ 5.7 days on Stellar mainnet.
+pub(crate) const DEFAULT_APPROVAL_TTL: u32 = 100_000;
+const MIN_APPROVAL_TTL: u32 = 1_000;
+const MAX_APPROVAL_TTL: u32 = 500_000;
 
 /// Minimum ledgers remaining before `touch_user_ttl` extends a user's `Shares` entry.
 const USER_SHARES_TTL_THRESHOLD: u32 = 100;
@@ -2164,6 +2175,48 @@ impl NeuroWealthVault {
             .unwrap_or(0)
     }
 
+    /// Sets the number of ledgers that Blend token approvals remain valid.
+    ///
+    /// Only the owner can call this function. The TTL is bounded to prevent
+    /// approvals from expiring too quickly or remaining valid for too long.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `ttl` - Number of ledgers to add to the current ledger for approvals.
+    ///
+    /// # Returns
+    /// None.
+    ///
+    /// # Panics
+    /// - If the caller is not the owner.
+    /// - If `ttl` is below 1,000 ledgers.
+    /// - If `ttl` is above 500,000 ledgers.
+    pub fn set_approval_ttl(env: Env, ttl: u32) {
+        Self::require_initialized(&env);
+        Self::require_is_owner(&env);
+
+        if ttl < MIN_APPROVAL_TTL {
+            panic_with_error!(&env, VaultError::ApprovalTtlTooLow);
+        }
+        if ttl > MAX_APPROVAL_TTL {
+            panic_with_error!(&env, VaultError::ApprovalTtlTooHigh);
+        }
+
+        env.storage().instance().set(&DataKey::ApprovalTtl, &ttl);
+    }
+
+    /// Returns the configured Blend approval TTL, or the default if unset.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    ///
+    /// # Returns
+    /// Number of ledgers added to the current ledger for Blend token approvals.
+    pub fn get_approval_ttl(env: Env) -> u32 {
+        Self::require_initialized(&env);
+        Self::get_approval_ttl_internal(&env)
+    }
+
     // ==========================================================================
     // ADMINISTRATIVE - CONFIGURATION
     // ==========================================================================
@@ -3510,6 +3563,14 @@ impl NeuroWealthVault {
             .unwrap_or(DEFAULT_MAX_DEPOSIT)
     }
 
+    #[inline]
+    fn get_approval_ttl_internal(env: &Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::ApprovalTtl)
+            .unwrap_or(DEFAULT_APPROVAL_TTL)
+    }
+
     /// Validates that a deposit is within the user's cap.
     ///
     /// The cap is enforced against the user's current **asset value** (shares ×
@@ -3749,7 +3810,7 @@ impl NeuroWealthVault {
 
         let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
         let vault_address = env.current_contract_address();
-        let approval_ledger = env.ledger().sequence() + 100_000;
+        let approval_ledger = env.ledger().sequence() + Self::get_approval_ttl_internal(env);
 
         // Prepare authorization for token approval and Blend supply
         let approval_args: Vec<Val> = vec![

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -3565,6 +3565,7 @@ impl NeuroWealthVault {
 
     #[inline]
     fn get_approval_ttl_internal(env: &Env) -> u32 {
+        let _ = env.ledger().sequence();
         env.storage()
             .instance()
             .get(&DataKey::ApprovalTtl)

--- a/neurowealth-vault/contracts/vault/src/tests/mod.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/mod.rs
@@ -1,5 +1,5 @@
 mod test_access_control;
-mod test_update_total_assets_blend;
+mod test_approval_ttl;
 mod test_auth;
 mod test_balance_shares_invariant;
 #[cfg(feature = "blend-devnet")]
@@ -25,6 +25,7 @@ mod test_rounding_math;
 mod test_shares;
 mod test_total_assets_cap;
 mod test_ttl;
+mod test_update_total_assets_blend;
 mod test_withdraw;
 mod test_yield;
 mod utils;

--- a/neurowealth-vault/contracts/vault/src/tests/test_approval_ttl.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_approval_ttl.rs
@@ -1,0 +1,131 @@
+//! Tests for configurable Blend token approval TTL.
+
+use super::utils::*;
+use crate::{VaultError, DEFAULT_APPROVAL_TTL};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal,
+};
+
+fn setup_blend_position(
+    env: &Env,
+    ttl: Option<u32>,
+) -> (
+    Address,
+    Address,
+    Address,
+    NeuroWealthVaultClient<'_>,
+    TestTokenClient<'_>,
+) {
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, usdc_token, blend_pool) =
+        setup_vault_with_token_and_blend(env);
+    let client = NeuroWealthVaultClient::new(env, &contract_id);
+    let token_client = TestTokenClient::new(env, &usdc_token);
+
+    client.set_blend_pool(&owner, &blend_pool);
+    if let Some(ttl) = ttl {
+        client.set_approval_ttl(&ttl);
+    }
+
+    let user = Address::generate(env);
+    mint_and_deposit(env, &client, &usdc_token, &user, 10_000_000_i128);
+
+    (contract_id, usdc_token, blend_pool, client, token_client)
+}
+
+#[test]
+fn test_approval_expiry_uses_configured_ttl() {
+    let env = Env::default();
+    let configured_ttl = 2_500_u32;
+    let (contract_id, _usdc_token, blend_pool, client, token_client) =
+        setup_blend_position(&env, Some(configured_ttl));
+
+    let sequence = env.ledger().sequence();
+    client.rebalance(&symbol_short!("blend"), &700_i128, &0_i128);
+
+    let expiration = token_client.allowance_expiration(&contract_id, &blend_pool);
+    assert_eq!(expiration, sequence + configured_ttl);
+}
+
+#[test]
+fn test_approval_expiry_minimum_ttl_is_valid() {
+    let env = Env::default();
+    let minimum_ttl = 1_000_u32;
+    let (contract_id, _usdc_token, blend_pool, client, token_client) =
+        setup_blend_position(&env, Some(minimum_ttl));
+
+    let sequence = env.ledger().sequence();
+    client.rebalance(&symbol_short!("blend"), &700_i128, &0_i128);
+
+    let expiration = token_client.allowance_expiration(&contract_id, &blend_pool);
+    assert_eq!(expiration, sequence + minimum_ttl);
+    assert!(expiration > sequence);
+}
+
+#[test]
+fn test_set_approval_ttl_requires_owner_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner) = setup_vault(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let attacker = Address::generate(&env);
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "set_approval_ttl",
+            args: (2_000_u32,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_set_approval_ttl(&2_000_u32);
+    assert!(
+        result.is_err(),
+        "set_approval_ttl must fail without the owner's authorization"
+    );
+}
+
+#[test]
+fn test_default_approval_ttl_used_when_unconfigured() {
+    let env = Env::default();
+    let (contract_id, _usdc_token, blend_pool, client, token_client) =
+        setup_blend_position(&env, None);
+
+    assert_eq!(client.get_approval_ttl(), DEFAULT_APPROVAL_TTL);
+
+    let sequence = env.ledger().sequence();
+    client.rebalance(&symbol_short!("blend"), &700_i128, &0_i128);
+
+    let expiration = token_client.allowance_expiration(&contract_id, &blend_pool);
+    assert_eq!(expiration, sequence + DEFAULT_APPROVAL_TTL);
+}
+
+#[test]
+fn test_set_approval_ttl_rejects_below_minimum() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner) = setup_vault(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let result = client.try_set_approval_ttl(&999_u32);
+    assert_eq!(result, Err(Ok(VaultError::ApprovalTtlTooLow)));
+}
+
+#[test]
+fn test_set_approval_ttl_rejects_above_maximum() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner) = setup_vault(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let result = client.try_set_approval_ttl(&500_001_u32);
+    assert_eq!(result, Err(Ok(VaultError::ApprovalTtlTooHigh)));
+}

--- a/neurowealth-vault/contracts/vault/src/tests/test_balance_shares_invariant.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_balance_shares_invariant.rs
@@ -29,10 +29,7 @@ fn within_tolerance(a: i128, b: i128) -> bool {
     abs_diff(a, b) <= ROUNDING_TOLERANCE
 }
 
-fn assert_balance_share_consistency(
-    client: &NeuroWealthVaultClient,
-    user: &Address,
-) {
+fn assert_balance_share_consistency(client: &NeuroWealthVaultClient, user: &Address) {
     let balance = client.get_balance(user);
     let shares = client.get_shares(user);
     let converted = client.convert_to_assets(&shares);
@@ -46,10 +43,7 @@ fn assert_balance_share_consistency(
     );
 }
 
-fn assert_global_vault_invariants(
-    client: &NeuroWealthVaultClient,
-    users: &Vec<Address>,
-) {
+fn assert_global_vault_invariants(client: &NeuroWealthVaultClient, users: &Vec<Address>) {
     let total_assets = client.get_total_assets();
     let total_shares = client.get_total_shares();
 
@@ -59,16 +53,16 @@ fn assert_global_vault_invariants(
     for user in users.iter() {
         let balance = client.get_balance(&user);
         let shares = client.get_shares(&user);
-        
+
         assert!(balance >= 0, "Negative balance");
         assert!(shares >= 0, "Negative shares");
-        
+
         sum_balances += balance;
         sum_shares += shares;
-        
+
         assert_balance_share_consistency(client, &user);
     }
-    
+
     assert!(total_assets >= 0, "Negative total assets");
     assert!(total_shares >= 0, "Negative total shares");
 
@@ -84,10 +78,9 @@ fn assert_global_vault_invariants(
     assert_eq!(
         total_shares, sum_shares,
         "Total Vault Shares ({}) != Sum(User Shares) ({})",
-        total_shares,
-        sum_shares
+        total_shares, sum_shares
     );
-    
+
     // Exchange Rate Validity
     if total_assets > 0 && total_shares > 0 {
         assert!(total_assets > 0 && total_shares > 0, "Invalid share price");
@@ -125,7 +118,7 @@ fn test_invariant_yield_accrual() {
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
 
     let shares_before = client.get_shares(&user);
-    
+
     // Simulate yield
     let yield_amount = 5_000_000;
     token_client.mint(&contract_id, &yield_amount);
@@ -133,11 +126,14 @@ fn test_invariant_yield_accrual() {
 
     let mut users = Vec::new(&env);
     users.push_back(user.clone());
-    
+
     assert_global_vault_invariants(&client, &users);
-    
+
     let shares_after = client.get_shares(&user);
-    assert_eq!(shares_before, shares_after, "Share count should be unchanged by yield");
+    assert_eq!(
+        shares_before, shares_after,
+        "Share count should be unchanged by yield"
+    );
 }
 
 #[test]
@@ -162,7 +158,7 @@ fn test_invariant_partial_withdrawal() {
 
     let mut users = Vec::new(&env);
     users.push_back(user.clone());
-    
+
     assert_global_vault_invariants(&client, &users);
 }
 
@@ -195,7 +191,7 @@ fn test_invariant_full_withdrawal() {
 
     let mut users = Vec::new(&env);
     users.push_back(user.clone());
-    
+
     assert_global_vault_invariants(&client, &users);
 }
 
@@ -207,12 +203,12 @@ fn test_invariant_multi_user() {
     let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
     let token_client = TestTokenClient::new(&env, &usdc_token);
-    
+
     let user_a = Address::generate(&env);
     let user_b = Address::generate(&env);
 
     mint_and_deposit(&env, &client, &usdc_token, &user_a, 10_000_000);
-    
+
     // Simulate yield
     token_client.mint(&contract_id, &2_000_000);
     client.update_total_assets(&agent, &12_000_000, &false, &0);
@@ -226,7 +222,7 @@ fn test_invariant_multi_user() {
     let mut users = Vec::new(&env);
     users.push_back(user_a.clone());
     users.push_back(user_b.clone());
-    
+
     assert_global_vault_invariants(&client, &users);
 }
 
@@ -235,7 +231,8 @@ fn test_invariant_blend_integration() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (contract_id, agent, owner, usdc_token, blend_pool) = setup_vault_with_token_and_blend(&env);
+    let (contract_id, agent, owner, usdc_token, blend_pool) =
+        setup_vault_with_token_and_blend(&env);
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
     let token_client = TestTokenClient::new(&env, &usdc_token);
     let blend_client = MockBlendPoolClient::new(&env, &blend_pool);
@@ -255,14 +252,14 @@ fn test_invariant_blend_integration() {
     let vault_balance = token_client.balance(&contract_id);
     let blend_balance = blend_client.balance(&usdc_token, &contract_id);
     let new_total = vault_balance + blend_balance;
-    
+
     client.update_total_assets(&agent, &new_total, &false, &0);
 
     let mut users = Vec::new(&env);
     users.push_back(user.clone());
-    
+
     assert_global_vault_invariants(&client, &users);
-    
+
     // Validate: Vault Assets = On-chain Assets + Blend Position Value
     assert_eq!(client.get_total_assets(), new_total);
 }
@@ -272,12 +269,13 @@ fn test_invariant_sequential_lifecycle() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (contract_id, agent, owner, usdc_token, blend_pool) = setup_vault_with_token_and_blend(&env);
+    let (contract_id, agent, owner, usdc_token, blend_pool) =
+        setup_vault_with_token_and_blend(&env);
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
     let token_client = TestTokenClient::new(&env, &usdc_token);
     let blend_client = MockBlendPoolClient::new(&env, &blend_pool);
     client.set_blend_pool(&owner, &blend_pool);
-    
+
     let user_a = Address::generate(&env);
     let mut users = Vec::new(&env);
     users.push_back(user_a.clone());
@@ -307,7 +305,7 @@ fn test_invariant_sequential_lifecycle() {
     // 6. Blend Update
     client.rebalance(&soroban_sdk::Symbol::new(&env, "blend"), &850_i128, &0_i128);
     token_client.mint(&blend_pool, &2_000_000); // Blend Yield
-    
+
     let vault_balance = token_client.balance(&contract_id);
     let blend_balance = blend_client.balance(&usdc_token, &contract_id);
     let new_total = vault_balance + blend_balance;
@@ -376,7 +374,7 @@ fn test_invariant_repeated_yield_updates() {
         token_client.mint(&contract_id, &yield_amount);
         current_assets += yield_amount;
         client.update_total_assets(&agent, &current_assets, &false, &0);
-        
+
         assert_global_vault_invariants(&client, &users);
     }
 }
@@ -389,7 +387,7 @@ fn test_invariant_rounding_edge_cases() {
     let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
     let token_client = TestTokenClient::new(&env, &usdc_token);
-    
+
     let user_a = Address::generate(&env);
     let user_b = Address::generate(&env);
     let mut users = Vec::new(&env);
@@ -406,7 +404,7 @@ fn test_invariant_rounding_edge_cases() {
     mint_and_deposit(&env, &client, &usdc_token, &user_b, 2_000_001);
 
     assert_global_vault_invariants(&client, &users);
-    
+
     client.withdraw(&user_b, &1);
     assert_global_vault_invariants(&client, &users);
 }

--- a/neurowealth-vault/contracts/vault/src/tests/test_events.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_events.rs
@@ -454,8 +454,14 @@ fn test_rebalance_emits_rebalance_event_with_correct_payload() {
         "Event amount_attempted should be 0"
     );
     assert_eq!(event.amount_moved, 0, "Event amount_moved should be 0");
-    assert_eq!(event.amount_supplied, 0, "Event amount_supplied should be 0");
-    assert_eq!(event.amount_withdrawn, 0, "Event amount_withdrawn should be 0");
+    assert_eq!(
+        event.amount_supplied, 0,
+        "Event amount_supplied should be 0"
+    );
+    assert_eq!(
+        event.amount_withdrawn, 0,
+        "Event amount_withdrawn should be 0"
+    );
 }
 
 #[test]
@@ -505,7 +511,10 @@ fn test_rebalance_with_blend_emits_correct_event() {
         event.amount_supplied, 10_000_000_i128,
         "Event amount_supplied should match supplied balance"
     );
-    assert_eq!(event.amount_withdrawn, 0, "Event amount_withdrawn should be 0");
+    assert_eq!(
+        event.amount_withdrawn, 0,
+        "Event amount_withdrawn should be 0"
+    );
 }
 
 #[test]
@@ -555,7 +564,10 @@ fn test_rebalance_with_blend_partial_fill_emits_correct_event() {
         event.amount_supplied, 3_000_000_i128,
         "Event amount_supplied should be 3M"
     );
-    assert_eq!(event.amount_withdrawn, 0, "Event amount_withdrawn should be 0");
+    assert_eq!(
+        event.amount_withdrawn, 0,
+        "Event amount_withdrawn should be 0"
+    );
 }
 
 #[test]
@@ -598,8 +610,14 @@ fn test_rebalance_with_blend_failed_fill_emits_correct_event() {
         "Event amount_attempted should be 10M"
     );
     assert_eq!(event.amount_moved, 0, "Event amount_moved should be 0");
-    assert_eq!(event.amount_supplied, 0, "Event amount_supplied should be 0");
-    assert_eq!(event.amount_withdrawn, 0, "Event amount_withdrawn should be 0");
+    assert_eq!(
+        event.amount_supplied, 0,
+        "Event amount_supplied should be 0"
+    );
+    assert_eq!(
+        event.amount_withdrawn, 0,
+        "Event amount_withdrawn should be 0"
+    );
 }
 
 #[test]

--- a/neurowealth-vault/contracts/vault/src/tests/test_rebalance_cooldown.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_rebalance_cooldown.rs
@@ -191,7 +191,10 @@ fn test_rebalance_within_cooldown_returns_error() {
 
     // Second call: must fail with RebalanceCooldownActive (#43)
     let result = client.try_rebalance(&symbol_short!("none"), &0_i128, &0_i128);
-    assert!(result.is_err(), "Second rebalance within cooldown should fail");
+    assert!(
+        result.is_err(),
+        "Second rebalance within cooldown should fail"
+    );
 }
 
 /// After cooldown elapses (ledger advances past the interval), rebalance

--- a/neurowealth-vault/contracts/vault/src/tests/test_rounding_math.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_rounding_math.rs
@@ -721,7 +721,10 @@ impl SimplePrng {
 
     // Simple LCG random generator
     fn next_u64(&mut self) -> u64 {
-        self.state = self.state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        self.state = self
+            .state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
         self.state
     }
 
@@ -765,10 +768,10 @@ fn test_property_deposit_withdraw_never_increases_shares() {
 
         // Generate randomized subsequent deposit
         let subsequent_deposit = prng.next_range(1_000_000, 10_000_000_000);
-        
+
         // Check shares minted for the subsequent deposit
         let shares_minted = client.preview_deposit_to_shares(&subsequent_deposit);
-        
+
         // Perform actual deposit
         mint_and_deposit(&env, &client, &usdc_token, &user2, subsequent_deposit);
         let actual_shares = client.get_shares(&user2);
@@ -832,7 +835,10 @@ fn test_property_total_shares_conserved_on_transfers() {
         let user3_shares = client.get_shares(&user3);
 
         // Invariant: total shares must equal sum of user shares
-        assert_eq!(total_shares_before, user1_shares + user2_shares + user3_shares);
+        assert_eq!(
+            total_shares_before,
+            user1_shares + user2_shares + user3_shares
+        );
 
         // 2. Perform direct token transfers of the underlying token (USDC)
         // This simulates users sending USDC directly between themselves or to external parties.

--- a/neurowealth-vault/contracts/vault/src/tests/utils.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/utils.rs
@@ -123,6 +123,13 @@ pub mod token {
                 .unwrap_or(0)
         }
 
+        pub fn allowance_expiration(env: Env, from: Address, spender: Address) -> u32 {
+            env.storage()
+                .persistent()
+                .get(&TokenDataKey::AllowanceExpiration(from, spender))
+                .unwrap_or(0)
+        }
+
         pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
             spender.require_auth();
             assert!(amount > 0, "amount must be positive");

--- a/neurowealth-vault/fuzz/fuzz_targets/deposit_withdraw_sequence.rs
+++ b/neurowealth-vault/fuzz/fuzz_targets/deposit_withdraw_sequence.rs
@@ -58,14 +58,12 @@ mod token {
                 .get(&TokenDataKey::Balance(to.clone()))
                 .unwrap_or(0);
 
-            env.storage().persistent().set(
-                &TokenDataKey::Balance(from),
-                &(from_balance - amount),
-            );
-            env.storage().persistent().set(
-                &TokenDataKey::Balance(to),
-                &(to_balance + amount),
-            );
+            env.storage()
+                .persistent()
+                .set(&TokenDataKey::Balance(from), &(from_balance - amount));
+            env.storage()
+                .persistent()
+                .set(&TokenDataKey::Balance(to), &(to_balance + amount));
         }
 
         pub fn balance(env: Env, owner: Address) -> i128 {
@@ -155,7 +153,8 @@ fuzz_target!(|data: &[u8]| {
             continue;
         }
         let op = chunk[0] % 2;
-        let raw = u16::from(chunk.get(1).copied().unwrap_or(0)) | (u16::from(chunk.get(2).copied().unwrap_or(0)) << 8);
+        let raw = u16::from(chunk.get(1).copied().unwrap_or(0))
+            | (u16::from(chunk.get(2).copied().unwrap_or(0)) << 8);
         let amount = i128::from(raw % 20_000) * MIN_DEPOSIT + MIN_DEPOSIT;
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -190,16 +189,9 @@ fuzz_target!(|data: &[u8]| {
                 let msg = payload
                     .downcast_ref::<&str>()
                     .copied()
-                    .or_else(|| {
-                        payload
-                            .downcast_ref::<String>()
-                            .map(|s| s.as_str())
-                    })
+                    .or_else(|| payload.downcast_ref::<String>().map(|s| s.as_str()))
                     .unwrap_or("unknown panic");
-                assert!(
-                    is_allowed_panic(msg),
-                    "unexpected panic at step {i}: {msg}"
-                );
+                assert!(is_allowed_panic(msg), "unexpected panic at step {i}: {msg}");
             }
         }
     }


### PR DESCRIPTION
Closes #187

Made Blend token approval expiry configurable via owner-settable instance storage instead of a hardcoded 100_000 ledger TTL. Adds a documented DEFAULT_APPROVAL_TTL constant with ledger math, a validated setter/getter, and tests covering the expiration edge case, non-owner rejection, and default fallback.