### PR TITLE
feat:add access-control test: non-owner cannot call set_deposit_limits

### DIFF
--- a/neurowealth-vault/contracts/vault/src/tests/test_access_control.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_access_control.rs
@@ -149,6 +149,75 @@ fn test_owner_can_set_blend_pool() {
 // OWNER-ONLY NEGATIVE PATHS (non-owner must be rejected)
 // ============================================================================
 
+/// `set_deposit_limits` enforces ownership via `require_is_owner`, which calls
+/// `owner.require_auth()` on the stored owner address. Because there is no
+/// explicit address parameter to compare against, the guard cannot be tested
+/// by passing a fake address; instead we revoke all auth with `mock_auths(&[])`
+/// and verify the call is rejected through the `try_*` client variant.
+#[test]
+fn test_non_owner_cannot_set_deposit_limits() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    // Drop all auth: owner.require_auth() inside require_is_owner cannot be
+    // satisfied, so the call must fail regardless of who invokes it.
+    let _non_owner = Address::generate(&env);
+    env.mock_auths(&[]);
+
+    let min = 2_000_000_i128;
+    let max = 50_000_000_000_i128;
+    let result = client.try_set_deposit_limits(&min, &max);
+    assert!(
+        result.is_err(),
+        "set_deposit_limits must reject calls without the owner's authorization"
+    );
+}
+
+/// `set_tvl_cap` is owner-only via `require_is_owner`. Removing that guard
+/// would cause this test to fail: valid inputs would return `Ok` and
+/// `result.is_err()` would be false.
+#[test]
+fn test_non_owner_cannot_set_tvl_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let _non_owner = Address::generate(&env);
+    env.mock_auths(&[]);
+
+    let result = client.try_set_tvl_cap(&50_000_000_000_i128);
+    assert!(
+        result.is_err(),
+        "set_tvl_cap must reject calls without the owner's authorization"
+    );
+}
+
+/// `set_limits` is owner-only via `require_is_owner`. Removing that guard
+/// would cause this test to fail: valid inputs would return `Ok(Ok(()))` and
+/// the outer `result.is_err()` would be false.
+#[test]
+fn test_non_owner_cannot_set_limits() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let _non_owner = Address::generate(&env);
+    env.mock_auths(&[]);
+
+    let result = client.try_set_limits(&1_000_000_i128, &50_000_000_000_i128);
+    assert!(
+        result.is_err(),
+        "set_limits must reject calls without the owner's authorization"
+    );
+}
+
 #[test]
 #[should_panic(expected = "Error(Contract, #19)")]
 fn test_non_owner_cannot_pause() {

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,28 @@
+## Summary
+
+Closes #225 — adds regression tests proving non-owners cannot call `set_deposit_limits`, `set_tvl_cap`, and `set_limits`.
+
+- **`test_non_owner_cannot_set_deposit_limits`** — required test from the issue; verifies `set_deposit_limits` rejects calls without owner auth.
+- **`test_non_owner_cannot_set_tvl_cap`** — parity test; verifies `set_tvl_cap` rejects calls without owner auth.
+- **`test_non_owner_cannot_set_limits`** — parity test; verifies `set_limits` rejects calls without owner auth.
+
+## Why a different pattern from the existing non-owner tests
+
+The existing negative tests (`test_non_owner_cannot_pause`, `test_non_owner_cannot_upgrade`, etc.) work by passing a freshly-generated `Address::generate` to a function that takes an explicit owner parameter and does an identity comparison. Those functions can be called "as a non-owner" because there's a param to swap.
+
+`set_deposit_limits`, `set_tvl_cap`, and `set_limits` have no such parameter — ownership is enforced via `require_is_owner`, which fetches the stored owner address and calls `owner.require_auth()`. The only way to test rejection is to ensure the stored owner's auth is absent at call time.
+
+The tests follow the stricter pattern already used in `test_auth.rs`:
+1. Call `env.mock_all_auths()` during setup (initialization legitimately requires the deployer's signature — mocking it is incidental setup noise).
+2. Call `env.mock_auths(&[])` immediately before the function under test, revoking all authorization.
+3. Use the `try_*` client variant and `assert!(result.is_err())`.
+
+If the `require_is_owner` guard is ever removed from any of these functions, valid inputs would complete successfully, `result.is_err()` would be `false`, and the test would fail — exactly what the issue requires.
+
+## Test plan
+
+- [ ] `cargo test -p neurowealth-vault test_non_owner_cannot_set_deposit_limits` passes
+- [ ] `cargo test -p neurowealth-vault test_non_owner_cannot_set_tvl_cap` passes
+- [ ] `cargo test -p neurowealth-vault test_non_owner_cannot_set_limits` passes
+- [ ] No existing tests in `test_access_control.rs` are broken
+- [ ] Removing `require_is_owner` from any of the three functions causes the corresponding test to fail


### PR DESCRIPTION
## Summary

Closes #225 

 adds regression tests proving non-owners cannot call `set_deposit_limits`, `set_tvl_cap`, and `set_limits`.

- **`test_non_owner_cannot_set_deposit_limits`** — required test from the issue; verifies `set_deposit_limits` rejects calls without owner auth.
- **`test_non_owner_cannot_set_tvl_cap`** — parity test; verifies `set_tvl_cap` rejects calls without owner auth.
- **`test_non_owner_cannot_set_limits`** — parity test; verifies `set_limits` rejects calls without owner auth.

## Why a different pattern from the existing non-owner tests

The existing negative tests (`test_non_owner_cannot_pause`, `test_non_owner_cannot_upgrade`, etc.) work by passing a freshly-generated `Address::generate` to a function that takes an explicit owner parameter and does an identity comparison. Those functions can be called "as a non-owner" because there's a param to swap.

`set_deposit_limits`, `set_tvl_cap`, and `set_limits` have no such parameter — ownership is enforced via `require_is_owner`, which fetches the stored owner address and calls `owner.require_auth()`. The only way to test rejection is to ensure the stored owner's auth is absent at call time.

The tests follow the stricter pattern already used in `test_auth.rs`:
1. Call `env.mock_all_auths()` during setup (initialization legitimately requires the deployer's signature — mocking it is incidental setup noise).
2. Call `env.mock_auths(&[])` immediately before the function under test, revoking all authorization.
3. Use the `try_*` client variant and `assert!(result.is_err())`.

If the `require_is_owner` guard is ever removed from any of these functions, valid inputs would complete successfully, `result.is_err()` would be `false`, and the test would fail — exactly what the issue requires.

## Test plan

- [ ] `cargo test -p neurowealth-vault test_non_owner_cannot_set_deposit_limits` passes
- [ ] `cargo test -p neurowealth-vault test_non_owner_cannot_set_tvl_cap` passes
- [ ] `cargo test -p neurowealth-vault test_non_owner_cannot_set_limits` passes
- [ ] No existing tests in `test_access_control.rs` are broken
- [ ] Removing `require_is_owner` from any of the three functions causes the corresponding test to fail
