### PR TITLE
Add BlendPoolConfiguredEvent and emit on pool configuration change

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -319,6 +319,19 @@ pub struct BlendWithdrawEvent {
 }
 ```
 
+### 15a. BlendPoolConfiguredEvent
+**Topic:** `"blend_cfg"`
+
+Emitted after `set_blend_pool` updates the configured Blend pool address.
+
+```rust
+pub struct BlendPoolConfiguredEvent {
+    pub old_pool: Option<Address>, // Previous pool address, or None on first configuration
+    pub new_pool: Address,         // Newly configured pool address
+    pub owner: Address,            // Owner/admin who triggered the change
+}
+```
+
 ## Upgrade Events
 
 ### 16. UpgradedEvent

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -589,6 +589,21 @@ pub struct BlendWithdrawEvent {
     pub success: bool,
 }
 
+/// Emitted when the Blend pool address is configured.
+///
+/// # Topics
+/// - `SymbolShort("blend_cfg")` - Event identifier
+#[allow(missing_docs)]
+#[contracttype]
+pub struct BlendPoolConfiguredEvent {
+    /// Previous Blend pool address, or None if it was not configured
+    pub old_pool: Option<Address>,
+    /// Newly configured Blend pool address
+    pub new_pool: Address,
+    /// Owner who triggered the configuration change
+    pub owner: Address,
+}
+
 /// Emitted when a rebalance aborts due to a protocol exit failure.
 ///
 /// Emitted instead of panicking so the failure is observable on-chain without
@@ -673,6 +688,7 @@ pub(crate) const TOPIC_ASSETS_UPDATED: Symbol = symbol_short!("assets");
 pub(crate) const TOPIC_UPGRADED: Symbol = symbol_short!("upgraded");
 pub(crate) const TOPIC_BLEND_SUPPLY: Symbol = symbol_short!("blend_sup");
 pub(crate) const TOPIC_BLEND_WITHDRAW: Symbol = symbol_short!("blend_wd");
+pub(crate) const TOPIC_BLEND_POOL_CONFIGURED: Symbol = symbol_short!("blend_cfg");
 pub(crate) const TOPIC_PROTOCOL_CHANGED: Symbol = symbol_short!("proto_chg");
 pub(crate) const TOPIC_REBALANCE_FAILED: Symbol = symbol_short!("reb_fail");
 
@@ -2118,7 +2134,7 @@ impl NeuroWealthVault {
     ///
     /// # Events
     ///
-    /// None.
+    /// - `BlendPoolConfiguredEvent`
     ///
     /// # Errors
     ///
@@ -2320,6 +2336,8 @@ impl NeuroWealthVault {
         let vault_address = env.current_contract_address();
         BlendPoolClient::get_balance(&env, &pool_address, &usdc_token, &vault_address);
 
+        let old_pool: Option<Address> = env.storage().instance().get(&DataKey::BlendPool);
+
         env.storage()
             .instance()
             .set(&DataKey::BlendPool, &pool_address);
@@ -2330,6 +2348,15 @@ impl NeuroWealthVault {
                 .instance()
                 .set(&DataKey::CurrentProtocol, &symbol_short!("none"));
         }
+
+        env.events().publish(
+            (TOPIC_BLEND_POOL_CONFIGURED,),
+            BlendPoolConfiguredEvent {
+                old_pool,
+                new_pool: pool_address.clone(),
+                owner: owner.clone(),
+            },
+        );
     }
 
     /// Updates the ledger TTL used when approving Blend token spend.

--- a/neurowealth-vault/contracts/vault/src/tests/test_events.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_events.rs
@@ -2,13 +2,13 @@
 
 use super::utils::*;
 use crate::{
-    AgentUpdatedEvent, AssetsUpdatedEvent, BlendSupplyEvent, BlendWithdrawEvent, CapsUpdatedEvent,
-    DepositEvent, EmergencyPausedEvent, LimitsUpdatedEvent, RebalanceEvent, TvlCapUpdatedEvent,
-    UserDepositCapUpdatedEvent, VaultInitializedEvent, VaultPausedEvent, VaultUnpausedEvent,
-    WithdrawEvent, TOPIC_AGENT_UPDATED, TOPIC_ASSETS_UPDATED, TOPIC_BLEND_SUPPLY,
-    TOPIC_BLEND_WITHDRAW, TOPIC_CAPS_UPDATED, TOPIC_DEPOSIT, TOPIC_EMERGENCY_PAUSED, TOPIC_INIT,
-    TOPIC_LIMITS_UPDATED, TOPIC_PAUSED, TOPIC_REBALANCE, TOPIC_TVL_CAP_UPDATED, TOPIC_UNPAUSED,
-    TOPIC_USER_CAP_UPDATED, TOPIC_WITHDRAW,
+    AgentUpdatedEvent, AssetsUpdatedEvent, BlendPoolConfiguredEvent, BlendSupplyEvent,
+    BlendWithdrawEvent, CapsUpdatedEvent, DepositEvent, EmergencyPausedEvent, LimitsUpdatedEvent,
+    RebalanceEvent, TvlCapUpdatedEvent, UserDepositCapUpdatedEvent, VaultInitializedEvent,
+    VaultPausedEvent, VaultUnpausedEvent, WithdrawEvent, TOPIC_AGENT_UPDATED, TOPIC_ASSETS_UPDATED,
+    TOPIC_BLEND_POOL_CONFIGURED, TOPIC_BLEND_SUPPLY, TOPIC_BLEND_WITHDRAW, TOPIC_CAPS_UPDATED,
+    TOPIC_DEPOSIT, TOPIC_EMERGENCY_PAUSED, TOPIC_INIT, TOPIC_LIMITS_UPDATED, TOPIC_PAUSED,
+    TOPIC_REBALANCE, TOPIC_TVL_CAP_UPDATED, TOPIC_UNPAUSED, TOPIC_USER_CAP_UPDATED, TOPIC_WITHDRAW,
 };
 use soroban_sdk::{symbol_short, testutils::Address as _, Address, BytesN, Env, TryFromVal};
 
@@ -56,6 +56,42 @@ fn test_initialize_emits_init_event_with_correct_payload() {
         event.tvl_cap, expected_tvl_cap,
         "Event tvl_cap should match default cap"
     );
+}
+
+#[test]
+fn test_set_blend_pool_emits_configured_event_with_correct_payload() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token, old_pool) =
+        setup_vault_with_token_and_blend(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let new_pool = env.register_contract(None, MockBlendPool);
+
+    client.set_blend_pool(&owner, &old_pool);
+    client.set_blend_pool(&owner, &new_pool);
+
+    let events = find_events_by_topic(env.events().all(), &env, TOPIC_BLEND_POOL_CONFIGURED);
+    assert_eq!(
+        events.len(),
+        2,
+        "Each set_blend_pool call should emit a BlendPoolConfiguredEvent"
+    );
+
+    let (_, _, data) = &events[1];
+    let event = BlendPoolConfiguredEvent::try_from_val(&env, data)
+        .expect("Should be a BlendPoolConfiguredEvent");
+
+    assert_eq!(
+        event.old_pool,
+        Some(old_pool),
+        "Event old_pool should match the previously configured pool"
+    );
+    assert_eq!(
+        event.new_pool, new_pool,
+        "Event new_pool should match the replacement pool"
+    );
+    assert_eq!(event.owner, owner, "Event owner should match the caller");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Closes #193

Emits a `BlendPoolConfiguredEvent` from `set_blend_pool` so indexers and 
ops tooling can react to pool changes without polling `get_blend_pool()`.

## Changes
- `set_blend_pool`: capture `old_pool` before overwrite, emit event with 
  `old_pool`, `new_pool`, and `owner` fields after storage update
- `EVENTS.md`: added schema entry for `BlendPoolConfiguredEvent`
- Tests: added schema test asserting event is emitted with correct values

## Acceptance Criteria
- [x] Event includes `old_pool`, `new_pool`, and `owner`
- [x] `EVENTS.md` entry added
- [x] Schema/emission test passes