### PR TITLE
fix(events): split LimitsUpdatedEvent into semantic admin events

### DIFF
--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -496,13 +496,33 @@ pub struct CapsUpdatedEvent {
     pub new_tvl_cap: i128,
 }
 
-/// Emitted when deposit limits are updated.
+/// Emitted by the deprecated `set_limits` function only.
+///
+/// # Deprecated
+/// Use `DepositLimitsUpdatedEvent` (topic `"dep_lim"`) for per-transaction
+/// deposit-limit changes, and `TvlCapUpdatedEvent` / `UserDepositCapUpdatedEvent`
+/// for cap changes. This event is retained only for backward compatibility with
+/// indexers that still observe the `set_limits` call path.
 ///
 /// # Topics
-/// - `SymbolShort("limits_updated")` - Event identifier
+/// - `SymbolShort("l_upd")` - Event identifier
 #[allow(missing_docs)]
 #[contracttype]
 pub struct LimitsUpdatedEvent {
+    pub old_min: i128,
+    pub new_min: i128,
+    pub old_max: i128,
+    pub new_max: i128,
+}
+
+/// Emitted when per-transaction deposit limits (min/max per deposit) are updated
+/// via `set_deposit_limits`.
+///
+/// # Topics
+/// - `SymbolShort("dep_lim")` - Event identifier
+#[allow(missing_docs)]
+#[contracttype]
+pub struct DepositLimitsUpdatedEvent {
     pub old_min: i128,
     pub new_min: i128,
     pub old_max: i128,
@@ -752,6 +772,7 @@ pub(crate) const TOPIC_EMERGENCY_PAUSED: Symbol = symbol_short!("emerg");
 pub(crate) const TOPIC_TVL_CAP_UPDATED: Symbol = symbol_short!("tvl_cap");
 pub(crate) const TOPIC_USER_CAP_UPDATED: Symbol = symbol_short!("user_cap");
 pub(crate) const TOPIC_LIMITS_UPDATED: Symbol = symbol_short!("l_upd");
+pub(crate) const TOPIC_DEPOSIT_LIMITS_UPDATED: Symbol = symbol_short!("dep_lim");
 pub(crate) const TOPIC_CAPS_UPDATED: Symbol = symbol_short!("caps_upd");
 pub(crate) const TOPIC_AGENT_UPDATED: Symbol = symbol_short!("agent");
 pub(crate) const TOPIC_OWNERSHIP_INITIATED: Symbol = symbol_short!("own_init");
@@ -2220,7 +2241,7 @@ impl NeuroWealthVault {
     /// # Events
     ///
     /// Emits:
-    /// - `LimitsUpdatedEvent`
+    /// - `DepositLimitsUpdatedEvent`
     ///
     /// # Errors
     ///
@@ -2258,8 +2279,8 @@ impl NeuroWealthVault {
         env.storage().instance().set(&DataKey::MaxDeposit, &max);
 
         env.events().publish(
-            (TOPIC_LIMITS_UPDATED,),
-            LimitsUpdatedEvent {
+            (TOPIC_DEPOSIT_LIMITS_UPDATED,),
+            DepositLimitsUpdatedEvent {
                 old_min,
                 new_min: min,
                 old_max,

--- a/neurowealth-vault/contracts/vault/src/tests/test_event_schema.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_event_schema.rs
@@ -8,14 +8,15 @@
 
 use super::utils::*;
 use crate::{
-    AgentUpdatedEvent, AssetsUpdatedEvent, BlendSupplyEvent, BlendWithdrawEvent, DepositEvent,
-    EmergencyPausedEvent, LimitsUpdatedEvent, OwnershipTransferInitiatedEvent,
+    AgentUpdatedEvent, AssetsUpdatedEvent, BlendSupplyEvent, BlendWithdrawEvent,
+    DepositEvent, DepositLimitsUpdatedEvent, EmergencyPausedEvent, OwnershipTransferInitiatedEvent,
     OwnershipTransferredEvent, ProtocolChangedEvent, RebalanceEvent, TvlCapUpdatedEvent,
     UserDepositCapUpdatedEvent, VaultInitializedEvent, VaultPausedEvent, VaultUnpausedEvent,
     WithdrawEvent, TOPIC_AGENT_UPDATED, TOPIC_ASSETS_UPDATED, TOPIC_BLEND_SUPPLY,
-    TOPIC_BLEND_WITHDRAW, TOPIC_DEPOSIT, TOPIC_EMERGENCY_PAUSED, TOPIC_INIT, TOPIC_LIMITS_UPDATED,
-    TOPIC_OWNERSHIP_INITIATED, TOPIC_OWNERSHIP_TRANSFERRED, TOPIC_PAUSED, TOPIC_PROTOCOL_CHANGED,
-    TOPIC_REBALANCE, TOPIC_TVL_CAP_UPDATED, TOPIC_UNPAUSED, TOPIC_USER_CAP_UPDATED, TOPIC_WITHDRAW,
+    TOPIC_BLEND_WITHDRAW, TOPIC_DEPOSIT, TOPIC_DEPOSIT_LIMITS_UPDATED, TOPIC_EMERGENCY_PAUSED,
+    TOPIC_INIT, TOPIC_OWNERSHIP_INITIATED, TOPIC_OWNERSHIP_TRANSFERRED, TOPIC_PAUSED,
+    TOPIC_PROTOCOL_CHANGED, TOPIC_REBALANCE, TOPIC_TVL_CAP_UPDATED, TOPIC_UNPAUSED,
+    TOPIC_USER_CAP_UPDATED, TOPIC_WITHDRAW,
 };
 use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, TryFromVal};
 
@@ -124,21 +125,21 @@ fn test_event_schema_administrative_events() {
         VaultUnpausedEvent::try_from_val(&env, data).expect("Should be a valid VaultUnpausedEvent");
     assert_eq!(unpause_event.owner, owner);
 
-    // Test limits update event
+    // Test deposit limits update event
     let new_min = 2_000_000_i128;
     let new_max = 20_000_000_000_i128;
     client.set_deposit_limits(&new_min, &new_max);
 
-    let limits_events = find_events_by_topic(env.events().all(), &env, TOPIC_LIMITS_UPDATED);
+    let limits_events = find_events_by_topic(env.events().all(), &env, TOPIC_DEPOSIT_LIMITS_UPDATED);
     assert_eq!(
         limits_events.len(),
         1,
-        "Exactly one limits update event should be emitted"
+        "Exactly one deposit limits update event should be emitted"
     );
 
     let (_, _, data) = &limits_events[0];
-    let limits_event =
-        LimitsUpdatedEvent::try_from_val(&env, data).expect("Should be a valid LimitsUpdatedEvent");
+    let limits_event = DepositLimitsUpdatedEvent::try_from_val(&env, data)
+        .expect("Should be a valid DepositLimitsUpdatedEvent");
 
     // Verify payload structure
     assert_eq!(limits_event.old_min, 1_000_000_i128); // Default minimum
@@ -501,7 +502,7 @@ fn test_all_event_topics_schema_compliance() {
         ("paused", "Vault paused"),
         ("unpaused", "Vault unpaused"),
         ("emerg", "Emergency pause"),
-        ("l_upd", "Limits updated"),
+        ("dep_lim", "Deposit limits updated"),
         ("tvl_cap", "TVL cap updated"),
         ("user_cap", "User cap updated"),
         ("agent", "Agent updated"),
@@ -566,8 +567,9 @@ fn test_all_event_topics_schema_compliance() {
                     description
                 );
             }
-            "limits" => {
-                let events = find_events_by_topic(env.events().all(), &env, TOPIC_LIMITS_UPDATED);
+            "dep_lim" => {
+                let events =
+                    find_events_by_topic(env.events().all(), &env, TOPIC_DEPOSIT_LIMITS_UPDATED);
                 assert!(
                     !events.is_empty(),
                     "Expected event topic '{}' for {} not found",

--- a/neurowealth-vault/contracts/vault/src/tests/test_events.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_events.rs
@@ -3,12 +3,13 @@
 use super::utils::*;
 use crate::{
     AgentUpdatedEvent, AssetsUpdatedEvent, BlendPoolConfiguredEvent, BlendSupplyEvent,
-    BlendWithdrawEvent, CapsUpdatedEvent, DepositEvent, EmergencyPausedEvent, LimitsUpdatedEvent,
-    RebalanceEvent, TvlCapUpdatedEvent, UserDepositCapUpdatedEvent, VaultInitializedEvent,
-    VaultPausedEvent, VaultUnpausedEvent, WithdrawEvent, TOPIC_AGENT_UPDATED, TOPIC_ASSETS_UPDATED,
-    TOPIC_BLEND_POOL_CONFIGURED, TOPIC_BLEND_SUPPLY, TOPIC_BLEND_WITHDRAW, TOPIC_CAPS_UPDATED,
-    TOPIC_DEPOSIT, TOPIC_EMERGENCY_PAUSED, TOPIC_INIT, TOPIC_LIMITS_UPDATED, TOPIC_PAUSED,
-    TOPIC_REBALANCE, TOPIC_TVL_CAP_UPDATED, TOPIC_UNPAUSED, TOPIC_USER_CAP_UPDATED, TOPIC_WITHDRAW,
+    BlendWithdrawEvent, CapsUpdatedEvent, DepositEvent, DepositLimitsUpdatedEvent,
+    EmergencyPausedEvent, RebalanceEvent, TvlCapUpdatedEvent, UserDepositCapUpdatedEvent,
+    VaultInitializedEvent, VaultPausedEvent, VaultUnpausedEvent, WithdrawEvent,
+    TOPIC_AGENT_UPDATED, TOPIC_ASSETS_UPDATED, TOPIC_BLEND_POOL_CONFIGURED, TOPIC_BLEND_SUPPLY,
+    TOPIC_BLEND_WITHDRAW, TOPIC_CAPS_UPDATED, TOPIC_DEPOSIT, TOPIC_DEPOSIT_LIMITS_UPDATED,
+    TOPIC_EMERGENCY_PAUSED, TOPIC_INIT, TOPIC_PAUSED, TOPIC_REBALANCE, TOPIC_TVL_CAP_UPDATED,
+    TOPIC_UNPAUSED, TOPIC_USER_CAP_UPDATED, TOPIC_WITHDRAW,
 };
 use soroban_sdk::{symbol_short, testutils::Address as _, Address, BytesN, Env, TryFromVal};
 
@@ -291,15 +292,15 @@ fn test_set_deposit_limits_emits_limits_event_with_correct_payload() {
     let new_max = 20_000_000_000_i128;
     client.set_deposit_limits(&new_min, &new_max);
 
-    let limits_events = find_events_by_topic(env.events().all(), &env, TOPIC_LIMITS_UPDATED);
+    let limits_events = find_events_by_topic(env.events().all(), &env, TOPIC_DEPOSIT_LIMITS_UPDATED);
     assert!(
         !limits_events.is_empty(),
-        "set_deposit_limits should emit a limits event"
+        "set_deposit_limits should emit a DepositLimitsUpdatedEvent"
     );
 
     let (_, _, data) = &limits_events[0];
-    let event =
-        LimitsUpdatedEvent::try_from_val(&env, data).expect("Should be a LimitsUpdatedEvent");
+    let event = DepositLimitsUpdatedEvent::try_from_val(&env, data)
+        .expect("Should be a DepositLimitsUpdatedEvent");
     assert_eq!(
         event.new_min, new_min,
         "Event new_min should match set value"
@@ -672,7 +673,7 @@ fn test_all_events_have_correct_topics() {
     client.emergency_pause(&owner);
 
     let init_events = find_events_by_topic(env.events().all(), &env, TOPIC_INIT);
-    let limits_events = find_events_by_topic(env.events().all(), &env, TOPIC_LIMITS_UPDATED);
+    let limits_events = find_events_by_topic(env.events().all(), &env, TOPIC_DEPOSIT_LIMITS_UPDATED);
     let caps_events = find_events_by_topic(env.events().all(), &env, TOPIC_CAPS_UPDATED);
     let rebalance_events = find_events_by_topic(env.events().all(), &env, TOPIC_REBALANCE);
     let paused_events = find_events_by_topic(env.events().all(), &env, TOPIC_PAUSED);


### PR DESCRIPTION
<p>Closes #226</p>
<h2>What changed</h2>
<p>The overloaded <code>LimitsUpdatedEvent</code> was being reused across different admin functions with inconsistent field semantics, making it ambiguous for indexers and off-chain consumers.</p>
<p>This PR introduces a dedicated <code>DepositLimitsUpdatedEvent</code> for per-transaction deposit limit changes and routes <code>set_deposit_limits</code> to emit it exclusively.</p>
<h3>New event</h3>
<pre><code class="language-rust">// Topic: "dep_lim"
pub struct DepositLimitsUpdatedEvent {
    pub old_min: i128,
    pub new_min: i128,
    pub old_max: i128,
    pub new_max: i128,
}
</code></pre>
<h3>Emit routing after this change</h3>

Function | Event | Topic
-- | -- | --
set_deposit_limits | DepositLimitsUpdatedEvent | "dep_lim" ✅
set_tvl_cap | TvlCapUpdatedEvent | "tvl_cap" ✅
set_user_deposit_cap | UserDepositCapUpdatedEvent | "user_cap" ✅
set_caps | CapsUpdatedEvent | "caps_upd" ✅
set_limits (deprecated) | LimitsUpdatedEvent | "l_upd" (kept for compat)


<h2>Breaking change</h2>
<p>Indexers currently listening to <code>"l_upd"</code> for deposit limit changes from <code>set_deposit_limits</code> must migrate to <code>"dep_lim"</code>. The <code>"l_upd"</code> topic is now only emitted by the deprecated <code>set_limits</code> function.</p>
<h2>Tests updated</h2>
<ul>
<li><code>test_events.rs</code> — <code>test_set_deposit_limits_emits_limits_event_with_correct_payload</code> asserts on <code>DepositLimitsUpdatedEvent</code> / <code>TOPIC_DEPOSIT_LIMITS_UPDATED</code></li>
<li><code>test_event_schema.rs</code> — schema compliance test updated to validate <code>"dep_lim"</code> topic and <code>DepositLimitsUpdatedEvent</code> payload; removed stale dead code and unused imports</li>
</ul>
</body></html>