### PR TITLE
feat(vault): add DEX liquidity pool integration (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ This changelog is tied to the vault contract `Version` storage value. Each relea
 - Add pending contract changes here.
 - Include the target `Version` storage value for any upgrade.
 - Update the PR description and reviewer notes when contract behavior changes.
+- **DEX liquidity pool integration (Issue #228):** the vault can now deploy USDC
+  to a Stellar DEX liquidity pool in addition to Blend, implementing the
+  on-chain side of the Balanced/Growth strategies.
+  - Added owner-configurable `DataKey::DexPool` with `set_dex_pool` / `get_dex_pool`.
+  - Added `supply_to_dex` / `withdraw_from_dex` internal helpers mirroring Blend.
+  - `rebalance` now accepts the `"dex"` protocol symbol with `min_out` slippage
+    protection; `CurrentProtocol` and `ProtocolChangedEvent` reflect DEX deployments.
+  - User `withdraw` / `withdraw_all` pull liquidity back from the DEX when needed.
+  - New events: `DexSupplyEvent` (`dex_sup`), `DexWithdrawEvent` (`dex_wd`),
+    `DexPoolConfiguredEvent` (`dex_cfg`).
+  - New errors: `DexPoolNotConfigured` (#46), `OnlyOwnerCanSetDexPool` (#47).
+  - New `dex-devnet` test feature flag. No `Version` bump (additive, pre-mainnet).
+  - See `DEX_INTEGRATION.md`.
 
 ## [1]
 - Initial vault implementation with ERC-4626-inspired share accounting.

--- a/DEX_INTEGRATION.md
+++ b/DEX_INTEGRATION.md
@@ -1,0 +1,166 @@
+# DEX Liquidity Pool Integration Research
+
+## Overview
+
+This document records the research and design for integrating the NeuroWealth
+Vault with a Stellar DEX liquidity pool, alongside the existing Blend Protocol
+integration. It implements the on-chain side of the **Balanced** and **Growth**
+strategies described in the README (lending + DEX liquidity provision).
+
+It mirrors the patterns established in [`BLEND_INTEGRATION_RESEARCH.md`](BLEND_INTEGRATION_RESEARCH.md).
+
+## Soroban DEX Interface
+
+The vault deploys a single asset (USDC) into a DEX liquidity pool. The pool is
+modelled as a **single-asset liquidity adapter** exposing three entrypoints:
+
+| Entrypoint | Purpose |
+|------------|---------|
+| `add_liquidity(from, asset, amount, min_out)` | Supply USDC liquidity after `approve` |
+| `remove_liquidity(to, asset, amount, min_out)` | Withdraw USDC liquidity |
+| `balance(asset, user)` | The vault's current liquidity position |
+
+`min_out` is the caller's slippage floor for the leg. The vault forwards it to
+the pool **and** independently enforces it on the realized amount (see
+[Slippage](#slippage-protection)), so a partial fill is rejected even if the
+pool ignores the hint.
+
+Implementation: `DexPoolClient` in
+[`neurowealth-vault/contracts/vault/src/lib.rs`](neurowealth-vault/contracts/vault/src/lib.rs).
+
+> **Note on production pools.** Real Stellar AMMs (e.g. Soroswap pairs, Aquarius,
+> Comet) are two-asset constant-product pools whose `deposit`/`swap`/`withdraw`
+> signatures differ from the single-asset adapter above. Deploying single-sided
+> USDC into such a pool requires an adapter contract that performs the swap/zap
+> and returns the realized USDC value. The vault is intentionally decoupled from
+> that detail: it calls `add_liquidity`/`remove_liquidity`/`balance` on whatever
+> `DexPool` address the owner registers, and measures results by its own USDC
+> balance delta. The configured address is expected to be either a compatible
+> pool or a thin adapter implementing these three entrypoints.
+
+## Cross-Contract Call Pattern
+
+```rust
+env.invoke_contract::<Val>(
+    &pool_address,
+    &Symbol::new(env, "add_liquidity"),
+    args,
+);
+```
+
+Supply flow (mirrors Blend):
+
+1. Vault `approve`s the DEX pool for the supply amount (TTL = `ApprovalTtl`).
+2. Vault authorizes `add_liquidity` with a `transfer_from` sub-invocation.
+3. Pool pulls USDC via `transfer_from`.
+4. Vault computes the realized amount from its own USDC balance delta.
+
+Withdraw flow:
+
+1. Vault calls `remove_liquidity` (amount `0` ⇒ withdraw the full position).
+2. Pool transfers USDC back to the vault.
+3. Vault computes the realized amount from its balance delta.
+
+## Owner Configuration
+
+```rust
+pub fn set_dex_pool(env: Env, owner: Address, pool_address: Address);
+pub fn get_dex_pool(env: Env) -> Option<Address>;
+```
+
+- Owner-only. The pool interface is validated by probing `balance` before the
+  address is stored (an invalid pool reverts at configuration time).
+- Stored under `DataKey::DexPool`; emits `DexPoolConfiguredEvent` (`dex_cfg`).
+
+## Rebalance API (agent)
+
+```rust
+pub fn rebalance(env: Env, protocol: Symbol, expected_apy: i128, min_out: i128);
+```
+
+- Supported `protocol` symbols: `"blend"`, `"dex"`, `"none"`.
+- Switching from one protocol to another exits the current one first; an
+  incomplete exit emits `RebalanceFailedEvent` and aborts without mutating state.
+- `min_out`: minimum assets per supply/withdraw leg; `0` disables the check.
+- `RebalanceEvent.status == "noop"`: no funds moved.
+
+## Protocol Tracking
+
+`DataKey::CurrentProtocol`:
+
+- `"none"`: Funds idle in the vault (or not deployed).
+- `"blend"`: Funds deployed to Blend.
+- `"dex"`: Funds deployed to the DEX pool.
+
+`ProtocolChangedEvent` (`proto_chg`) is emitted whenever `CurrentProtocol`
+changes, including transitions into and out of `"dex"`.
+
+## Slippage Protection
+
+On every DEX leg, `min_out` is enforced by `require_min_out`:
+
+- **Supply**: if the realized supplied amount `< min_out`, the call reverts with
+  `VaultError::MinOutNotMet` (`#42`).
+- **Withdraw**: if the realized withdrawn amount `< min_out`, the call reverts
+  with the same error.
+
+`min_out == 0` disables the check.
+
+## Events
+
+| Event | Topic | When |
+|-------|-------|------|
+| `DexSupplyEvent` | `dex_sup` | USDC supplied to the DEX pool |
+| `DexWithdrawEvent` | `dex_wd` | USDC withdrawn from the DEX pool |
+| `DexPoolConfiguredEvent` | `dex_cfg` | DEX pool address configured |
+
+See [`EVENTS.md`](EVENTS.md) for full schemas.
+
+## Testing
+
+| Layer | Command |
+|-------|---------|
+| Unit / mock pool | `cargo test -p neurowealth-vault` |
+| DEX interface (feature) | `cargo test -p neurowealth-vault --features dex-devnet` |
+
+`tests/test_dex_integration.rs` uses an in-env `MockDexPool` (same pattern as
+`MockBlendPool`) and covers: supply/withdraw via rebalance, balance reads,
+`CurrentProtocol`/`ProtocolChangedEvent` tracking, `min_out` enforcement,
+Blend↔DEX switching, and user withdrawals that pull liquidity back from the DEX.
+
+Manual devnet smoke (replace addresses):
+
+```bash
+soroban contract invoke --id "$DEX_POOL" --network testnet -- balance \
+  --asset "$USDC" --user "$VAULT"
+```
+
+## Security Considerations
+
+1. **Slippage**: `min_out` guard on every DEX supply/withdraw leg.
+2. **Incomplete exit**: rebalance aborts (via `RebalanceFailedEvent`) if a
+   protocol switch cannot withdraw the full deployed balance.
+3. **Pool validation**: `set_dex_pool` probes `balance` before storing the
+   address, rejecting non-conforming contracts.
+4. **Balance-delta accounting**: realized amounts are derived from the vault's
+   own USDC balance, not the pool's return value, so a misreporting pool cannot
+   inflate accounting.
+
+## Status
+
+1. ✅ Research DEX interface (this document)
+2. ✅ `DataKey::DexPool` + owner-configurable pool address
+3. ✅ `supply_to_dex` / `withdraw_from_dex` internal helpers (mirror Blend)
+4. ✅ `rebalance` supports the `dex` protocol with `min_out` slippage protection
+5. ✅ `CurrentProtocol` / `ProtocolChangedEvent` reflect DEX deployments
+6. ✅ Integration tests with mock DEX pool
+7. ✅ `dex-devnet` feature flag for testnet smoke tests
+8. ⏳ Measure gas on testnet
+9. ⏳ Production AMM adapter (two-asset pool zap) — out of scope for this issue
+
+## References
+
+- Soroswap (Soroban AMM): https://docs.soroswap.finance
+- Stellar liquidity pools: https://developers.stellar.org/docs/learn/encyclopedia/sdex/liquidity-on-stellar-sdex-liquidity-pools
+- Soroban SDK Documentation: https://soroban.stellar.org/docs
+- Blend integration: [`BLEND_INTEGRATION_RESEARCH.md`](BLEND_INTEGRATION_RESEARCH.md)

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -332,6 +332,45 @@ pub struct BlendPoolConfiguredEvent {
 }
 ```
 
+### 15b. DexSupplyEvent
+**Topic:** `"dex_sup"`
+
+Emitted when assets are supplied to a DEX liquidity pool (Issue #228).
+
+```rust
+pub struct DexSupplyEvent {
+    pub asset: Address,        // Asset address (USDC)
+    pub amount_actual: i128,   // Amount actually supplied (balance-delta measured)
+    pub success: bool,         // Whether supply succeeded
+}
+```
+
+### 15c. DexWithdrawEvent
+**Topic:** `"dex_wd"`
+
+Emitted when assets are withdrawn from a DEX liquidity pool (Issue #228).
+
+```rust
+pub struct DexWithdrawEvent {
+    pub asset: Address,        // Asset address (USDC)
+    pub amount_actual: i128,   // Amount actually received (balance-delta measured)
+    pub success: bool,         // Whether withdrawal succeeded
+}
+```
+
+### 15d. DexPoolConfiguredEvent
+**Topic:** `"dex_cfg"`
+
+Emitted after `set_dex_pool` updates the configured DEX pool address (Issue #228).
+
+```rust
+pub struct DexPoolConfiguredEvent {
+    pub old_pool: Option<Address>, // Previous pool address, or None on first configuration
+    pub new_pool: Address,         // Newly configured pool address
+    pub owner: Address,            // Owner/admin who triggered the change
+}
+```
+
 ## Upgrade Events
 
 ### 16. UpgradedEvent

--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ Key Functions
 | `deposit` | Any verified user | Deposit USDC into the vault |
 | `withdraw` | User (their own funds) | Withdraw USDC back to wallet |
 | `withdraw_all` | User (their own funds) | Withdraw all USDC by burning all shares |
-| `rebalance` | AI Agent only | Move funds between yield strategies (`protocol`, `expected_apy`, `min_out`; supported: `blend`, `none`) |
+| `rebalance` | AI Agent only | Move funds between yield strategies (`protocol`, `expected_apy`, `min_out`; supported: `blend`, `dex`, `none`) |
+| `set_blend_pool` | Owner only | Configure the Blend lending pool address |
+| `set_dex_pool` | Owner only | Configure the DEX liquidity pool address |
 | `get_balance` | Anyone | Read a user's current balance |
 | `get_total_deposits` | Anyone | Read total vault TVL |
 | `get_exchange_rate` | Anyone | Read current exchange rate (assets per share * 10,000,000) |

--- a/neurowealth-vault/contracts/vault/Cargo.toml
+++ b/neurowealth-vault/contracts/vault/Cargo.toml
@@ -10,6 +10,8 @@ crate-type = ["cdylib", "rlib"]
 default = []
 # Enable `cargo test -p neurowealth-vault --features blend-devnet`
 blend-devnet = []
+# Enable `cargo test -p neurowealth-vault --features dex-devnet`
+dex-devnet = []
 
 [dependencies]
 soroban-sdk = { workspace = true }

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -221,6 +221,10 @@ pub enum VaultError {
     ApprovalTtlTooLow = 44,
     /// Approval TTL is above the allowed ceiling.
     ApprovalTtlTooHigh = 45,
+    /// DEX liquidity pool is not configured.
+    DexPoolNotConfigured = 46,
+    /// Caller is not allowed to set the DEX pool.
+    OnlyOwnerCanSetDexPool = 47,
 }
 
 // ============================================================================
@@ -303,6 +307,10 @@ pub enum DataKey {
     LastRebalanceLedger,
     /// Number of ledgers added to the current ledger for Blend token approvals.
     ApprovalTtl,
+    /// DEX liquidity pool contract address
+    /// The address of the Stellar DEX liquidity pool contract used by the
+    /// Balanced/Growth strategies for on-chain liquidity provision.
+    DexPool,
 }
 
 // ============================================================================
@@ -614,6 +622,51 @@ pub struct BlendPoolConfiguredEvent {
     pub owner: Address,
 }
 
+/// Emitted when assets are supplied to a DEX liquidity pool.
+///
+/// # Topics
+/// - `SymbolShort("dex_sup")` - Event identifier
+#[allow(missing_docs)]
+#[contracttype]
+pub struct DexSupplyEvent {
+    /// The asset address (USDC)
+    pub asset: Address,
+    /// Actual amount transferred to the DEX pool (may be less than requested due to slippage/limits)
+    pub amount_actual: i128,
+    /// Whether the supply was successful
+    pub success: bool,
+}
+
+/// Emitted when assets are withdrawn from a DEX liquidity pool.
+///
+/// # Topics
+/// - `SymbolShort("dex_wd")` - Event identifier
+#[allow(missing_docs)]
+#[contracttype]
+pub struct DexWithdrawEvent {
+    /// The asset address (USDC)
+    pub asset: Address,
+    /// Actual amount received from the DEX pool (may be less than requested due to liquidity)
+    pub amount_actual: i128,
+    /// Whether the withdrawal succeeded
+    pub success: bool,
+}
+
+/// Emitted when the DEX pool address is configured.
+///
+/// # Topics
+/// - `SymbolShort("dex_cfg")` - Event identifier
+#[allow(missing_docs)]
+#[contracttype]
+pub struct DexPoolConfiguredEvent {
+    /// Previous DEX pool address, or None if it was not configured
+    pub old_pool: Option<Address>,
+    /// Newly configured DEX pool address
+    pub new_pool: Address,
+    /// Owner who triggered the configuration change
+    pub owner: Address,
+}
+
 /// Emitted when a rebalance aborts due to a protocol exit failure.
 ///
 /// Emitted instead of panicking so the failure is observable on-chain without
@@ -709,6 +762,9 @@ pub(crate) const TOPIC_UPGRADED: Symbol = symbol_short!("upgraded");
 pub(crate) const TOPIC_BLEND_SUPPLY: Symbol = symbol_short!("blend_sup");
 pub(crate) const TOPIC_BLEND_WITHDRAW: Symbol = symbol_short!("blend_wd");
 pub(crate) const TOPIC_BLEND_POOL_CONFIGURED: Symbol = symbol_short!("blend_cfg");
+pub(crate) const TOPIC_DEX_SUPPLY: Symbol = symbol_short!("dex_sup");
+pub(crate) const TOPIC_DEX_WITHDRAW: Symbol = symbol_short!("dex_wd");
+pub(crate) const TOPIC_DEX_POOL_CONFIGURED: Symbol = symbol_short!("dex_cfg");
 pub(crate) const TOPIC_PROTOCOL_CHANGED: Symbol = symbol_short!("proto_chg");
 pub(crate) const TOPIC_REBALANCE_FAILED: Symbol = symbol_short!("reb_fail");
 
@@ -817,6 +873,105 @@ impl BlendPoolClient {
     }
 
     /// Gets the balance of assets supplied to the Blend pool.
+    fn get_balance(env: &Env, pool_address: &Address, asset: &Address, user: &Address) -> i128 {
+        use soroban_sdk::{vec, IntoVal, Symbol};
+        let args: Vec<Val> = vec![env, asset.into_val(env), user.into_val(env)];
+        env.invoke_contract::<i128>(pool_address, &Symbol::new(env, "balance"), args)
+    }
+}
+
+// ============================================================================
+// DEX LIQUIDITY POOL CLIENT INTERFACE
+// ============================================================================
+
+/// Helper functions for interacting with a Stellar DEX liquidity pool contract.
+///
+/// The vault provides single-asset (USDC) liquidity to a DEX pool to execute the
+/// Balanced/Growth strategies described in the README. The pool is treated as a
+/// single-asset adapter exposing:
+/// - `add_liquidity(from, asset, amount, min_out)` — supply liquidity after USDC `approve`
+/// - `remove_liquidity(to, asset, amount, min_out)` — withdraw liquidity
+/// - `balance(asset, user)` — the vault's current liquidity position
+///
+/// Actual amounts are derived from the vault's USDC balance delta, mirroring the
+/// Blend integration so partial fills (slippage) are observable on-chain.
+///
+/// See `DEX_INTEGRATION.md` for the full interface research and rationale.
+struct DexPoolClient;
+
+impl DexPoolClient {
+    /// Supplies assets to the DEX liquidity pool via `add_liquidity`.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `pool_address` - The DEX pool contract address
+    /// * `asset` - The asset token address (USDC)
+    /// * `amount` - Amount of assets to supply
+    /// * `min_out` - Minimum accepted liquidity (forwarded to the pool for slippage protection)
+    /// * `to` - Address providing/owning the liquidity position (vault address)
+    ///
+    /// # Returns
+    /// The amount of assets actually supplied (derived from the vault balance delta).
+    fn supply(
+        env: &Env,
+        pool_address: &Address,
+        asset: &Address,
+        amount: i128,
+        min_out: i128,
+        to: &Address,
+    ) -> i128 {
+        use soroban_sdk::{vec, IntoVal, Symbol};
+
+        let token_client = token::Client::new(env, asset);
+        let vault_address = env.current_contract_address();
+        let balance_before = token_client.balance(&vault_address);
+
+        // add_liquidity(from: Address, asset: Address, amount: i128, min_out: i128)
+        let args: Vec<Val> = vec![
+            env,
+            to.into_val(env),     // from: vault address (liquidity provider)
+            asset.into_val(env),  // asset: USDC token
+            amount.into_val(env), // amount: desired liquidity
+            min_out.into_val(env),
+        ];
+
+        env.invoke_contract::<Val>(pool_address, &Symbol::new(env, "add_liquidity"), args);
+
+        let balance_after = token_client.balance(&vault_address);
+        balance_before.saturating_sub(balance_after)
+    }
+
+    /// Removes assets from the DEX liquidity pool via `remove_liquidity`.
+    fn withdraw(
+        env: &Env,
+        pool_address: &Address,
+        asset: &Address,
+        amount: i128,
+        min_out: i128,
+        to: &Address,
+    ) -> i128 {
+        use soroban_sdk::{vec, IntoVal, Symbol};
+
+        let token_client = token::Client::new(env, asset);
+        let vault_address = env.current_contract_address();
+        let balance_before = token_client.balance(&vault_address);
+
+        // remove_liquidity(to: Address, asset: Address, amount: i128, min_out: i128)
+        let args: Vec<Val> = vec![
+            env,
+            to.into_val(env),     // to: vault address (receives withdrawn assets)
+            asset.into_val(env),  // asset: USDC token
+            amount.into_val(env), // amount: liquidity to remove
+            min_out.into_val(env),
+        ];
+
+        env.invoke_contract::<Val>(pool_address, &Symbol::new(env, "remove_liquidity"), args);
+
+        let balance_after = token_client.balance(&vault_address);
+        balance_after.saturating_sub(balance_before)
+    }
+
+    /// Gets the vault's current liquidity position in the DEX pool.
     fn get_balance(env: &Env, pool_address: &Address, asset: &Address, user: &Address) -> i128 {
         use soroban_sdk::{vec, IntoVal, Symbol};
         let args: Vec<Val> = vec![env, asset.into_val(env), user.into_val(env)];
@@ -1145,22 +1300,23 @@ impl NeuroWealthVault {
         // Initially, we assume we can fulfill the whole request.
         let mut actual_to_return = amount;
 
-        if current_protocol == symbol_short!("blend") {
+        if current_protocol == symbol_short!("blend") || current_protocol == symbol_short!("dex") {
             // Check vault's USDC balance
             let vault_balance = token_client.balance(&env.current_contract_address());
 
-            // If vault doesn't have enough USDC, try to withdraw from Blend
+            // If vault doesn't have enough USDC, try to withdraw from the active protocol
             if vault_balance < amount {
                 // Calculate how much we need to withdraw
                 let needed = amount
                     .checked_sub(vault_balance)
                     .expect("vault: math error");
 
-                // Attempt to withdraw from Blend
+                // Attempt to withdraw from the active protocol (Blend or DEX).
                 // If this returns less than needed, we will reconcile below
-                let _withdrawn = Self::withdraw_from_blend(&env, needed, 0);
+                let _withdrawn =
+                    Self::withdraw_amount_from_protocol(&env, &current_protocol, needed, 0);
 
-                // RECONCILIATION: Check actual available USDC after Blend withdrawal.
+                // RECONCILIATION: Check actual available USDC after the withdrawal.
                 // We cap the withdrawal to what the vault actually has available.
                 let available_usdc = token_client.balance(&env.current_contract_address());
                 actual_to_return = min(amount, available_usdc);
@@ -1324,19 +1480,19 @@ impl NeuroWealthVault {
         let mut usdc_to_return = entitled_amount;
         let mut shares_to_burn = user_shares;
 
-        if current_protocol == symbol_short!("blend") {
+        if current_protocol == symbol_short!("blend") || current_protocol == symbol_short!("dex") {
             // Check vault's USDC balance
             let vault_balance = token_client.balance(&env.current_contract_address());
 
-            // If vault doesn't have enough USDC, try to withdraw from Blend
+            // If vault doesn't have enough USDC, try to withdraw from the active protocol
             if vault_balance < entitled_amount {
-                // Attempt to withdraw from Blend
+                // Attempt to withdraw from the active protocol (Blend or DEX)
                 let needed = entitled_amount
                     .checked_sub(vault_balance)
                     .expect("vault: math error");
-                let _ = Self::withdraw_from_blend(&env, needed, 0);
+                let _ = Self::withdraw_amount_from_protocol(&env, &current_protocol, needed, 0);
 
-                // RECONCILIATION: Check actual available USDC after potential Blend withdrawal
+                // RECONCILIATION: Check actual available USDC after the potential withdrawal
                 let available_usdc = token_client.balance(&env.current_contract_address());
 
                 // If vault has less than entitled, we cap the withdrawal.
@@ -1409,7 +1565,7 @@ impl NeuroWealthVault {
     /// # Arguments
     ///
     /// * `env` - The Soroban environment.
-    /// * `protocol` - The target protocol to move funds to ("blend" or "none").
+    /// * `protocol` - The target protocol to move funds to ("blend", "dex", or "none").
     /// * `expected_apy` - Expected APY in basis points (e.g., 850 = 8.5%).
     /// * `min_out` - Minimum assets expected to remain (slippage protection).
     ///
@@ -1423,8 +1579,8 @@ impl NeuroWealthVault {
     /// - `RebalanceEvent`
     /// - `ProtocolChangedEvent`
     /// - `RebalanceFailedEvent` (if exit fails)
-    /// - `BlendWithdrawEvent`
-    /// - `BlendSupplyEvent`
+    /// - `BlendWithdrawEvent` / `BlendSupplyEvent` (Blend legs)
+    /// - `DexWithdrawEvent` / `DexSupplyEvent` (DEX legs)
     ///
     /// # Errors
     ///
@@ -1439,6 +1595,7 @@ impl NeuroWealthVault {
     /// - If slippage protection (min_out) is triggered.
     /// - If protocol interaction fails.
     /// - If Blend pool is not configured and protocol is "blend"
+    /// - If the DEX pool is not configured and protocol is "dex"
     /// - If a leg moves fewer assets than `min_out` when `min_out > 0`
     pub fn rebalance(env: Env, protocol: Symbol, expected_apy: i128, min_out: i128) {
         Self::require_initialized(&env);
@@ -1474,7 +1631,12 @@ impl NeuroWealthVault {
         }
 
         // Validate protocol against allowlist
-        let supported_protocols = vec![&env, symbol_short!("blend"), symbol_short!("none")];
+        let supported_protocols = vec![
+            &env,
+            symbol_short!("blend"),
+            symbol_short!("dex"),
+            symbol_short!("none"),
+        ];
         if !supported_protocols.contains(protocol.clone()) {
             panic_with_error!(&env, VaultError::UnsupportedProtocol);
         }
@@ -1544,6 +1706,47 @@ impl NeuroWealthVault {
                 // Noop: no funds to supply, but protocol target is blend.
                 // Update CurrentProtocol so tracking matches intent (Issue #146).
                 Self::set_current_protocol(&env, symbol_short!("blend"));
+                status = symbol_short!("noop");
+            }
+
+            env.events().publish(
+                (TOPIC_REBALANCE,),
+                RebalanceEvent {
+                    protocol,
+                    expected_apy,
+                    status,
+                    amount_attempted,
+                    amount_moved,
+                    amount_supplied,
+                    amount_withdrawn,
+                },
+            );
+        } else if protocol == symbol_short!("dex") {
+            if !env.storage().instance().has(&DataKey::DexPool) {
+                panic_with_error!(&env, VaultError::DexPoolNotConfigured);
+            }
+
+            let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
+            let token_client = token::Client::new(&env, &usdc_token);
+            let vault_balance = token_client.balance(&env.current_contract_address());
+
+            let mut status = symbol_short!("success");
+
+            if vault_balance > 0 {
+                amount_attempted = amount_attempted.saturating_add(vault_balance);
+                let supplied = Self::supply_to_dex(&env, vault_balance, min_out);
+                amount_supplied = amount_supplied.saturating_add(supplied);
+                amount_moved = amount_moved.saturating_add(supplied);
+
+                if supplied == 0 {
+                    status = symbol_short!("failed");
+                } else if supplied < vault_balance {
+                    status = symbol_short!("partial");
+                }
+            } else if amount_moved == 0 {
+                // Noop: no funds to supply, but protocol target is dex.
+                // Update CurrentProtocol so tracking matches intent (mirrors Blend, Issue #146).
+                Self::set_current_protocol(&env, symbol_short!("dex"));
                 status = symbol_short!("noop");
             }
 
@@ -2346,6 +2549,68 @@ impl NeuroWealthVault {
         env.events().publish(
             (TOPIC_BLEND_POOL_CONFIGURED,),
             BlendPoolConfiguredEvent {
+                old_pool,
+                new_pool: pool_address.clone(),
+                owner: owner.clone(),
+            },
+        );
+    }
+
+    /// Configures the DEX liquidity pool contract address (owner only).
+    ///
+    /// Mirrors [`Self::set_blend_pool`]. The pool interface is validated by probing
+    /// its `balance` entrypoint before the address is stored, so an invalid pool
+    /// address is rejected at configuration time. `CurrentProtocol` is initialized
+    /// to `"none"` when not already set.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment.
+    /// * `owner` - The owner address (must authorize this call).
+    /// * `pool_address` - The DEX liquidity pool contract address.
+    ///
+    /// # Events
+    ///
+    /// Emits:
+    /// - `DexPoolConfiguredEvent`
+    ///
+    /// # Panics
+    ///
+    /// - If the caller is not the owner.
+    /// - If the provided `pool_address` is not a valid DEX pool contract.
+    pub fn set_dex_pool(env: Env, owner: Address, pool_address: Address) {
+        Self::require_initialized(&env);
+        owner.require_auth();
+        let stored_owner: Address = env.storage().instance().get(&DataKey::Owner).unwrap();
+        Self::require(
+            &env,
+            owner == stored_owner,
+            VaultError::OnlyOwnerCanSetDexPool,
+        );
+
+        // Validate the pool interface by probing the `balance` function. If the
+        // address is not a valid DEX pool contract the invocation panics here,
+        // rejecting the registration before the address is stored.
+        let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
+        let vault_address = env.current_contract_address();
+        DexPoolClient::get_balance(&env, &pool_address, &usdc_token, &vault_address);
+
+        let old_pool: Option<Address> = env.storage().instance().get(&DataKey::DexPool);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::DexPool, &pool_address);
+
+        // Initialize CurrentProtocol to "none" if not set
+        if !env.storage().instance().has(&DataKey::CurrentProtocol) {
+            env.storage()
+                .instance()
+                .set(&DataKey::CurrentProtocol, &symbol_short!("none"));
+        }
+
+        env.events().publish(
+            (TOPIC_DEX_POOL_CONFIGURED,),
+            DexPoolConfiguredEvent {
                 old_pool,
                 new_pool: pool_address.clone(),
                 owner: owner.clone(),
@@ -3369,6 +3634,20 @@ impl NeuroWealthVault {
         env.storage().instance().get(&DataKey::BlendPool)
     }
 
+    /// Returns the DEX liquidity pool contract address, if configured.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment.
+    ///
+    /// # Returns
+    ///
+    /// Returns the DEX pool contract address, or None if not configured.
+    pub fn get_dex_pool(env: Env) -> Option<Address> {
+        Self::require_initialized(&env);
+        env.storage().instance().get(&DataKey::DexPool)
+    }
+
     /// Returns the ledger TTL used when approving Blend token spend.
     pub fn get_blend_approval_ttl(env: Env) -> u32 {
         Self::require_initialized(&env);
@@ -3983,6 +4262,202 @@ impl NeuroWealthVault {
         withdrawn
     }
 
+    /// Internal helper: Supplies USDC to the DEX liquidity pool.
+    ///
+    /// Mirrors [`Self::supply_to_blend`]: approves the pool to pull USDC, authorizes
+    /// the cross-contract `add_liquidity` call (with its `transfer_from`
+    /// sub-invocation), then supplies. The `min_out` floor is enforced both by
+    /// forwarding it to the pool and by [`Self::require_min_out`] on the realized
+    /// amount, giving slippage protection on the DEX leg.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `amount` - Amount of USDC to supply
+    /// * `min_out` - Minimum amount that must be supplied (0 = no check)
+    ///
+    /// # Returns
+    /// The amount actually supplied (may be less than requested).
+    ///
+    /// # Error Handling
+    /// - Returns 0 if amount <= 0
+    /// - Panics if the DEX pool address is not configured
+    /// - Panics with `MinOutNotMet` if the realized amount is below `min_out`
+    /// - Emits `DexSupplyEvent` with success status
+    fn supply_to_dex(env: &Env, amount: i128, min_out: i128) -> i128 {
+        if amount <= 0 {
+            return 0;
+        }
+
+        let pool_address: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::DexPool)
+            .expect("vault: dex pool not configured");
+
+        let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
+        let vault_address = env.current_contract_address();
+        let approval_ledger = env
+            .ledger()
+            .sequence()
+            .saturating_add(Self::get_approval_ttl_internal(env));
+
+        let approval_args: Vec<Val> = vec![
+            env,
+            vault_address.clone().into_val(env),
+            pool_address.clone().into_val(env),
+            amount.into_val(env),
+            approval_ledger.into_val(env),
+        ];
+        let add_liquidity_args: Vec<Val> = vec![
+            env,
+            vault_address.clone().into_val(env),
+            usdc_token.clone().into_val(env),
+            amount.into_val(env),
+            min_out.into_val(env),
+        ];
+        let transfer_from_args: Vec<Val> = vec![
+            env,
+            pool_address.clone().into_val(env),
+            vault_address.clone().into_val(env),
+            pool_address.clone().into_val(env),
+            amount.into_val(env),
+        ];
+
+        // Approve the DEX pool to spend USDC.
+        let token_client = token::Client::new(env, &usdc_token);
+        env.authorize_as_current_contract(vec![
+            env,
+            InvokerContractAuthEntry::Contract(SubContractInvocation {
+                context: ContractContext {
+                    contract: usdc_token.clone(),
+                    fn_name: Symbol::new(env, "approve"),
+                    args: approval_args,
+                },
+                sub_invocations: vec![env],
+            }),
+        ]);
+        token_client.approve(&vault_address, &pool_address, &amount, &approval_ledger);
+
+        // Authorize and execute the DEX add_liquidity (pulls USDC via transfer_from).
+        env.authorize_as_current_contract(vec![
+            env,
+            InvokerContractAuthEntry::Contract(SubContractInvocation {
+                context: ContractContext {
+                    contract: pool_address.clone(),
+                    fn_name: Symbol::new(env, "add_liquidity"),
+                    args: add_liquidity_args.clone(),
+                },
+                sub_invocations: vec![
+                    env,
+                    InvokerContractAuthEntry::Contract(SubContractInvocation {
+                        context: ContractContext {
+                            contract: usdc_token.clone(),
+                            fn_name: Symbol::new(env, "transfer_from"),
+                            args: transfer_from_args,
+                        },
+                        sub_invocations: vec![env],
+                    }),
+                ],
+            }),
+        ]);
+
+        let supplied = DexPoolClient::supply(
+            env,
+            &pool_address,
+            &usdc_token,
+            amount,
+            min_out,
+            &vault_address,
+        );
+
+        Self::require_min_out(env, supplied, min_out, "dex supply");
+
+        if supplied > 0 {
+            Self::set_current_protocol(env, symbol_short!("dex"));
+        }
+
+        env.events().publish(
+            (TOPIC_DEX_SUPPLY,),
+            DexSupplyEvent {
+                asset: usdc_token,
+                amount_actual: supplied,
+                success: supplied > 0,
+            },
+        );
+
+        supplied
+    }
+
+    /// Internal helper: Withdraws USDC from the DEX liquidity pool.
+    ///
+    /// Mirrors [`Self::withdraw_from_blend`]. When `amount == 0` the full deployed
+    /// position is withdrawn.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `amount` - Amount of USDC to withdraw (0 = withdraw all)
+    /// * `min_out` - Minimum amount that must be withdrawn (0 = no check)
+    ///
+    /// # Returns
+    /// The amount actually withdrawn.
+    ///
+    /// # Error Handling
+    /// - Returns 0 if there is nothing to withdraw
+    /// - Panics if the DEX pool address is not configured
+    /// - Panics with `MinOutNotMet` if the realized amount is below `min_out`
+    /// - Emits `DexWithdrawEvent` with success status and actual amount received
+    fn withdraw_from_dex(env: &Env, amount: i128, min_out: i128) -> i128 {
+        let pool_address: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::DexPool)
+            .expect("vault: dex pool not configured");
+
+        let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
+        let vault_address = env.current_contract_address();
+
+        // If amount is 0, withdraw the full deployed position.
+        let amount_to_withdraw = if amount == 0 {
+            DexPoolClient::get_balance(env, &pool_address, &usdc_token, &vault_address)
+        } else {
+            amount
+        };
+
+        if amount_to_withdraw <= 0 {
+            return 0;
+        }
+
+        let withdrawn = DexPoolClient::withdraw(
+            env,
+            &pool_address,
+            &usdc_token,
+            amount_to_withdraw,
+            min_out,
+            &vault_address,
+        );
+
+        Self::require_min_out(env, withdrawn, min_out, "dex withdraw");
+
+        if withdrawn > 0 {
+            let remaining =
+                DexPoolClient::get_balance(env, &pool_address, &usdc_token, &vault_address);
+            if remaining == 0 {
+                Self::set_current_protocol(env, symbol_short!("none"));
+            }
+        }
+
+        env.events().publish(
+            (TOPIC_DEX_WITHDRAW,),
+            DexWithdrawEvent {
+                asset: usdc_token,
+                amount_actual: withdrawn,
+                success: withdrawn > 0,
+            },
+        );
+
+        withdrawn
+    }
+
     /// Internal helper: Withdraws from the current protocol if funds are deployed.
     ///
     /// This function checks the current protocol and withdraws funds if necessary.
@@ -4002,6 +4477,31 @@ impl NeuroWealthVault {
 
         if current_protocol == *protocol && *protocol == symbol_short!("blend") {
             Self::withdraw_from_blend(env, 0, min_out)
+        } else if current_protocol == *protocol && *protocol == symbol_short!("dex") {
+            Self::withdraw_from_dex(env, 0, min_out)
+        } else {
+            0
+        }
+    }
+
+    /// Internal helper: Withdraws a specific `amount` from the active protocol.
+    ///
+    /// Used by user-facing `withdraw`/`withdraw_all` to pull only the liquidity
+    /// needed to satisfy a redemption (as opposed to [`Self::withdraw_from_protocol`],
+    /// which exits the full position). Dispatches to the protocol-specific helper.
+    ///
+    /// # Returns
+    /// The amount actually withdrawn, or 0 if `protocol` holds no funds.
+    fn withdraw_amount_from_protocol(
+        env: &Env,
+        protocol: &Symbol,
+        amount: i128,
+        min_out: i128,
+    ) -> i128 {
+        if *protocol == symbol_short!("blend") {
+            Self::withdraw_from_blend(env, amount, min_out)
+        } else if *protocol == symbol_short!("dex") {
+            Self::withdraw_from_dex(env, amount, min_out)
         } else {
             0
         }
@@ -4025,6 +4525,16 @@ impl NeuroWealthVault {
                     env.storage().instance().get(&DataKey::UsdcToken).unwrap();
                 let vault_address = env.current_contract_address();
                 BlendPoolClient::get_balance(env, &pool, &usdc_token, &vault_address)
+            } else {
+                0
+            }
+        } else if *protocol == symbol_short!("dex") {
+            let pool_address: Option<Address> = env.storage().instance().get(&DataKey::DexPool);
+            if let Some(pool) = pool_address {
+                let usdc_token: Address =
+                    env.storage().instance().get(&DataKey::UsdcToken).unwrap();
+                let vault_address = env.current_contract_address();
+                DexPoolClient::get_balance(env, &pool, &usdc_token, &vault_address)
             } else {
                 0
             }

--- a/neurowealth-vault/contracts/vault/src/tests/mod.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/mod.rs
@@ -8,6 +8,9 @@ mod test_blend_integration;
 mod test_budget;
 mod test_checked_arithmetic;
 mod test_deposit;
+#[cfg(feature = "dex-devnet")]
+mod test_dex_devnet;
+mod test_dex_integration;
 mod test_event_schema;
 mod test_events;
 mod test_exchange_rate;

--- a/neurowealth-vault/contracts/vault/src/tests/test_dex_devnet.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_dex_devnet.rs
@@ -1,0 +1,31 @@
+//! DEX production-interface tests (enabled with `--features dex-devnet`, #228).
+//!
+//! Uses the in-env mock pool that implements the same entrypoints expected from a
+//! Stellar DEX liquidity pool (`add_liquidity`, `remove_liquidity`, `balance`).
+//! For a live network smoke test, invoke these against `DEX_POOL_ADDRESS` via the
+//! Soroban CLI (see `DEX_INTEGRATION.md`).
+
+#![cfg(all(test, feature = "dex-devnet"))]
+
+use super::utils::*;
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+#[test]
+fn test_dex_production_entrypoints_on_mock_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, usdc_token, dex_pool) = setup_vault_with_token_and_dex(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_dex_pool(&owner, &dex_pool);
+
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, 5_000_000_i128);
+
+    client.rebalance(&symbol_short!("dex"), &850_i128, &0_i128);
+    assert_eq!(client.get_current_protocol(), symbol_short!("dex"));
+
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
+    assert_eq!(client.get_current_protocol(), symbol_short!("none"));
+}

--- a/neurowealth-vault/contracts/vault/src/tests/test_dex_integration.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_dex_integration.rs
@@ -1,0 +1,210 @@
+#![cfg(test)]
+
+//! DEX liquidity pool integration tests (Issue #228).
+//!
+//! Mirrors `test_blend_integration.rs` but exercises the `dex` protocol path:
+//! supplying to / withdrawing from a configured DEX pool via `rebalance`,
+//! `CurrentProtocol`/`ProtocolChangedEvent` tracking, `min_out` slippage
+//! enforcement, protocol switching, and user withdrawals that pull from the DEX.
+
+use super::utils::*;
+use soroban_sdk::{
+    symbol_short, testutils::Address as _, vec, Address, Env, IntoVal, Symbol, Val, Vec,
+};
+
+#[test]
+fn test_dex_integration_supply_via_rebalance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, _agent, owner, usdc_token, dex_pool) = setup_vault_with_token_and_dex(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    // 1. Give the vault some USDC.
+    let deposit_amount = 100_000_000; // 100 USDC
+    token_client.mint(&vault_id, &deposit_amount);
+    assert_eq!(token_client.balance(&vault_id), deposit_amount);
+
+    // 2. Configure the DEX pool.
+    vault_client.set_dex_pool(&owner, &dex_pool);
+    assert_eq!(vault_client.get_dex_pool(), Some(dex_pool.clone()));
+
+    // 3. Rebalance into the DEX pool.
+    let protocol = Symbol::new(&env, "dex");
+    vault_client.rebalance(&protocol, &850, &0_i128);
+
+    // 4. Funds moved to the DEX, protocol tracked as "dex".
+    assert_eq!(token_client.balance(&vault_id), 0);
+    assert_eq!(token_client.balance(&dex_pool), deposit_amount);
+    assert_eq!(vault_client.get_current_protocol(), protocol);
+
+    // 5. Events: dex_sup and proto_chg.
+    let events = env.events().all();
+    let dex_sup_events = find_events_by_topic(events.clone(), &env, Symbol::new(&env, "dex_sup"));
+    assert_eq!(dex_sup_events.len(), 1);
+    let proto_chg_events = find_events_by_topic(events, &env, Symbol::new(&env, "proto_chg"));
+    assert_eq!(proto_chg_events.len(), 1);
+}
+
+#[test]
+fn test_dex_integration_withdraw_via_rebalance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, _agent, owner, usdc_token, dex_pool) = setup_vault_with_token_and_dex(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    vault_client.set_dex_pool(&owner, &dex_pool);
+
+    // 1. Supply to the DEX.
+    let amount = 50_000_000;
+    token_client.mint(&vault_id, &amount);
+    vault_client.rebalance(&Symbol::new(&env, "dex"), &850, &0_i128);
+    assert_eq!(token_client.balance(&dex_pool), amount);
+
+    // 2. Exit the DEX by rebalancing to "none".
+    vault_client.rebalance(&Symbol::new(&env, "none"), &0, &0_i128);
+
+    // 3. Funds restored, protocol back to "none".
+    assert_eq!(token_client.balance(&vault_id), amount);
+    assert_eq!(token_client.balance(&dex_pool), 0);
+    assert_eq!(
+        vault_client.get_current_protocol(),
+        Symbol::new(&env, "none")
+    );
+
+    // 4. Event: dex_wd.
+    let events = env.events().all();
+    let dex_wd_events = find_events_by_topic(events, &env, Symbol::new(&env, "dex_wd"));
+    assert_eq!(dex_wd_events.len(), 1);
+}
+
+#[test]
+fn test_dex_integration_balance_read() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, _agent, owner, usdc_token, dex_pool) = setup_vault_with_token_and_dex(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    vault_client.set_dex_pool(&owner, &dex_pool);
+
+    let amount = 75_000_000;
+    token_client.mint(&vault_id, &amount);
+    vault_client.rebalance(&Symbol::new(&env, "dex"), &850, &0_i128);
+
+    // The pool reports the vault's supplied position via `balance(asset, user)`.
+    let args: Vec<Val> = vec![&env, usdc_token.into_val(&env), vault_id.into_val(&env)];
+    let balance: i128 = env.invoke_contract(&dex_pool, &Symbol::new(&env, "balance"), args);
+    assert_eq!(balance, amount);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #46)")]
+fn test_rebalance_dex_without_pool_configured_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, _agent, _owner, usdc_token, _dex_pool) = setup_vault_with_token_and_dex(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    token_client.mint(&vault_id, &10_000_000);
+    // No set_dex_pool — DexPoolNotConfigured (#46).
+    vault_client.rebalance(&Symbol::new(&env, "dex"), &850, &0_i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #47)")]
+fn test_set_dex_pool_non_owner_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, _agent, _owner, _usdc_token, dex_pool) = setup_vault_with_token_and_dex(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+
+    let stranger = Address::generate(&env);
+    // OnlyOwnerCanSetDexPool (#47).
+    vault_client.set_dex_pool(&stranger, &dex_pool);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #42)")]
+fn test_dex_supply_min_out_enforced() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, _agent, owner, usdc_token, dex_pool) = setup_vault_with_token_and_dex(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+    let dex_client = MockDexPoolClient::new(&env, &dex_pool);
+
+    vault_client.set_dex_pool(&owner, &dex_pool);
+
+    // Mint 100 USDC but cap the pool to accept only 40 — a partial fill.
+    token_client.mint(&vault_id, &100_000_000);
+    dex_client.set_max_supply_limit(&40_000_000);
+
+    // Require at least 50 USDC supplied: the 40 USDC fill trips MinOutNotMet (#42).
+    vault_client.rebalance(&Symbol::new(&env, "dex"), &850, &50_000_000);
+}
+
+#[test]
+fn test_rebalance_switch_blend_to_dex() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Vault with both a Blend pool and a DEX pool.
+    let (vault_id, _agent, owner, usdc_token) = setup_vault_with_token(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+    let blend_pool = env.register_contract(None, MockBlendPool);
+    let dex_pool = env.register_contract(None, MockDexPool);
+
+    vault_client.set_blend_pool(&owner, &blend_pool);
+    vault_client.set_dex_pool(&owner, &dex_pool);
+
+    // 1. Deploy to Blend.
+    let amount = 60_000_000;
+    token_client.mint(&vault_id, &amount);
+    vault_client.rebalance(&symbol_short!("blend"), &850, &0_i128);
+    assert_eq!(token_client.balance(&blend_pool), amount);
+    assert_eq!(vault_client.get_current_protocol(), symbol_short!("blend"));
+
+    // 2. Switch to the DEX — exits Blend, then supplies the DEX.
+    vault_client.rebalance(&symbol_short!("dex"), &900, &0_i128);
+
+    assert_eq!(token_client.balance(&blend_pool), 0);
+    assert_eq!(token_client.balance(&dex_pool), amount);
+    assert_eq!(vault_client.get_current_protocol(), symbol_short!("dex"));
+}
+
+#[test]
+fn test_user_withdraw_pulls_from_dex() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, _agent, owner, usdc_token, dex_pool) = setup_vault_with_token_and_dex(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    vault_client.set_dex_pool(&owner, &dex_pool);
+
+    // User deposits, agent deploys everything to the DEX.
+    let user = Address::generate(&env);
+    let amount = 80_000_000;
+    mint_and_deposit(&env, &vault_client, &usdc_token, &user, amount);
+    vault_client.rebalance(&Symbol::new(&env, "dex"), &850, &0_i128);
+    assert_eq!(token_client.balance(&vault_id), 0);
+    assert_eq!(token_client.balance(&dex_pool), amount);
+
+    // User withdraws — the vault pulls the needed liquidity back from the DEX.
+    let withdraw_amount = 30_000_000;
+    vault_client.withdraw(&user, &withdraw_amount);
+
+    assert_eq!(token_client.balance(&user), withdraw_amount);
+    assert_eq!(token_client.balance(&dex_pool), amount - withdraw_amount);
+}

--- a/neurowealth-vault/contracts/vault/src/tests/utils.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/utils.rs
@@ -32,6 +32,17 @@ enum BlendMockDataKey {
     MaxWithdrawLimit,
 }
 
+#[derive(Clone)]
+#[contracttype]
+enum DexMockDataKey {
+    /// Liquidity supplied by a provider for a given asset.
+    Supplied(Address),
+    /// Configurable max supply limit (0 = no limit, use requested amount)
+    MaxSupplyLimit,
+    /// Configurable max withdraw limit per transaction (0 = no limit)
+    MaxWithdrawLimit,
+}
+
 pub mod token {
     use super::*;
 
@@ -345,6 +356,139 @@ pub mod blend {
 
 pub use blend::{MockBlendPool, MockBlendPoolClient};
 
+pub mod dex {
+    use super::*;
+
+    /// Minimal single-asset DEX liquidity pool mock.
+    ///
+    /// Implements the same entrypoints the vault's `DexPoolClient` calls:
+    /// `add_liquidity`, `remove_liquidity`, and `balance`. It pulls/returns the
+    /// underlying USDC via `transfer_from`/`transfer` (mirroring the Blend mock)
+    /// and supports configurable supply/withdraw limits to simulate slippage and
+    /// partial fills for `min_out` testing.
+    #[contract]
+    pub struct MockDexPool;
+
+    #[contractimpl]
+    impl MockDexPool {
+        pub fn add_liquidity(
+            env: Env,
+            from: Address,
+            asset: Address,
+            amount: i128,
+            _min_out: i128,
+        ) -> i128 {
+            from.require_auth();
+            assert!(amount > 0, "amount must be positive");
+
+            let token_client = TestTokenClient::new(&env, &asset);
+            let pool = env.current_contract_address();
+            let allowance = token_client.allowance(&from, &pool);
+            assert!(allowance >= amount, "expected allowance before pool pull");
+
+            // Respect a configured supply limit to simulate slippage / shortfall.
+            let max_supply_limit: i128 = env
+                .storage()
+                .persistent()
+                .get(&DexMockDataKey::MaxSupplyLimit)
+                .unwrap_or(0);
+
+            let actual_amount = if max_supply_limit < 0 {
+                0
+            } else if max_supply_limit > 0 {
+                core::cmp::min(amount, max_supply_limit)
+            } else {
+                amount
+            };
+
+            if actual_amount > 0 {
+                token_client.transfer_from(&pool, &from, &pool, &actual_amount);
+
+                let supplied: i128 = env
+                    .storage()
+                    .persistent()
+                    .get(&DexMockDataKey::Supplied(asset.clone()))
+                    .unwrap_or(0);
+                env.storage().persistent().set(
+                    &DexMockDataKey::Supplied(asset),
+                    &(supplied + actual_amount),
+                );
+            }
+
+            actual_amount
+        }
+
+        pub fn remove_liquidity(
+            env: Env,
+            to: Address,
+            asset: Address,
+            amount: i128,
+            _min_out: i128,
+        ) -> i128 {
+            to.require_auth();
+            assert!(amount > 0, "amount must be positive");
+
+            let supplied: i128 = env
+                .storage()
+                .persistent()
+                .get(&DexMockDataKey::Supplied(asset.clone()))
+                .unwrap_or(0);
+            let amount_to_withdraw = core::cmp::min(amount, supplied);
+
+            // Respect a configured withdraw limit to simulate stuck liquidity.
+            let max_withdraw_limit: i128 = env
+                .storage()
+                .persistent()
+                .get(&DexMockDataKey::MaxWithdrawLimit)
+                .unwrap_or(0);
+
+            let actual_withdraw = if max_withdraw_limit > 0 {
+                core::cmp::min(amount_to_withdraw, max_withdraw_limit)
+            } else {
+                amount_to_withdraw
+            };
+
+            if actual_withdraw > 0 {
+                let token_client = TestTokenClient::new(&env, &asset);
+                token_client.transfer(&env.current_contract_address(), &to, &actual_withdraw);
+
+                env.storage().persistent().set(
+                    &DexMockDataKey::Supplied(asset),
+                    &(supplied - actual_withdraw),
+                );
+            }
+
+            actual_withdraw
+        }
+
+        /// Returns the liquidity position held for `_user` in `asset`.
+        pub fn balance(env: Env, asset: Address, _user: Address) -> i128 {
+            env.storage()
+                .persistent()
+                .get(&DexMockDataKey::Supplied(asset))
+                .unwrap_or(0)
+        }
+
+        /// Sets a max supply limit to simulate slippage / partial fills.
+        /// 0 = no limit (default behavior); negative = reject all supply.
+        pub fn set_max_supply_limit(env: Env, limit: i128) {
+            env.storage()
+                .persistent()
+                .set(&DexMockDataKey::MaxSupplyLimit, &limit);
+        }
+
+        /// Sets a max withdraw limit to simulate stuck liquidity.
+        /// 0 = no limit (default behavior).
+        pub fn set_max_withdraw_limit(env: Env, limit: i128) {
+            env.storage()
+                .persistent()
+                .set(&DexMockDataKey::MaxWithdrawLimit, &limit);
+        }
+    }
+}
+
+pub use dex::{MockDexPool, MockDexPoolClient};
+
 // ============================================================================
 // TEST SETUP FUNCTIONS
 // ============================================================================
@@ -382,6 +526,18 @@ pub fn setup_vault_with_token_and_blend(
     let blend_pool = env.register_contract(None, MockBlendPool);
 
     (contract_id, agent, owner, usdc_token, blend_pool)
+}
+
+/// Sets up a vault with a real deployed TestToken and a MockDexPool.
+///
+/// Returns `(vault_id, agent, owner, usdc_token, dex_pool)`.
+pub fn setup_vault_with_token_and_dex(
+    env: &Env,
+) -> (Address, Address, Address, Address, Address) {
+    let (contract_id, agent, owner, usdc_token) = setup_vault_with_token(env);
+    let dex_pool = env.register_contract(None, MockDexPool);
+
+    (contract_id, agent, owner, usdc_token, dex_pool)
 }
 
 // ============================================================================


### PR DESCRIPTION
<!--
TEMPORARY FILE — paste the contents below into the GitHub PR description, then delete this file.
Open the PR FROM:  xeladev4:feat/228-dex-liquidity-pool-integration
Base branch:       develop (per CONTRIBUTING.md; use main if develop is unavailable on upstream)
-->

# DEX liquidity pool integration (Phase 2)

Closes #228 

## Summary

Adds Stellar DEX liquidity pool support to the vault alongside the existing Blend
integration, implementing the on-chain side of the **Balanced** and **Growth**
strategies described in the README (lending + DEX liquidity provision). The agent
can now `rebalance` vault USDC into and out of a configured DEX pool with
`min_out` slippage protection, and `CurrentProtocol` / `ProtocolChangedEvent`
reflect DEX deployments.

The DEX path mirrors the established Blend patterns (approve →
`authorize_as_current_contract` → cross-contract call → balance-delta accounting),
so it reuses the same security and slippage conventions.

## Changes

**Contract (`neurowealth-vault/contracts/vault/src/lib.rs`)**
- New `DataKey::DexPool` plus owner-only `set_dex_pool` / `get_dex_pool`
  (pool interface validated by probing `balance` before the address is stored).
- New `DexPoolClient` (`add_liquidity` / `remove_liquidity` / `balance`) and
  internal `supply_to_dex` / `withdraw_from_dex` helpers mirroring the Blend ones.
- `rebalance` accepts the `"dex"` protocol symbol; allowlist is now
  `blend` / `dex` / `none`. Switching protocols exits the source first; an
  incomplete exit emits `RebalanceFailedEvent` and aborts without mutating state.
- `min_out` slippage floor enforced on every DEX supply/withdraw leg
  (`require_min_out` → `MinOutNotMet`).
- User `withdraw` / `withdraw_all` now pull liquidity back from the DEX (not just
  Blend) when the vault's idle USDC is insufficient.
- New events `DexSupplyEvent` (`dex_sup`), `DexWithdrawEvent` (`dex_wd`),
  `DexPoolConfiguredEvent` (`dex_cfg`); new errors `DexPoolNotConfigured` (#46),
  `OnlyOwnerCanSetDexPool` (#47).

**Tests**
- `MockDexPool` harness + `setup_vault_with_token_and_dex` in `tests/utils.rs`
  (same pattern as `MockBlendPool`), with configurable supply/withdraw limits to
  simulate slippage and partial fills.
- `tests/test_dex_integration.rs`: supply/withdraw via rebalance, balance read,
  `CurrentProtocol`/`ProtocolChangedEvent` tracking, `min_out` enforcement (#42),
  unconfigured-pool (#46) and non-owner (#47) guards, Blend↔DEX switching, and a
  user withdrawal that pulls liquidity back from the DEX.
- `dex-devnet` feature flag + `tests/test_dex_devnet.rs` for testnet smoke tests
  (mirrors `blend-devnet`).

**Docs**
- New `DEX_INTEGRATION.md` (interface research + design, mirroring
  `BLEND_INTEGRATION_RESEARCH.md`).
- `CHANGELOG.md`, `EVENTS.md`, and `README.md` updated.

## Acceptance criteria

- [x] Agent can rebalance vault USDC into and out of a configured DEX pool.
- [x] `CurrentProtocol` and `ProtocolChangedEvent` reflect DEX deployments.
- [x] Slippage floor (`min_out`) enforced on DEX legs.
- [x] Tests added (no network required); devnet tests documented behind the
      `dex-devnet` feature flag.

## ⚠️ Reviewer note — pre-existing base does not compile

This change is **additive** and does not touch the broken code, but reviewers
should be aware that the base branch does not currently build (confirmed on
`origin/main`), independent of this PR:

- `reduce_total_deposits_on_withdraw` is called in `withdraw` / `withdraw_all`
  but has no definition anywhere in git history.
- `get_balance` references an undefined `shares_key`.
- `touch_user_ttl` is declared `-> bool` but its body returns an `i128` and never
  extends TTL.
- `require_within_deposit_cap` references an undefined `current_balance`.
- Several test files are out of sync with the current API (`update_total_assets`
  arity, `BlendSupplyEvent` field name, `Ledger::with_mut`).

I validated that the **library compiles with these DEX changes** by temporarily
patching only those pre-existing errors locally (reverted, not included here).
These base fixes are intentionally **out of scope** for this issue and should be
addressed separately so #228 stays focused.

## Checklist

- [x] I have updated `CHANGELOG.md` for any contract version or on-chain behavior changes.
- [x] I have confirmed the release entry matches the expected contract `Version` storage value (no `Version` bump — additive, pre-mainnet).
- [x] I have included tests and documentation updates for the new contract behavior.
