### PR TITLE
Add tests for owner compromise blast radius

### DIFF
--- a/test/NotOwnerCompromiseBlastRadius.test.ts
+++ b/test/NotOwnerCompromiseBlastRadius.test.ts
@@ -1,0 +1,117 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { Contract, Signer } from "ethers";
+
+describe("Owner Compromise - Blast Radius Tests", function () {
+  let contract: Contract;
+  let owner: Signer;
+  let attacker: Signer;
+  let user1: Signer;
+  let user2: Signer;
+
+  beforeEach(async () => {
+    [owner, attacker, user1, user2] = await ethers.getSigners();
+    
+    // Deploy contract with owner
+    const ContractFactory = await ethers.getContractFactory("YourContract");
+    contract = await ContractFactory.deploy();
+    await contract.deployed();
+  });
+
+  describe("Threat Model: Owner has been compromised", function () {
+    
+    // Owner CAN do - intended behaviors
+    describe("Owner CAN perform authorized actions", function () {
+      it("should allow owner to pause contract", async () => {
+        await expect(contract.connect(owner).pause())
+          .to.emit(contract, "Paused");
+      });
+
+      it("should allow owner to update configuration", async () => {
+        const newConfig = "0x1234567890";
+        await expect(contract.connect(owner).updateConfig(newConfig))
+          .to.emit(contract, "ConfigUpdated");
+      });
+    });
+
+    // Owner CANNOT do - blast radius is limited
+    describe("Owner CANNOT breach trust model (blast radius limited)", function () {
+      it("should NOT allow owner to steal user funds", async () => {
+        await contract.connect(user1).deposit({ value: ethers.utils.parseEther("1") });
+        
+        await expect(
+          contract.connect(owner).withdrawUserFunds(user1.getAddress())
+        ).to.be.revertedWith("Unauthorized");
+      });
+
+      it("should NOT allow owner to modify user balances", async () => {
+        const userAddr = await user1.getAddress();
+        
+        await expect(
+          contract.connect(owner).forceSetBalance(userAddr, 0)
+        ).to.be.revertedWith("Unauthorized");
+      });
+
+      it("should NOT allow owner to bypass withdrawal limits", async () => {
+        await contract.connect(user1).deposit({ value: ethers.utils.parseEther("10") });
+        
+        // Contract has max withdrawal per day = 1 ETH
+        await expect(
+          contract.connect(owner).overrideWithdrawalLimit(ethers.utils.parseEther("100"))
+        ).to.be.revertedWith("Unauthorized");
+      });
+
+      it("should NOT allow owner to transfer contract ownership to attacker", async () => {
+        const attackerAddr = await attacker.getAddress();
+        
+        await expect(
+          contract.connect(owner).transferOwnership(attackerAddr)
+        ).to.be.revertedWith("Disabled");
+      });
+    });
+
+    describe("Privileged abuse scenarios", function () {
+      it("owner compromise should NOT affect other users' funds", async () => {
+        const user1Addr = await user1.getAddress();
+        const user2Addr = await user2.getAddress();
+        
+        await contract.connect(user1).deposit({ value: ethers.utils.parseEther("5") });
+        await contract.connect(user2).deposit({ value: ethers.utils.parseEther("3") });
+        
+        const user2BalanceBefore = await contract.getBalance(user2Addr);
+        
+        // Owner tries malicious action
+        await expect(
+          contract.connect(owner).pause()
+        ).to.not.affect(await contract.getBalance(user2Addr));
+        
+        expect(await contract.getBalance(user2Addr)).to.equal(user2BalanceBefore);
+      });
+
+      it("emergency pause should not lock user withdrawals permanently", async () => {
+        await contract.connect(user1).deposit({ value: ethers.utils.parseEther("1") });
+        
+        await contract.connect(owner).pause();
+        
+        // After unpause, users can withdraw
+        await contract.connect(owner).unpause();
+        await expect(
+          contract.connect(user1).withdraw(ethers.utils.parseEther("1"))
+        ).to.not.be.reverted;
+      });
+    });
+  });
+
+  describe("Blast Radius - Attack Surface Limits", function () {
+    it("owner actions should be immutable or time-delayed if critical", async () => {
+      const delayPeriod = await contract.CRITICAL_DELAY();
+      expect(delayPeriod).to.be.gt(0, "Critical actions should have delay");
+    });
+
+    it("sensitive functions should emit events for auditing", async () => {
+      await expect(contract.connect(owner).pause())
+        .to.emit(contract, "Paused")
+        .withArgs(owner.getAddress());
+    });
+  });
+});


### PR DESCRIPTION

## Summary
Add comprehensive tests for owner compromise scenarios, ensuring that owner actions are limited and do not affect user funds. Includes scenarios for authorized actions, unauthorized fund access, and event emissions for critical actions.

closes #284 
closes #285 
closes #286 
closes #287 