### PR TITLE
feat:enforce optimised WASM size limit in CI  

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
   schedule:
     - cron: "0 3 * * 0"
 
+env:
+  # Maximum allowed size in bytes for the optimised contract WASM.
+  # Raise this in the same PR as any deliberate feature addition that grows
+  # the binary, and document the reason in the PR description.
+  WASM_SIZE_LIMIT_BYTES: 1500000
+
 jobs:
   ci-matrix:
     name: CI Matrix
@@ -111,12 +117,44 @@ jobs:
               wasm-opt --strip-target-features --mvp-features \
                 "$WASM_FILE" \
                 -o "$WASM_FILE"
+
+              WASM_SIZE=$(stat -c%s "$WASM_FILE")
+              LIMIT="${WASM_SIZE_LIMIT_BYTES:-1500000}"
+
+              {
+                echo "## WASM Size Report"
+                echo ""
+                echo "| Metric | Value |"
+                echo "|--------|-------|"
+                echo "| Optimised size | ${WASM_SIZE} bytes |"
+                echo "| Limit          | ${LIMIT} bytes |"
+              } >> "$GITHUB_STEP_SUMMARY"
+
+              if [ "$WASM_SIZE" -gt "$LIMIT" ]; then
+                echo "| Status | :x: EXCEEDED |" >> "$GITHUB_STEP_SUMMARY"
+                echo "::error::Optimised WASM is ${WASM_SIZE} bytes, which exceeds the ${LIMIT}-byte limit. See docs/WASM_SIZE.md for reduction tips."
+                exit 1
+              else
+                echo "| Status | :white_check_mark: OK |" >> "$GITHUB_STEP_SUMMARY"
+                echo "Optimised WASM is ${WASM_SIZE} bytes — within the ${LIMIT}-byte limit."
+              fi
+
+              # Export the WASM path for the artifact upload step.
+              echo "WASM_FILE=$WASM_FILE" >> "$GITHUB_ENV"
               ;;
             *)
               echo "Unknown step: ${{ matrix.step }}" >&2
               exit 1
               ;;
           esac
+
+      - name: Upload optimised WASM artifact
+        if: matrix.step == 'build-wasm'
+        uses: actions/upload-artifact@v4
+        with:
+          name: neurowealth-vault-wasm
+          path: ${{ env.WASM_FILE }}
+          retention-days: 14
 
   cargo-deny:
     name: Dependency Audit (cargo-deny)

--- a/docs/WASM_SIZE.md
+++ b/docs/WASM_SIZE.md
@@ -4,13 +4,13 @@
 
 The CI pipeline fails if the optimised contract WASM exceeds **1.5 MB** (configurable via `WASM_SIZE_LIMIT_BYTES` in `.github/workflows/ci.yml`).
 
-NEAR Protocol's on-chain code-storage hard limit is **4 MB**.  Our 1.5 MB gate provides ample headroom and catches unintentional bloat early.
+Stellar's Soroban network enforces a `maxContractSizeBytes` network parameter that caps how large a contract WASM can be when uploaded via `stellar contract upload`. The CI gate sits well below that limit to catch unintentional bloat early and leave room for future feature additions.
 
 ## Why This Matters
 
 | Issue | Consequence |
 |-------|-------------|
-| WASM > 4 MB | Deployment transaction rejected by the network |
+| WASM > network `maxContractSizeBytes` | Deployment transaction rejected by the Soroban network |
 | WASM > CI limit | PR blocked until size is reduced |
 | Gradual growth | Limits room for future feature additions |
 
@@ -18,12 +18,13 @@ NEAR Protocol's on-chain code-storage hard limit is **4 MB**.  Our 1.5 MB gate p
 
 1. **Audit new dependencies** — `cargo bloat --release --crates` shows which crates contribute most to binary size.
 2. **Use `no-default-features`** — disable crate features you don't need.
