### PR TITLE
Fix/issues 298 299

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -432,14 +432,19 @@ as reported by the agent via `update_total_assets()`.  The live balance getters
 query on-chain token balances directly and therefore represent the current
 on-chain state before any yield reporting adjustment.
 
-## TotalDeposits vs TotalAssets Relationship (Issue #183)
+## TotalDeposits vs TotalAssets Relationship (Issues #183, #299)
 
 Two separate values track vault accounting:
 
 | Field | Updated by | Includes yield? | Used for |
 |---|---|---|---|
-| `TotalDeposits` | `deposit`, `withdraw` | No | Principal bookkeeping, reporting |
-| `TotalAssets` | `deposit`, `withdraw`, `update_total_assets` | Yes | Share pricing, TVL cap guard |
+| `TotalDeposits` | `deposit`, `withdraw` | No | Principal bookkeeping, reporting only |
+| `TotalAssets` | `deposit`, `withdraw`, `update_total_assets` | Yes | Share pricing, TVL cap guard, all economic math |
+
+**Design decision (issue #299):** `TotalDeposits` is intentionally *not* synced
+when `update_total_assets()` is called.  It is a principal-only counter.
+`TotalAssets` is the authoritative value for all economic calculations and cap
+enforcement.
 
 **TVL cap check uses `TotalAssets`**: after yield accrual `TotalAssets` can
 exceed `TotalDeposits`.  The cap must compare against `TotalAssets` to prevent
@@ -447,9 +452,13 @@ additional deposits from pushing total managed value past the intended limit.
 Checking `TotalDeposits` instead would allow over-subscription once yield has
 grown the vault past the cap.
 
-Share price formula: `share_price = TotalAssets / TotalShares`.  All economic
+**Share pricing**: `share_price = TotalAssets / TotalShares`.  All economic
 quantities (user balance, redemption amount) derive from `TotalAssets`, not
 `TotalDeposits`.
+
+**Regression tests**: `tests/test_total_assets_cap.rs` covers the full lifecycle:
+deposit → yield accrual → withdrawal → cap check, confirming that `TotalAssets`
+diverges from `TotalDeposits` after yield and that cap guards remain correct.
 
 ## expected_apy Validation (Issue #185)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This changelog is tied to the vault contract `Version` storage value. Each relea
 ## [Unreleased]
 <!-- Add entries below. Format: `- Short description (Issue #N).` -->
 <!-- If this PR bumps get_version(), note the new Version value here. -->
+- `deploy-devnet.sh` now writes `OWNER_ADDRESS` to `devnet-contracts.env` so
+  `verify-deployment.sh` can run without missing-variable errors (Issue #298).
+- Document the `TotalDeposits` vs `TotalAssets` design decision in `lib.rs`,
+  `ARCHITECTURE.md`, and `test_total_assets_cap.rs`; `TotalDeposits` is
+  intentionally not synced on yield — all cap guards use `TotalAssets`
+  (Issue #299).
 - Add GitHub issue templates as structured YAML forms (Issue #330).
 - Migrate weak `!events.is_empty()` test assertions to strict payload checks (Issue #333).
 - Dedicated `TvlCapUpdatedEvent` / `UserDepositCapUpdatedEvent` replace ambiguous

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -65,7 +65,8 @@
 //! ### Instance Storage (Contract-Wide, Expensive to Read/Write)
 //! - `Agent`: The authorized AI agent address that can call rebalance()
 //! - `UsdcToken`: The USDC token contract address
-//! - `TotalDeposits`: Total USDC held in vault (excluding yield deployed externally)
+//! - `TotalDeposits`: Total USDC principal deposited by users; never includes yield.
+//!   Use `TotalAssets` for share pricing and cap guards (see issue #299 / ARCHITECTURE.md).
 //! - `Paused`: Boolean flag for emergency pause state
 //! - `Owner`: Contract owner address for administrative functions
 //! - `TvlCap`: Maximum total value locked in the vault
@@ -3443,27 +3444,26 @@ impl NeuroWealthVault {
         }
     }
 
-    /// Returns the total USDC deposited in the vault.
+    /// Returns the total USDC principal deposited in the vault (issue #299).
     ///
-    /// This is the sum of all user principal balances. It represents the
-    /// total principal deposited by users and does NOT include yield that
-    /// may have been earned through external strategies.
+    /// **Relationship between `TotalDeposits`, `TotalAssets`, and shares:**
     ///
-    /// # Arguments
+    /// | Value | Includes yield? | Used for |
+    /// |---|---|---|
+    /// | `TotalDeposits` | No  | Principal bookkeeping and reporting only |
+    /// | `TotalAssets`   | Yes | Share pricing, TVL cap guard, user balances |
     ///
-    /// * `env` - The Soroban environment.
+    /// After `update_total_assets()` is called to reflect external yield,
+    /// `TotalAssets >= TotalDeposits`.  All economic quantities — share minting,
+    /// user redemption amounts, and the TVL cap check — use `TotalAssets`, never
+    /// `TotalDeposits`.  `TotalDeposits` is intentionally not synced on yield
+    /// updates; it is a principal-only counter useful for reporting.
+    ///
+    /// See also: `get_total_assets()`, ARCHITECTURE.md §"TotalDeposits vs TotalAssets".
     ///
     /// # Returns
     ///
     /// Returns total USDC principal deposits in raw units (7 decimal places).
-    ///
-    /// # Events
-    ///
-    /// None.
-    ///
-    /// # Errors
-    ///
-    /// None.
     ///
     /// # Panics
     ///

--- a/neurowealth-vault/contracts/vault/src/tests/test_total_assets_cap.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_total_assets_cap.rs
@@ -1,9 +1,18 @@
-//! Regression tests for issue #183 – TVL cap uses TotalAssets (not TotalDeposits).
+//! Regression tests for issues #183 and #299 – TVL cap uses TotalAssets (not TotalDeposits).
 //!
-//! TotalDeposits tracks principal only; TotalAssets includes yield.
-//! After yield accrual via update_total_assets(), TotalAssets > TotalDeposits.
-//! The TVL cap must compare against TotalAssets to prevent the vault from
-//! accepting deposits that would push total managed value past the cap.
+//! ## TotalDeposits vs TotalAssets (issue #299)
+//!
+//! `TotalDeposits` tracks principal only; `TotalAssets` includes yield.
+//! After `update_total_assets()`, `TotalAssets >= TotalDeposits`.
+//!
+//! Design decision (issue #299): `TotalDeposits` is intentionally *not* synced on
+//! yield updates.  It is a principal-only counter for reporting.  All cap guards
+//! and share-pricing use `TotalAssets` so that yield is correctly accounted for.
+//!
+//! The TVL cap compares against `TotalAssets` to prevent the vault from accepting
+//! deposits that would push total managed value (principal + yield) past the cap.
+//! Checking `TotalDeposits` instead would allow over-subscription once yield grows
+//! the vault past the cap.
 
 use super::utils::*;
 use soroban_sdk::{testutils::Address as _, Address, Env};

--- a/scripts/deploy-devnet.sh
+++ b/scripts/deploy-devnet.sh
@@ -224,6 +224,9 @@ VAULT_CONTRACT_ID="$vault_address"
 USDC_TOKEN_ADDRESS="$token_address"
 DEPLOYER_ADDRESS="$deployer_address"
 
+# Owner (deployer is the initial owner after initialize)
+OWNER_ADDRESS="$deployer_address"
+
 # AI Agent (using deployer key for testing)
 AGENT_SECRET_KEY="$SOROBAN_SECRET_KEY"
 AGENT_ADDRESS="$deployer_address"


### PR DESCRIPTION
## Summary

Addresses two open issues in a single focused PR.

---

### Issue #298 — `scripts/verify-deployment.sh` for post-deploy smoke checks

`verify-deployment.sh` already exists and satisfies all acceptance criteria
(reads `devnet-contracts.env`, checks `get_version`/init state, `get_agent`,
`get_usdc_token`, `is_paused`, exits non-zero on failure).

**Gap fixed:** `deploy-devnet.sh` was writing `DEPLOYER_ADDRESS` to the env
file but not `OWNER_ADDRESS`, which `verify-deployment.sh` requires as a
mandatory variable.  After `initialize()` the deployer is the owner, so:

```
# scripts/deploy-devnet.sh — new line in save_contract_addresses()
OWNER_ADDRESS="$deployer_address"
```

The full flow `./scripts/deploy-devnet.sh && ./scripts/verify-deployment.sh`
now runs without a `missing required variable: OWNER_ADDRESS` error.

---

### Issue #299 — Reconcile `TotalDeposits` with share-based `TotalAssets` after yield

**Design decision (already correct in code, now documented explicitly):**

`TotalDeposits` is intentionally *not* synced when `update_total_assets()` is
called. It is a principal-only counter useful for off-chain reporting. All
on-chain economic calculations — share minting, user redemption, TVL cap
enforcement — use `TotalAssets` (principal + yield).

| Field | Updated by | Includes yield? | Used for |
|---|---|---|---|
| `TotalDeposits` | `deposit`, `withdraw` | No | Principal bookkeeping only |
| `TotalAssets` | `deposit`, `withdraw`, `update_total_assets` | Yes | Share pricing, TVL cap guard |

**Changes:**
- `neurowealth-vault/contracts/vault/src/lib.rs`: updated module-level storage
  table and `get_total_deposits()` doc comment with a relationship table and a
  cross-reference to `ARCHITECTURE.md`.
- `ARCHITECTURE.md`: §"TotalDeposits vs TotalAssets" now references issue #299,
  states the design decision, and links to the regression test file.
- `tests/test_total_assets_cap.rs`: module doc updated to reference issue #299
  and state the design rationale inline.
- `CHANGELOG.md`: entries added under `[Unreleased]`.

**Regression coverage** (all 4 tests pass):
- `test_tvl_cap_blocks_deposit_after_yield_accrual` — cap check rejects deposits
  once TotalAssets (not TotalDeposits) exceeds the cap.
- `test_deposit_accepted_when_total_assets_plus_amount_within_cap` — deposit
  accepted while TotalAssets remains below cap after yield.
- `test_deposit_yield_withdraw_cap_regression` — full lifecycle: deposit → yield
  → withdraw → cap check.
- `test_total_assets_reflects_yield_while_total_deposits_stays_as_principal` —
  confirms TotalDeposits is unchanged by yield while TotalAssets grows.

---

## Checklist

- [x] I have updated `CHANGELOG.md` under `[Unreleased]` for any contract behavior, event, or error-code changes.
- [x] If this PR bumps `get_version()`, the new version number is noted in `CHANGELOG.md`. *(no version bump — documentation/script only)*
- [x] I have confirmed the release entry matches the expected contract `Version` storage value. *(N/A)*
- [x] I have included tests or documentation updates for new contract behavior.
- [x] New or changed events are reflected in `EVENTS.md`. *(no new events)*

Closes #298
Closes #299
