### PR TITLE
Standardize event topic constants and align EVENTS.md

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -136,6 +136,18 @@ pub struct ProtocolChangedEvent {
 **Usage:**
 - Indexers record explicit protocol state transitions without inferring from rebalance events alone
 
+### 4b. RebalanceFailedEvent
+**Topic:** `"reb_fail"`
+
+Emitted when a rebalance exits a protocol but the withdrawal leg leaves a non-zero balance behind (incomplete exit).
+
+```rust
+pub struct RebalanceFailedEvent {
+    pub from_protocol: Symbol,  // The protocol the vault was trying to exit
+    pub reason: Symbol,         // Short reason code ("exit_fail" = incomplete withdrawal)
+}
+```
+
 ## Administrative Events
 
 ### 5. VaultPausedEvent
@@ -161,7 +173,7 @@ pub struct VaultUnpausedEvent {
 ```
 
 ### 7. EmergencyPausedEvent
-**Topic:** `"emergency"`
+**Topic:** `"emerg"`
 
 Emitted when the vault is emergency paused by the agent.
 
@@ -172,7 +184,7 @@ pub struct EmergencyPausedEvent {
 ```
 
 ### 8. LimitsUpdatedEvent
-**Topic:** `"limits"`
+**Topic:** `"l_upd"`
 
 Emitted when per-transaction deposit limits are updated.
 
@@ -189,7 +201,21 @@ pub struct LimitsUpdatedEvent {
 }
 ```
 
-### 8a. TvlCapUpdatedEvent
+### 8a. DepositLimitsUpdatedEvent
+**Topic:** `"dep_lim"`
+
+Emitted when per-transaction deposit limits are updated via `set_deposit_limits`. This is the current, unambiguous replacement for the legacy `LimitsUpdatedEvent` topic above.
+
+```rust
+pub struct DepositLimitsUpdatedEvent {
+    pub old_min: i128,    // Previous minimum deposit limit
+    pub new_min: i128,    // New minimum deposit limit
+    pub old_max: i128,    // Previous maximum deposit limit
+    pub new_max: i128,    // New maximum deposit limit
+}
+```
+
+### 8b. TvlCapUpdatedEvent
 **Topic:** `"tvl_cap"`
 
 Emitted when the vault's total TVL cap is updated.
@@ -201,7 +227,7 @@ pub struct TvlCapUpdatedEvent {
 }
 ```
 
-### 8b. UserDepositCapUpdatedEvent
+### 8c. UserDepositCapUpdatedEvent
 **Topic:** `"user_cap"`
 
 Emitted when the per-user deposit cap is updated.
@@ -213,7 +239,7 @@ pub struct UserDepositCapUpdatedEvent {
 }
 ```
 
-### 8c. CapsUpdatedEvent
+### 8d. CapsUpdatedEvent
 **Topic:** `"caps_upd"`
 
 Emitted when user deposit and TVL caps are updated in a single transaction via `set_caps`.
@@ -249,6 +275,19 @@ Emitted when total assets are updated (yield accrual).
 pub struct AssetsUpdatedEvent {
     pub old_total: i128,   // Previous total assets
     pub new_total: i128,   // New total assets
+}
+```
+
+### 10a. UserStrategyUpdatedEvent
+**Topic:** `"usr_strat"`
+
+Emitted when a user updates their investment strategy preference.
+
+```rust
+pub struct UserStrategyUpdatedEvent {
+    pub user: Address,          // The user who updated their strategy
+    pub old_strategy: Symbol,   // Previous strategy symbol ("conservative", "balanced", "growth", or "")
+    pub new_strategy: Symbol,   // New strategy symbol
 }
 ```
 
@@ -299,9 +338,9 @@ Emitted when assets are supplied to Blend protocol.
 
 ```rust
 pub struct BlendSupplyEvent {
-    pub asset: Address,   // Asset address (USDC)
-    pub amount: i128,     // Amount supplied
-    pub success: bool,    // Whether supply succeeded
+    pub asset: Address,         // Asset address (USDC)
+    pub amount_actual: i128,    // Actual amount transferred to Blend (may be less than requested due to pool limits)
+    pub success: bool,          // Whether supply succeeded
 }
 ```
 
@@ -312,10 +351,9 @@ Emitted when assets are withdrawn from Blend protocol.
 
 ```rust
 pub struct BlendWithdrawEvent {
-    pub asset: Address,           // Asset address (USDC)
-    pub requested_amount: i128,   // Amount requested to withdraw
-    pub amount_received: i128,    // Amount actually received
-    pub success: bool,            // Whether withdrawal succeeded
+    pub asset: Address,         // Asset address (USDC)
+    pub amount_actual: i128,    // Actual amount received from Blend (may be less than requested due to pool liquidity)
+    pub success: bool,          // Whether withdrawal succeeded
 }
 ```
 

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -784,33 +784,15 @@ const USER_SHARES_TTL_EXTEND_TO: u32 = 100;
 /// `current_ledger_sequence + BlendApprovalTtl`.
 const DEFAULT_BLEND_APPROVAL_TTL: u32 = 100_000;
 
-pub(crate) const TOPIC_INIT: Symbol = symbol_short!("init");
-pub(crate) const TOPIC_DEPOSIT: Symbol = symbol_short!("deposit");
-pub(crate) const TOPIC_WITHDRAW: Symbol = symbol_short!("withdraw");
-pub(crate) const TOPIC_REBALANCE: Symbol = symbol_short!("rebalance");
-pub(crate) const TOPIC_PAUSED: Symbol = symbol_short!("paused");
-pub(crate) const TOPIC_UNPAUSED: Symbol = symbol_short!("unpaused");
-pub(crate) const TOPIC_EMERGENCY_PAUSED: Symbol = symbol_short!("emerg");
-pub(crate) const TOPIC_TVL_CAP_UPDATED: Symbol = symbol_short!("tvl_cap");
-pub(crate) const TOPIC_USER_CAP_UPDATED: Symbol = symbol_short!("user_cap");
-pub(crate) const TOPIC_LIMITS_UPDATED: Symbol = symbol_short!("l_upd");
-pub(crate) const TOPIC_DEPOSIT_LIMITS_UPDATED: Symbol = symbol_short!("dep_lim");
-pub(crate) const TOPIC_CAPS_UPDATED: Symbol = symbol_short!("caps_upd");
-pub(crate) const TOPIC_AGENT_UPDATED: Symbol = symbol_short!("agent");
-pub(crate) const TOPIC_OWNERSHIP_INITIATED: Symbol = symbol_short!("own_init");
-pub(crate) const TOPIC_OWNERSHIP_TRANSFERRED: Symbol = symbol_short!("own_xfer");
-pub(crate) const TOPIC_OWNERSHIP_CANCELLED: Symbol = symbol_short!("own_cncl");
-pub(crate) const TOPIC_ASSETS_UPDATED: Symbol = symbol_short!("assets");
-pub(crate) const TOPIC_UPGRADED: Symbol = symbol_short!("upgraded");
-pub(crate) const TOPIC_BLEND_SUPPLY: Symbol = symbol_short!("blend_sup");
-pub(crate) const TOPIC_BLEND_WITHDRAW: Symbol = symbol_short!("blend_wd");
-pub(crate) const TOPIC_BLEND_POOL_CONFIGURED: Symbol = symbol_short!("blend_cfg");
-pub(crate) const TOPIC_DEX_SUPPLY: Symbol = symbol_short!("dex_sup");
-pub(crate) const TOPIC_DEX_WITHDRAW: Symbol = symbol_short!("dex_wd");
-pub(crate) const TOPIC_DEX_POOL_CONFIGURED: Symbol = symbol_short!("dex_cfg");
-pub(crate) const TOPIC_PROTOCOL_CHANGED: Symbol = symbol_short!("proto_chg");
-pub(crate) const TOPIC_USER_STRATEGY_UPDATED: Symbol = symbol_short!("usr_strat");
-pub(crate) const TOPIC_REBALANCE_FAILED: Symbol = symbol_short!("reb_fail");
+use topics::{
+    TOPIC_AGENT_UPDATED, TOPIC_ASSETS_UPDATED, TOPIC_BLEND_POOL_CONFIGURED, TOPIC_BLEND_SUPPLY,
+    TOPIC_BLEND_WITHDRAW, TOPIC_CAPS_UPDATED, TOPIC_DEPOSIT, TOPIC_DEPOSIT_LIMITS_UPDATED,
+    TOPIC_DEX_POOL_CONFIGURED, TOPIC_DEX_SUPPLY, TOPIC_DEX_WITHDRAW, TOPIC_EMERGENCY_PAUSED,
+    TOPIC_INIT, TOPIC_LIMITS_UPDATED, TOPIC_OWNERSHIP_CANCELLED, TOPIC_OWNERSHIP_INITIATED,
+    TOPIC_OWNERSHIP_TRANSFERRED, TOPIC_PAUSED, TOPIC_PROTOCOL_CHANGED, TOPIC_REBALANCE,
+    TOPIC_REBALANCE_FAILED, TOPIC_TVL_CAP_UPDATED, TOPIC_UNPAUSED, TOPIC_UPGRADED,
+    TOPIC_USER_CAP_UPDATED, TOPIC_USER_STRATEGY_UPDATED, TOPIC_WITHDRAW,
+};
 
 impl BlendPoolClient {
     /// Deposits assets to the Blend pool.

--- a/neurowealth-vault/contracts/vault/src/topics.rs
+++ b/neurowealth-vault/contracts/vault/src/topics.rs
@@ -1,29 +1,39 @@
 //! Event topic constants for the NeuroWealth Vault contract.
 //!
-//! This module serves as the single source of truth for all event topics
-//! emitted by the vault. Symbols are limited to 9 characters.
+//! This module is the single source of truth for every event topic emitted
+//! by the vault. `lib.rs` imports these constants directly rather than
+//! redefining its own copies, so the on-chain symbols, this file, and
+//! `EVENTS.md` cannot drift apart. Symbols are limited to 9 characters
+//! (the `symbol_short!` limit).
 
 #![allow(missing_docs)]
 
 use soroban_sdk::{symbol_short, Symbol};
 
-pub const INIT: Symbol = symbol_short!("init");
-pub const DEPOSIT: Symbol = symbol_short!("deposit");
-pub const WITHDRAW: Symbol = symbol_short!("withdraw");
-pub const REBALANCE: Symbol = symbol_short!("rebalance");
-pub const PAUSED: Symbol = symbol_short!("paused");
-pub const UNPAUSED: Symbol = symbol_short!("unpaused");
-pub const EMERGENCY: Symbol = symbol_short!("emergency");
-pub const TVL_CAP: Symbol = symbol_short!("tvl_cap");
-pub const USER_CAP: Symbol = symbol_short!("user_cap");
-pub const LIMITS: Symbol = symbol_short!("limits");
-pub const CAPS: Symbol = symbol_short!("caps");
-pub const AGENT: Symbol = symbol_short!("agent");
-pub const OWN_INIT: Symbol = symbol_short!("own_init");
-pub const OWN_XFER: Symbol = symbol_short!("own_xfer");
-pub const OWN_CNCL: Symbol = symbol_short!("own_cncl");
-pub const ASSETS: Symbol = symbol_short!("assets");
-pub const UPGRADED: Symbol = symbol_short!("upgraded");
-pub const BLEND_SUP: Symbol = symbol_short!("blend_sup");
-pub const BLEND_WD: Symbol = symbol_short!("blend_wd");
-pub const USER_STRATEGY: Symbol = symbol_short!("usr_strat");
+pub const TOPIC_INIT: Symbol = symbol_short!("init");
+pub const TOPIC_DEPOSIT: Symbol = symbol_short!("deposit");
+pub const TOPIC_WITHDRAW: Symbol = symbol_short!("withdraw");
+pub const TOPIC_REBALANCE: Symbol = symbol_short!("rebalance");
+pub const TOPIC_PAUSED: Symbol = symbol_short!("paused");
+pub const TOPIC_UNPAUSED: Symbol = symbol_short!("unpaused");
+pub const TOPIC_EMERGENCY_PAUSED: Symbol = symbol_short!("emerg");
+pub const TOPIC_TVL_CAP_UPDATED: Symbol = symbol_short!("tvl_cap");
+pub const TOPIC_USER_CAP_UPDATED: Symbol = symbol_short!("user_cap");
+pub const TOPIC_LIMITS_UPDATED: Symbol = symbol_short!("l_upd");
+pub const TOPIC_DEPOSIT_LIMITS_UPDATED: Symbol = symbol_short!("dep_lim");
+pub const TOPIC_CAPS_UPDATED: Symbol = symbol_short!("caps_upd");
+pub const TOPIC_AGENT_UPDATED: Symbol = symbol_short!("agent");
+pub const TOPIC_OWNERSHIP_INITIATED: Symbol = symbol_short!("own_init");
+pub const TOPIC_OWNERSHIP_TRANSFERRED: Symbol = symbol_short!("own_xfer");
+pub const TOPIC_OWNERSHIP_CANCELLED: Symbol = symbol_short!("own_cncl");
+pub const TOPIC_ASSETS_UPDATED: Symbol = symbol_short!("assets");
+pub const TOPIC_UPGRADED: Symbol = symbol_short!("upgraded");
+pub const TOPIC_BLEND_SUPPLY: Symbol = symbol_short!("blend_sup");
+pub const TOPIC_BLEND_WITHDRAW: Symbol = symbol_short!("blend_wd");
+pub const TOPIC_BLEND_POOL_CONFIGURED: Symbol = symbol_short!("blend_cfg");
+pub const TOPIC_DEX_SUPPLY: Symbol = symbol_short!("dex_sup");
+pub const TOPIC_DEX_WITHDRAW: Symbol = symbol_short!("dex_wd");
+pub const TOPIC_DEX_POOL_CONFIGURED: Symbol = symbol_short!("dex_cfg");
+pub const TOPIC_PROTOCOL_CHANGED: Symbol = symbol_short!("proto_chg");
+pub const TOPIC_USER_STRATEGY_UPDATED: Symbol = symbol_short!("usr_strat");
+pub const TOPIC_REBALANCE_FAILED: Symbol = symbol_short!("reb_fail");


### PR DESCRIPTION
## Summary
- `topics.rs` declared a parallel set of `TOPIC_*` constants that `lib.rs` never actually imported, so `lib.rs` kept its own copies and the two sets of symbol values diverged from each other and from `EVENTS.md` (e.g. `topics.rs` had `"limits"` while the code actually emitted `"l_upd"`; `"emergency"` vs the real `"emerg"`; `"caps"` vs the real `"caps_upd"`).
- `lib.rs` now imports its `TOPIC_*` constants directly from `topics.rs`, so there is exactly one definition per topic and no risk of drift.
- `EVENTS.md` is corrected to document the real on-chain topic strings and real event field names (`BlendSupplyEvent`/`BlendWithdrawEvent` use `amount_actual`, not `amount`/`requested_amount`/`amount_received`), and now documents three events that existed in code but were missing from the doc: `DepositLimitsUpdatedEvent` (`"dep_lim"`), `RebalanceFailedEvent` (`"reb_fail"`), `UserStrategyUpdatedEvent` (`"usr_strat"`).

While investigating this, I also verified the other three issues assigned to me are already satisfied by code currently on `main` (no further changes needed there):
- **#297** (ownership two-step transfer test coverage): `test_access_control.rs` already has dedicated happy-path, cancel-path, and non-pending-accept-panic tests (`test_cancel_ownership_transfer_clears_pending`, `test_accept_after_cancel_panics`, `test_wrong_address_cannot_accept_ownership`, etc.).
- **#326** (slippage guard on rebalance): `rebalance()` already takes a `min_out` parameter enforced per-leg via `require_min_out()`, with `test_rebalance_min_out_panics_when_pool_returns_less_than_requested` covering a mock pool that returns less than requested.
- **#327** (real Blend ABI): `BlendPoolClient` already calls the production `submit_with_allowance`/`submit`/`balance` entrypoints (not simplified mocks), matching `docs/BLEND_INTEGRATION_RESEARCH.md`, with devnet integration tests behind the `blend-devnet`/`dex-devnet` Cargo features.

Closes #292
Closes #297
Closes #326
Closes #327

## Test plan
- [x] `cargo build -p neurowealth-vault` — clean, no warnings
- [x] `cargo test -p neurowealth-vault` — 418 passed; 4 pre-existing failures unrelated to this change (TTL threshold tests, rebalance cooldown, strategy-switch test) reproduce identically on `main` before this branch
- [x] Cross-checked every topic in `topics.rs` against `EVENTS.md` — all 27 now match exactly