-3. **Prefer `near-sdk` primitives** — avoid pulling in heavy `std` types where a simpler alternative exists.
+3. **Prefer `soroban-sdk` primitives** — avoid pulling in heavy `std` types where a simpler alternative exists.
 4. **Avoid `format!` / `String` in hot paths** — string formatting pulls in significant code.
-5. **Run `wasm-opt -Oz`** locally to see the post-optimisation size before pushing:
+5. **Run `wasm-opt` locally** to see the post-optimisation size before pushing:
    ```bash
-   cargo build --target wasm32-unknown-unknown --release --no-default-features
-   wasm-opt -Oz --strip-debug --vacuum \
+   RUSTFLAGS="-C target-cpu=mvp" cargo build \
+     --target wasm32-unknown-unknown --release
+   wasm-opt --strip-target-features --mvp-features \
      target/wasm32-unknown-unknown/release/neurowealth_vault.wasm \
      -o /tmp/vault_opt.wasm
    wc -c /tmp/vault_opt.wasm

--- a/pr.md
+++ b/pr.md
@@ -1,28 +1,61 @@
 ## Summary
 
 Closes #225 — adds regression tests proving non-owners cannot call `set_deposit_limits`, `set_tvl_cap`, and `set_limits`.
+Closes #224 — enforces an optimised WASM size limit in CI and fixes incorrect NEAR references in `docs/WASM_SIZE.md`.
+
+---
+
+### Issue #225 — Access-control tests for `set_deposit_limits`
 
 - **`test_non_owner_cannot_set_deposit_limits`** — required test from the issue; verifies `set_deposit_limits` rejects calls without owner auth.
 - **`test_non_owner_cannot_set_tvl_cap`** — parity test; verifies `set_tvl_cap` rejects calls without owner auth.
 - **`test_non_owner_cannot_set_limits`** — parity test; verifies `set_limits` rejects calls without owner auth.
 
-## Why a different pattern from the existing non-owner tests
+#### Why a different pattern from the existing non-owner tests
 
-The existing negative tests (`test_non_owner_cannot_pause`, `test_non_owner_cannot_upgrade`, etc.) work by passing a freshly-generated `Address::generate` to a function that takes an explicit owner parameter and does an identity comparison. Those functions can be called "as a non-owner" because there's a param to swap.
+The existing negative tests (`test_non_owner_cannot_pause`, `test_non_owner_cannot_upgrade`, etc.) work by passing a freshly-generated address to a function that takes an explicit owner parameter and does an identity comparison.
 
 `set_deposit_limits`, `set_tvl_cap`, and `set_limits` have no such parameter — ownership is enforced via `require_is_owner`, which fetches the stored owner address and calls `owner.require_auth()`. The only way to test rejection is to ensure the stored owner's auth is absent at call time.
 
-The tests follow the stricter pattern already used in `test_auth.rs`:
-1. Call `env.mock_all_auths()` during setup (initialization legitimately requires the deployer's signature — mocking it is incidental setup noise).
+The tests follow the stricter pattern already established in `test_auth.rs`:
+1. Call `env.mock_all_auths()` during setup (initialization is incidental setup noise, not the behavior under test).
 2. Call `env.mock_auths(&[])` immediately before the function under test, revoking all authorization.
 3. Use the `try_*` client variant and `assert!(result.is_err())`.
 
 If the `require_is_owner` guard is ever removed from any of these functions, valid inputs would complete successfully, `result.is_err()` would be `false`, and the test would fail — exactly what the issue requires.
 
+---
+
+### Issue #224 — CI WASM size gate
+
+**`.github/workflows/ci.yml`**
+
+- Added `WASM_SIZE_LIMIT_BYTES: 1500000` as a workflow-level `env` variable — configurable without touching the shell script logic.
+- After `wasm-opt` in the `build-wasm` step:
+  - Measures the optimised WASM size with `stat -c%s`.
+  - Writes a markdown table (optimised size / limit / status) to `$GITHUB_STEP_SUMMARY`.
+  - Fails the job with a `::error::` annotation if size exceeds the limit; prints a link to `docs/WASM_SIZE.md` for reduction tips.
+  - Exports `WASM_FILE` to `$GITHUB_ENV` for the follow-on upload step.
+- Added an "Upload optimised WASM artifact" step (guarded by `matrix.step == 'build-wasm'`) that uploads the file via `actions/upload-artifact@v4` with 14-day retention.
+
+**`docs/WASM_SIZE.md`**
+
+- Removed all NEAR Protocol references (wrong network entirely).
+- Updated the constraint description to reference Soroban's `maxContractSizeBytes` network parameter.
+- Fixed reduction tips to reference `soroban-sdk` instead of `near-sdk`.
+- Aligned the local `wasm-opt` example command with the flags used in CI.
+
 ## Test plan
 
+**#225**
 - [ ] `cargo test -p neurowealth-vault test_non_owner_cannot_set_deposit_limits` passes
 - [ ] `cargo test -p neurowealth-vault test_non_owner_cannot_set_tvl_cap` passes
 - [ ] `cargo test -p neurowealth-vault test_non_owner_cannot_set_limits` passes
-- [ ] No existing tests in `test_access_control.rs` are broken
 - [ ] Removing `require_is_owner` from any of the three functions causes the corresponding test to fail
+
+**#224**
+- [ ] CI passes on current `main` (WASM is under 1.5 MB)
+- [ ] Step summary shows a WASM size table in the Build WASM job
+- [ ] Optimised WASM is uploaded as the `neurowealth-vault-wasm` artifact
+- [ ] Setting `WASM_SIZE_LIMIT_BYTES: 1` in the workflow causes the Build WASM job to fail
+- [ ] `docs/WASM_SIZE.md` contains no NEAR references


### PR DESCRIPTION
## Summary

Closes #224 
 enforces an optimised WASM size limit in CI and fixes incorrect NEAR references in `docs/WASM_SIZE.md`.


### Issue #224 — CI WASM size gate

**`.github/workflows/ci.yml`**

- Added `WASM_SIZE_LIMIT_BYTES: 1500000` as a workflow-level `env` variable — configurable without touching the shell script logic.
- After `wasm-opt` in the `build-wasm` step:
  - Measures the optimised WASM size with `stat -c%s`.
  - Writes a markdown table (optimised size / limit / status) to `$GITHUB_STEP_SUMMARY`.
  - Fails the job with a `::error::` annotation if size exceeds the limit; prints a link to `docs/WASM_SIZE.md` for reduction tips.
  - Exports `WASM_FILE` to `$GITHUB_ENV` for the follow-on upload step.
- Added an "Upload optimised WASM artifact" step (guarded by `matrix.step == 'build-wasm'`) that uploads the file via `actions/upload-artifact@v4` with 14-day retention.

**`docs/WASM_SIZE.md`**

- Removed all NEAR Protocol references (wrong network entirely).
- Updated the constraint description to reference Soroban's `maxContractSizeBytes` network parameter.
- Fixed reduction tips to reference `soroban-sdk` instead of `near-sdk`.
- Aligned the local `wasm-opt` example command with the flags used in CI.

## Test plan

**#225**
- [ ] `cargo test -p neurowealth-vault test_non_owner_cannot_set_deposit_limits` passes
- [ ] `cargo test -p neurowealth-vault test_non_owner_cannot_set_tvl_cap` passes
- [ ] `cargo test -p neurowealth-vault test_non_owner_cannot_set_limits` passes
- [ ] Removing `require_is_owner` from any of the three functions causes the corresponding test to fail

**#224**
- [ ] CI passes on current `main` (WASM is under 1.5 MB)
- [ ] Step summary shows a WASM size table in the Build WASM job
- [ ] Optimised WASM is uploaded as the `neurowealth-vault-wasm` artifact
- [ ] Setting `WASM_SIZE_LIMIT_BYTES: 1` in the workflow causes the Build WASM job to fail
- [ ] `docs/WASM_SIZE.md` contains no NEAR references
