### PR TITLE
docs: clarify decoupled init roles and set_limits cap semantics (#278–#281)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Key Functions
 
 | Function | Who Can Call | Description |
 | :--- | :--- | :--- |
-| `initialize` | Owner (once) | Set agent address and USDC token |
+| `initialize` | Deployer (once) | Authorize via deployer signature and set **separate** owner and agent addresses plus the USDC token |
 | `deposit` | Any verified user | Deposit USDC into the vault |
 | `withdraw` | User (their own funds) | Withdraw USDC back to wallet |
 | `withdraw_all` | User (their own funds) | Withdraw all USDC by burning all shares |

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -2166,7 +2166,12 @@ impl NeuroWealthVault {
     ///
     /// * `env` - The Soroban environment.
     /// * `min` - New per-user deposit cap in USDC units (7 decimal places).
+    ///   Despite the name, this is the user-deposit cap, not a per-deposit minimum.
     /// * `max` - New TVL cap in USDC units (7 decimal places).
+    ///   Despite the name, this is the TVL cap, not a per-deposit maximum.
+    ///
+    /// Both values are validated to be non-negative, and `max` must be `>= min`,
+    /// so a negative input can never silently disable a cap (issues #280, #281).
     ///
     /// # Returns
     ///


### PR DESCRIPTION
## Summary

The invariant/role/cap protections for these four issues are already implemented in `neurowealth-vault/contracts/vault/src/lib.rs`. This PR adds documentation reinforcements so the public docs match the on-chain behavior.

## Changes

- **README** — Updated the Key Functions table: `initialize` is deployer-authorized (front-running protected) and sets **separate** owner and agent addresses plus the USDC token.
- **lib.rs** — Clarified `set_limits(min, max)` doc comment: the params are the user-deposit cap and TVL cap (not per-deposit min/max), and both are validated non-negative with `max >= min`, so a negative input can never silently disable a cap.

## Verified behavior (already in code)

- `initialize(deployer, owner, agent, …)` requires `deployer.require_auth()` + `deployed_address()` check, with separate owner/agent.
- `set_tvl_cap`, `set_user_deposit_cap`, and `set_limits` all reject negative inputs.
- `set_limits` enforces non-negative values and `max >= min`, emitting `LimitsUpdatedEvent`.
- Secure deployment sequence is documented in the README.

Closes #278
Closes #279
Closes #280
Closes #281
