### PR TITLE
Feat/upgrade timelock and dex tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ This changelog is tied to the vault contract `Version` storage value. Each relea
 ## [Unreleased]
 <!-- Add entries below. Format: `- Short description (Issue #N).` -->
 <!-- If this PR bumps get_version(), note the new Version value here. -->
+- **Timelocked contract upgrade (Issue #316):** the instant `upgrade()` is
+  replaced by a two-step, timelocked flow with a cancel path so a compromised
+  owner key can no longer swap WASM with no recovery window.
+  - New `schedule_upgrade(owner, new_wasm_hash)` records a pending hash and a
+    ≈24-hour (`UPGRADE_TIMELOCK_LEDGERS`) expiry ledger; `execute_upgrade(owner)`
+    applies it only after the timelock; `cancel_upgrade(owner)` clears a pending
+    upgrade. `get_pending_upgrade()` exposes the pending hash and expiry.
+  - New storage keys `DataKey::PendingUpgradeHash` / `UpgradeTimelockExpiry`.
+  - New events `UpgradeScheduledEvent` (`upg_sched`) and `UpgradeCancelledEvent`
+    (`upg_cncl`); `UpgradedEvent` is now emitted by `execute_upgrade`. See EVENTS.md.
+  - Error codes 48–50 are generalized from agent-specific to shared timelock
+    names (`TimelockAlreadyPending`, `NoTimelockPending`, `TimelockNotExpired`)
+    and reused by both the agent (#317) and upgrade timelocks, since the SDK caps
+    `#[contracterror]` enums at 50 cases. Numeric codes are unchanged.
+  - No `Version` bump (pre-mainnet).
+- Add snapshot tests for the DEX event payloads `DexSupplyEvent`,
+  `DexWithdrawEvent`, and `DexPoolConfiguredEvent`, mirroring the existing Blend
+  event snapshot tests (Issue #340).
+- Add ApprovalTtl test coverage for the DEX supply path: default TTL, configured
+  TTL, and min/max bound rejection, mirroring the Blend coverage (Issue #341).
 - `deploy-devnet.sh` now writes `OWNER_ADDRESS` to `devnet-contracts.env` so
   `verify-deployment.sh` can run without missing-variable errors (Issue #298).
 - Document the `TotalDeposits` vs `TotalAssets` design decision in `lib.rs`,

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -423,6 +423,34 @@ pub struct UpgradedEvent {
 }
 ```
 
+Emitted by `execute_upgrade` once the upgrade timelock has elapsed (Issue #316).
+
+### 16a. UpgradeScheduledEvent
+**Topic:** `"upg_sched"`
+
+Emitted when an upgrade is scheduled via `schedule_upgrade` — step 1 of the
+two-step timelocked upgrade (Issue #316). The new WASM hash does not take effect
+until `execute_upgrade` is called at or after `effective_ledger`.
+
+```rust
+pub struct UpgradeScheduledEvent {
+    pub new_wasm_hash: BytesN<32>, // Hash of the WASM to activate after the timelock
+    pub effective_ledger: u32,     // Ledger at which execute_upgrade becomes callable
+}
+```
+
+### 16b. UpgradeCancelledEvent
+**Topic:** `"upg_cncl"`
+
+Emitted when a pending upgrade is cancelled via `cancel_upgrade` before it is
+executed — the recovery path against a malicious or mistaken schedule (Issue #316).
+
+```rust
+pub struct UpgradeCancelledEvent {
+    pub cancelled_wasm_hash: BytesN<32>, // Hash of the WASM whose pending upgrade was cancelled
+}
+```
+
 ## Event Monitoring Guide
 
 ### For AI Agents

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -226,12 +226,17 @@ pub enum VaultError {
     DexPoolNotConfigured = 46,
     /// Strategy must be one of "conservative", "balanced", or "growth".
     InvalidStrategy = 47,
-    /// An agent update proposal is already pending.
-    AgentUpdateAlreadyPending = 48,
-    /// No pending agent update exists to confirm or cancel.
-    NoAgentUpdatePending = 49,
-    /// The agent timelock delay has not yet elapsed.
-    AgentTimelockNotExpired = 50,
+    /// A timelocked proposal (agent update or upgrade) is already pending.
+    ///
+    /// Shared by the agent timelock (#317) and the upgrade timelock (#316).
+    /// The SDK caps `#[contracterror]` enums at 50 cases, so both two-step flows
+    /// reuse one set of generic timelock error codes rather than each defining
+    /// their own.
+    TimelockAlreadyPending = 48,
+    /// No timelocked proposal exists to confirm/execute or cancel.
+    NoTimelockPending = 49,
+    /// The timelock delay has not yet elapsed.
+    TimelockNotExpired = 50,
 }
 
 // ============================================================================
@@ -325,6 +330,10 @@ pub enum DataKey {
     PendingAgent,
     /// Ledger sequence at which the pending agent update becomes effective (#317).
     AgentTimelockExpiry,
+    /// Pending contract WASM hash awaiting timelock execution (#316).
+    PendingUpgradeHash,
+    /// Ledger sequence at which the pending upgrade becomes executable (#316).
+    UpgradeTimelockExpiry,
 }
 
 // ============================================================================
@@ -646,6 +655,30 @@ pub struct UpgradedEvent {
     pub new_version: u32,
 }
 
+/// Emitted when an upgrade is scheduled via `schedule_upgrade()` (timelock step 1). (#316)
+///
+/// # Topics
+/// - `SymbolShort("upg_sched")` - Event identifier
+#[allow(missing_docs)]
+#[contracttype]
+pub struct UpgradeScheduledEvent {
+    /// Hash of the WASM binary that will be activated once the timelock elapses.
+    pub new_wasm_hash: BytesN<32>,
+    /// Ledger at which `execute_upgrade()` becomes callable.
+    pub effective_ledger: u32,
+}
+
+/// Emitted when a pending upgrade is cancelled via `cancel_upgrade()`. (#316)
+///
+/// # Topics
+/// - `SymbolShort("upg_cncl")` - Event identifier
+#[allow(missing_docs)]
+#[contracttype]
+pub struct UpgradeCancelledEvent {
+    /// Hash of the WASM binary whose pending upgrade was cancelled.
+    pub cancelled_wasm_hash: BytesN<32>,
+}
+
 /// Emitted when assets are supplied to Blend protocol.
 ///
 /// # Topics
@@ -822,6 +855,12 @@ const MAX_APPROVAL_TTL: u32 = 500_000;
 /// 17,280 ledgers × ~5 s per ledger ≈ 86,400 s = 24 h.
 const AGENT_TIMELOCK_LEDGERS: u32 = 17_280;
 
+/// Number of ledgers an upgrade must wait between `schedule_upgrade` and
+/// `execute_upgrade` (#316). Same 24-hour window as the agent timelock, giving
+/// users and operators a recovery window to react to a malicious or mistaken
+/// upgrade proposal (and to `cancel_upgrade`) before new WASM takes effect.
+const UPGRADE_TIMELOCK_LEDGERS: u32 = 17_280;
+
 /// Minimum ledgers remaining before `touch_user_ttl` extends a user's `Shares` entry.
 const USER_SHARES_TTL_THRESHOLD: u32 = 100;
 /// Target ledgers to extend a user's `Shares` entry to when maintaining TTL.
@@ -839,8 +878,9 @@ use topics::{
     TOPIC_DEX_POOL_CONFIGURED, TOPIC_DEX_SUPPLY, TOPIC_DEX_WITHDRAW, TOPIC_EMERGENCY_PAUSED,
     TOPIC_INIT, TOPIC_LIMITS_UPDATED, TOPIC_OWNERSHIP_CANCELLED, TOPIC_OWNERSHIP_INITIATED,
     TOPIC_OWNERSHIP_TRANSFERRED, TOPIC_PAUSED, TOPIC_PROTOCOL_CHANGED, TOPIC_REBALANCE,
-    TOPIC_REBALANCE_FAILED, TOPIC_TVL_CAP_UPDATED, TOPIC_UNPAUSED, TOPIC_UPGRADED,
-    TOPIC_USER_CAP_UPDATED, TOPIC_USER_STRATEGY_UPDATED, TOPIC_WITHDRAW,
+    TOPIC_REBALANCE_FAILED, TOPIC_TVL_CAP_UPDATED, TOPIC_UNPAUSED, TOPIC_UPGRADE_CANCELLED,
+    TOPIC_UPGRADE_SCHEDULED, TOPIC_UPGRADED, TOPIC_USER_CAP_UPDATED, TOPIC_USER_STRATEGY_UPDATED,
+    TOPIC_WITHDRAW,
 };
 
 impl BlendPoolClient {
@@ -2648,7 +2688,7 @@ impl NeuroWealthVault {
     /// # Panics
     ///
     /// - If the caller is not the owner.
-    /// - If a pending agent update already exists (`AgentUpdateAlreadyPending`).
+    /// - If a pending agent update already exists (`TimelockAlreadyPending`).
     pub fn update_agent(env: Env, new_agent: Address) {
         Self::require_initialized(&env);
         Self::require_is_owner(&env);
@@ -2656,7 +2696,7 @@ impl NeuroWealthVault {
         Self::require(
             &env,
             !env.storage().instance().has(&DataKey::PendingAgent),
-            VaultError::AgentUpdateAlreadyPending,
+            VaultError::TimelockAlreadyPending,
         );
 
         let old_agent: Address = env.storage().instance().get(&DataKey::Agent).unwrap();
@@ -2696,8 +2736,8 @@ impl NeuroWealthVault {
     /// # Panics
     ///
     /// - If the caller is not the owner.
-    /// - If no pending proposal exists (`NoAgentUpdatePending`).
-    /// - If the timelock delay has not yet elapsed (`AgentTimelockNotExpired`).
+    /// - If no pending proposal exists (`NoTimelockPending`).
+    /// - If the timelock delay has not yet elapsed (`TimelockNotExpired`).
     pub fn confirm_agent_update(env: Env) {
         Self::require_initialized(&env);
         Self::require_is_owner(&env);
@@ -2705,7 +2745,7 @@ impl NeuroWealthVault {
         Self::require(
             &env,
             env.storage().instance().has(&DataKey::PendingAgent),
-            VaultError::NoAgentUpdatePending,
+            VaultError::NoTimelockPending,
         );
 
         let expiry: u32 = env
@@ -2717,7 +2757,7 @@ impl NeuroWealthVault {
         Self::require(
             &env,
             env.ledger().sequence() >= expiry,
-            VaultError::AgentTimelockNotExpired,
+            VaultError::TimelockNotExpired,
         );
 
         let old_agent: Address = env.storage().instance().get(&DataKey::Agent).unwrap();
@@ -2762,7 +2802,7 @@ impl NeuroWealthVault {
     /// # Panics
     ///
     /// - If the caller is not the owner.
-    /// - If no pending proposal exists (`NoAgentUpdatePending`).
+    /// - If no pending proposal exists (`NoTimelockPending`).
     pub fn cancel_agent_update(env: Env) {
         Self::require_initialized(&env);
         Self::require_is_owner(&env);
@@ -2770,7 +2810,7 @@ impl NeuroWealthVault {
         Self::require(
             &env,
             env.storage().instance().has(&DataKey::PendingAgent),
-            VaultError::NoAgentUpdatePending,
+            VaultError::NoTimelockPending,
         );
 
         let old_agent: Address = env.storage().instance().get(&DataKey::Agent).unwrap();
@@ -3287,12 +3327,15 @@ impl NeuroWealthVault {
     // ADMINISTRATIVE - UPGRADES
     // ==========================================================================
 
-    /// Upgrades the contract to a new WASM implementation.
+    /// Schedules a contract upgrade behind a timelock (step 1 of 2). (#316)
     ///
-    /// The owner must authorize this call. The new WASM hash must correspond
-    /// to a binary previously uploaded to the network via
-    /// `stellar contract install`. All storage state (user balances,
-    /// configuration, owner, agent) is preserved across upgrades.
+    /// Records `new_wasm_hash` as the pending upgrade and sets an expiry ledger
+    /// after which `execute_upgrade()` may be called. The delay
+    /// (`UPGRADE_TIMELOCK_LEDGERS`, ≈24 h) gives users and operators a recovery
+    /// window to observe the proposal on-chain and react — including calling
+    /// `cancel_upgrade()` — before new WASM takes effect. This closes the
+    /// "compromised owner key swaps WASM instantly" gap. Only one pending
+    /// upgrade is allowed at a time.
     ///
     /// # Arguments
     ///
@@ -3300,25 +3343,17 @@ impl NeuroWealthVault {
     /// * `owner` - The owner address (must authorize).
     /// * `new_wasm_hash` - Hash of the new WASM binary (32 bytes).
     ///
-    /// # Returns
-    ///
-    /// None.
-    ///
     /// # Events
     ///
     /// Emits:
-    /// - `UpgradedEvent`
-    ///
-    /// # Errors
-    ///
-    /// None.
+    /// - `UpgradeScheduledEvent`
     ///
     /// # Panics
     ///
     /// - If the vault is paused.
     /// - If the caller is not the stored owner.
-    /// - If `new_wasm_hash` does not correspond to an uploaded WASM binary.
-    pub fn upgrade(env: Env, owner: Address, new_wasm_hash: BytesN<32>) {
+    /// - If an upgrade is already pending (`TimelockAlreadyPending`).
+    pub fn schedule_upgrade(env: Env, owner: Address, new_wasm_hash: BytesN<32>) {
         Self::require_initialized(&env);
         owner.require_auth();
         Self::require_not_paused(&env);
@@ -3326,13 +3361,102 @@ impl NeuroWealthVault {
         let stored_owner: Address = env.storage().instance().get(&DataKey::Owner).unwrap();
         Self::require(&env, owner == stored_owner, VaultError::CallerIsNotOwner);
 
+        Self::require(
+            &env,
+            !env.storage().instance().has(&DataKey::PendingUpgradeHash),
+            VaultError::TimelockAlreadyPending,
+        );
+
+        let effective_ledger = env
+            .ledger()
+            .sequence()
+            .saturating_add(UPGRADE_TIMELOCK_LEDGERS);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingUpgradeHash, &new_wasm_hash);
+        env.storage()
+            .instance()
+            .set(&DataKey::UpgradeTimelockExpiry, &effective_ledger);
+
+        env.events().publish(
+            (TOPIC_UPGRADE_SCHEDULED,),
+            UpgradeScheduledEvent {
+                new_wasm_hash,
+                effective_ledger,
+            },
+        );
+    }
+
+    /// Executes a scheduled upgrade after the timelock has elapsed (step 2 of 2). (#316)
+    ///
+    /// Can only be called once `env.ledger().sequence() >= UpgradeTimelockExpiry`.
+    /// On success the pending WASM hash is activated, the contract `Version` is
+    /// incremented, and the pending proposal is cleared. All storage state (user
+    /// balances, configuration, owner, agent) is preserved across the upgrade.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment.
+    /// * `owner` - The owner address (must authorize).
+    ///
+    /// # Events
+    ///
+    /// Emits:
+    /// - `UpgradedEvent`
+    ///
+    /// # Panics
+    ///
+    /// - If the vault is paused.
+    /// - If the caller is not the stored owner.
+    /// - If no pending upgrade exists (`NoTimelockPending`).
+    /// - If the timelock delay has not yet elapsed (`TimelockNotExpired`).
+    /// - If the pending hash does not correspond to an uploaded WASM binary.
+    pub fn execute_upgrade(env: Env, owner: Address) {
+        Self::require_initialized(&env);
+        owner.require_auth();
+        Self::require_not_paused(&env);
+
+        let stored_owner: Address = env.storage().instance().get(&DataKey::Owner).unwrap();
+        Self::require(&env, owner == stored_owner, VaultError::CallerIsNotOwner);
+
+        Self::require(
+            &env,
+            env.storage().instance().has(&DataKey::PendingUpgradeHash),
+            VaultError::NoTimelockPending,
+        );
+
+        let expiry: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::UpgradeTimelockExpiry)
+            .unwrap_or(0);
+
+        Self::require(
+            &env,
+            env.ledger().sequence() >= expiry,
+            VaultError::TimelockNotExpired,
+        );
+
+        let new_wasm_hash: BytesN<32> = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingUpgradeHash)
+            .unwrap();
+
+        // Clear the pending proposal before applying the upgrade so a fresh
+        // proposal can be scheduled afterwards.
+        env.storage()
+            .instance()
+            .remove(&DataKey::PendingUpgradeHash);
+        env.storage()
+            .instance()
+            .remove(&DataKey::UpgradeTimelockExpiry);
+
         // Soroban will trap/panic here if the hash is not installed on the network.
-        // We perform the upgrade first to ensure a bad hash does not leave us with
-        // an incremented version but failed upgrade.
         env.deployer().update_current_contract_wasm(new_wasm_hash);
 
         let old_version: u32 = env.storage().instance().get(&DataKey::Version).unwrap_or(1);
-
         let new_version = old_version.checked_add(1).expect("vault: version overflow");
         env.storage()
             .instance()
@@ -3345,6 +3469,76 @@ impl NeuroWealthVault {
                 new_version,
             },
         );
+    }
+
+    /// Cancels a pending upgrade before it can be executed. (#316)
+    ///
+    /// Only the owner may cancel. Clears the pending proposal so a new one can
+    /// be scheduled. Safe to call at any point during the timelock window — this
+    /// is the recovery path if a malicious or mistaken upgrade was scheduled.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment.
+    /// * `owner` - The owner address (must authorize).
+    ///
+    /// # Events
+    ///
+    /// Emits:
+    /// - `UpgradeCancelledEvent`
+    ///
+    /// # Panics
+    ///
+    /// - If the caller is not the stored owner.
+    /// - If no pending upgrade exists (`NoTimelockPending`).
+    pub fn cancel_upgrade(env: Env, owner: Address) {
+        Self::require_initialized(&env);
+        owner.require_auth();
+
+        let stored_owner: Address = env.storage().instance().get(&DataKey::Owner).unwrap();
+        Self::require(&env, owner == stored_owner, VaultError::CallerIsNotOwner);
+
+        Self::require(
+            &env,
+            env.storage().instance().has(&DataKey::PendingUpgradeHash),
+            VaultError::NoTimelockPending,
+        );
+
+        let cancelled_wasm_hash: BytesN<32> = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingUpgradeHash)
+            .unwrap();
+
+        env.storage()
+            .instance()
+            .remove(&DataKey::PendingUpgradeHash);
+        env.storage()
+            .instance()
+            .remove(&DataKey::UpgradeTimelockExpiry);
+
+        env.events().publish(
+            (TOPIC_UPGRADE_CANCELLED,),
+            UpgradeCancelledEvent {
+                cancelled_wasm_hash,
+            },
+        );
+    }
+
+    /// Returns the pending upgrade WASM hash and effective ledger, if a proposal
+    /// is active. (#316)
+    pub fn get_pending_upgrade(env: Env) -> Option<(BytesN<32>, u32)> {
+        Self::require_initialized(&env);
+        let pending: Option<BytesN<32>> =
+            env.storage().instance().get(&DataKey::PendingUpgradeHash);
+        pending.map(|hash| {
+            let expiry: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::UpgradeTimelockExpiry)
+                .unwrap_or(0);
+            (hash, expiry)
+        })
     }
 
     // ==========================================================================

--- a/neurowealth-vault/contracts/vault/src/tests/mod.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/mod.rs
@@ -39,6 +39,7 @@ mod test_ttl;
 mod test_tvl_cap_serial;
 mod test_update_total_assets_blend;
 mod test_upgrade_compatibility;
+mod test_upgrade_timelock;
 mod test_user_strategy;
 mod test_withdraw;
 mod test_yield;

--- a/neurowealth-vault/contracts/vault/src/tests/test_access_control.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_access_control.rs
@@ -303,7 +303,7 @@ fn test_non_owner_cannot_upgrade() {
 
     let non_owner = Address::generate(&env);
     let fake_wasm_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
-    client.upgrade(&non_owner, &fake_wasm_hash);
+    client.schedule_upgrade(&non_owner, &fake_wasm_hash);
 }
 
 // ============================================================================
@@ -714,7 +714,7 @@ fn test_agent_cannot_upgrade() {
 
     let fake_wasm_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
     // agent is distinct from owner, so this should panic
-    client.upgrade(&agent, &fake_wasm_hash);
+    client.schedule_upgrade(&agent, &fake_wasm_hash);
 }
 
 // ============================================================================

--- a/neurowealth-vault/contracts/vault/src/tests/test_agent_timelock.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_agent_timelock.rs
@@ -5,8 +5,8 @@
 //! - Confirm succeeds only after the timelock window and emits both confirm events.
 //! - Cancel clears the pending proposal and emits AgentUpdateCancelledEvent.
 //! - Duplicate proposals are rejected while one is pending.
-//! - Confirm before timelock is rejected with AgentTimelockNotExpired.
-//! - Confirm/cancel with no pending proposal are rejected with NoAgentUpdatePending.
+//! - Confirm before timelock is rejected with TimelockNotExpired (#50).
+//! - Confirm/cancel with no pending proposal are rejected with NoTimelockPending (#49).
 //! - Only the owner can propose, confirm, or cancel.
 
 use super::utils::*;
@@ -53,7 +53,7 @@ fn test_propose_while_pending_rejected() {
     let new_agent2 = Address::generate(&env);
 
     client.update_agent(&new_agent1);
-    // Second proposal while first is pending must panic with AgentUpdateAlreadyPending (48).
+    // Second proposal while first is pending must panic with TimelockAlreadyPending (#48).
     client.update_agent(&new_agent2);
 }
 
@@ -168,7 +168,7 @@ fn test_new_proposal_allowed_after_cancel() {
     assert!(client.get_pending_agent_update().is_some());
 }
 
-/// Confirm with no pending proposal must be rejected with NoAgentUpdatePending (49).
+/// Confirm with no pending proposal must be rejected with NoTimelockPending (#49).
 #[test]
 #[should_panic(expected = "Error(Contract, #49)")]
 fn test_confirm_with_no_pending_rejected() {
@@ -181,7 +181,7 @@ fn test_confirm_with_no_pending_rejected() {
     client.confirm_agent_update();
 }
 
-/// Cancel with no pending proposal must be rejected with NoAgentUpdatePending (49).
+/// Cancel with no pending proposal must be rejected with NoTimelockPending (#49).
 #[test]
 #[should_panic(expected = "Error(Contract, #49)")]
 fn test_cancel_with_no_pending_rejected() {

--- a/neurowealth-vault/contracts/vault/src/tests/test_approval_ttl.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_approval_ttl.rs
@@ -36,6 +36,35 @@ fn setup_blend_position(
     (contract_id, usdc_token, blend_pool, client, token_client)
 }
 
+/// Sets up a vault with a configured DEX pool, a funded user deposit, and an
+/// optional approval TTL — the DEX analogue of [`setup_blend_position`].
+fn setup_dex_position(
+    env: &Env,
+    ttl: Option<u32>,
+) -> (
+    Address,
+    Address,
+    Address,
+    NeuroWealthVaultClient<'_>,
+    TestTokenClient<'_>,
+) {
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, usdc_token, dex_pool) = setup_vault_with_token_and_dex(env);
+    let client = NeuroWealthVaultClient::new(env, &contract_id);
+    let token_client = TestTokenClient::new(env, &usdc_token);
+
+    client.set_dex_pool(&owner, &dex_pool);
+    if let Some(ttl) = ttl {
+        client.set_approval_ttl(&ttl);
+    }
+
+    let user = Address::generate(env);
+    mint_and_deposit(env, &client, &usdc_token, &user, 10_000_000_i128);
+
+    (contract_id, usdc_token, dex_pool, client, token_client)
+}
+
 #[test]
 fn test_approval_expiry_uses_configured_ttl() {
     let env = Env::default();
@@ -133,5 +162,81 @@ fn test_set_approval_ttl_rejects_above_maximum() {
     assert!(
         result.is_err(),
         "set_approval_ttl should reject TTL above maximum"
+    );
+}
+
+// ─── DEX supply path (#341) ─────────────────────────────────────────────────
+//
+// The DEX supply path (`rebalance("dex", ..)` → `add_liquidity`) approves the
+// pool to spend USDC using the same configurable approval TTL as Blend. These
+// tests mirror the Blend coverage above for the DEX flow.
+
+#[test]
+fn test_dex_approval_expiry_uses_configured_ttl() {
+    let env = Env::default();
+    let configured_ttl = 2_500_u32;
+    let (contract_id, _usdc_token, dex_pool, client, token_client) =
+        setup_dex_position(&env, Some(configured_ttl));
+
+    let sequence = env.ledger().sequence();
+    client.rebalance(&symbol_short!("dex"), &700_i128, &0_i128);
+
+    let expiration = token_client.allowance_expiration(&contract_id, &dex_pool);
+    assert_eq!(expiration, sequence + configured_ttl);
+}
+
+#[test]
+fn test_dex_approval_expiry_minimum_ttl_is_valid() {
+    let env = Env::default();
+    let minimum_ttl = 1_000_u32;
+    let (contract_id, _usdc_token, dex_pool, client, token_client) =
+        setup_dex_position(&env, Some(minimum_ttl));
+
+    let sequence = env.ledger().sequence();
+    client.rebalance(&symbol_short!("dex"), &700_i128, &0_i128);
+
+    let expiration = token_client.allowance_expiration(&contract_id, &dex_pool);
+    assert_eq!(expiration, sequence + minimum_ttl);
+    assert!(expiration > sequence);
+}
+
+#[test]
+fn test_default_approval_ttl_used_for_dex_supply() {
+    let env = Env::default();
+    let (contract_id, _usdc_token, dex_pool, client, token_client) =
+        setup_dex_position(&env, None);
+
+    assert_eq!(client.get_approval_ttl(), DEFAULT_APPROVAL_TTL);
+
+    let sequence = env.ledger().sequence();
+    client.rebalance(&symbol_short!("dex"), &700_i128, &0_i128);
+
+    let expiration = token_client.allowance_expiration(&contract_id, &dex_pool);
+    assert_eq!(expiration, sequence + DEFAULT_APPROVAL_TTL);
+}
+
+#[test]
+fn test_dex_position_set_approval_ttl_rejects_below_minimum() {
+    let env = Env::default();
+    let (_contract_id, _usdc_token, _dex_pool, client, _token_client) =
+        setup_dex_position(&env, None);
+
+    let result = client.try_set_approval_ttl(&999_u32);
+    assert!(
+        result.is_err(),
+        "set_approval_ttl should reject TTL below minimum on the DEX path"
+    );
+}
+
+#[test]
+fn test_dex_position_set_approval_ttl_rejects_above_maximum() {
+    let env = Env::default();
+    let (_contract_id, _usdc_token, _dex_pool, client, _token_client) =
+        setup_dex_position(&env, None);
+
+    let result = client.try_set_approval_ttl(&500_001_u32);
+    assert!(
+        result.is_err(),
+        "set_approval_ttl should reject TTL above maximum on the DEX path"
     );
 }

--- a/neurowealth-vault/contracts/vault/src/tests/test_event_payloads.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_event_payloads.rs
@@ -15,11 +15,12 @@
 use super::utils::*;
 use crate::{
     AgentUpdatedEvent, AssetsUpdatedEvent, CapsUpdatedEvent, DepositEvent,
-    DepositLimitsUpdatedEvent, EmergencyPausedEvent, OwnershipTransferCancelledEvent,
-    OwnershipTransferInitiatedEvent, OwnershipTransferredEvent, RebalanceEvent,
-    TvlCapUpdatedEvent, UserDepositCapUpdatedEvent, VaultInitializedEvent, VaultPausedEvent,
-    VaultUnpausedEvent, WithdrawEvent, TOPIC_AGENT_UPDATED, TOPIC_ASSETS_UPDATED,
-    TOPIC_CAPS_UPDATED, TOPIC_DEPOSIT, TOPIC_DEPOSIT_LIMITS_UPDATED, TOPIC_EMERGENCY_PAUSED,
+    DepositLimitsUpdatedEvent, DexPoolConfiguredEvent, DexSupplyEvent, DexWithdrawEvent,
+    EmergencyPausedEvent, OwnershipTransferCancelledEvent, OwnershipTransferInitiatedEvent,
+    OwnershipTransferredEvent, RebalanceEvent, TvlCapUpdatedEvent, UserDepositCapUpdatedEvent,
+    VaultInitializedEvent, VaultPausedEvent, VaultUnpausedEvent, WithdrawEvent, TOPIC_AGENT_UPDATED,
+    TOPIC_ASSETS_UPDATED, TOPIC_CAPS_UPDATED, TOPIC_DEPOSIT, TOPIC_DEPOSIT_LIMITS_UPDATED,
+    TOPIC_DEX_POOL_CONFIGURED, TOPIC_DEX_SUPPLY, TOPIC_DEX_WITHDRAW, TOPIC_EMERGENCY_PAUSED,
     TOPIC_INIT, TOPIC_OWNERSHIP_CANCELLED, TOPIC_OWNERSHIP_INITIATED, TOPIC_OWNERSHIP_TRANSFERRED,
     TOPIC_PAUSED, TOPIC_REBALANCE, TOPIC_TVL_CAP_UPDATED, TOPIC_UNPAUSED, TOPIC_USER_CAP_UPDATED,
     TOPIC_WITHDRAW,
@@ -551,6 +552,96 @@ fn snapshot_ownership_transfer_cancelled_event_all_fields() {
 
     snap!(event, owner, owner, "OwnershipTransferCancelledEvent");
     snap!(event, cancelled_pending, pending_owner, "OwnershipTransferCancelledEvent");
+}
+
+// ── DexSupplyEvent (#340) ─────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_dex_supply_event_all_fields() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, usdc_token, dex_pool) = setup_vault_with_token_and_dex(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_dex_pool(&owner, &dex_pool);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 15_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
+
+    // Supply to the DEX: emits DexSupplyEvent with the full amount.
+    client.rebalance(&symbol_short!("dex"), &950_i128, &0_i128);
+
+    let events = find_events_by_topic(env.events().all(), &env, TOPIC_DEX_SUPPLY);
+    assert_eq!(events.len(), 1, "exactly one DexSupplyEvent expected");
+
+    let (_, _, data) = &events[0];
+    let event = DexSupplyEvent::try_from_val(&env, data)
+        .expect("DexSupplyEvent: try_from_val failed — schema may have drifted");
+
+    snap!(event, asset, usdc_token, "DexSupplyEvent");
+    snap!(event, amount_actual, deposit_amount, "DexSupplyEvent");
+    snap!(event, success, true, "DexSupplyEvent");
+}
+
+// ── DexWithdrawEvent (#340) ───────────────────────────────────────────────────
+
+#[test]
+fn snapshot_dex_withdraw_event_all_fields() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, usdc_token, dex_pool) = setup_vault_with_token_and_dex(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_dex_pool(&owner, &dex_pool);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 20_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
+
+    // Supply to the DEX, then exit by rebalancing to "none": emits DexWithdrawEvent.
+    client.rebalance(&symbol_short!("dex"), &1100_i128, &0_i128);
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
+
+    let events = find_events_by_topic(env.events().all(), &env, TOPIC_DEX_WITHDRAW);
+    assert_eq!(events.len(), 1, "exactly one DexWithdrawEvent expected");
+
+    let (_, _, data) = &events[0];
+    let event = DexWithdrawEvent::try_from_val(&env, data)
+        .expect("DexWithdrawEvent: try_from_val failed — schema may have drifted");
+
+    snap!(event, asset, usdc_token, "DexWithdrawEvent");
+    snap!(event, amount_actual, deposit_amount, "DexWithdrawEvent");
+    snap!(event, success, true, "DexWithdrawEvent");
+}
+
+// ── DexPoolConfiguredEvent (#340) ─────────────────────────────────────────────
+
+#[test]
+fn snapshot_dex_pool_configured_event_all_fields() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token, dex_pool) =
+        setup_vault_with_token_and_dex(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_dex_pool(&owner, &dex_pool);
+
+    let events = find_events_by_topic(env.events().all(), &env, TOPIC_DEX_POOL_CONFIGURED);
+    assert_eq!(events.len(), 1, "exactly one DexPoolConfiguredEvent expected");
+
+    let (_, _, data) = &events[0];
+    let event = DexPoolConfiguredEvent::try_from_val(&env, data)
+        .expect("DexPoolConfiguredEvent: try_from_val failed — schema may have drifted");
+
+    // First configuration: no previous pool.
+    let expected_old_pool: Option<Address> = None;
+    snap!(event, old_pool, expected_old_pool, "DexPoolConfiguredEvent");
+    snap!(event, new_pool, dex_pool, "DexPoolConfiguredEvent");
+    snap!(event, owner, owner, "DexPoolConfiguredEvent");
 }
 
 // ── Ordering regression ───────────────────────────────────────────────────────

--- a/neurowealth-vault/contracts/vault/src/tests/test_pause.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_pause.rs
@@ -199,7 +199,7 @@ fn test_upgrade_blocked_while_paused() {
     assert!(client.is_paused());
 
     let fake_hash = BytesN::from_array(&env, &[0u8; 32]);
-    client.upgrade(&owner, &fake_hash);
+    client.schedule_upgrade(&owner, &fake_hash);
 }
 
 #[test]

--- a/neurowealth-vault/contracts/vault/src/tests/test_upgrade_timelock.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_upgrade_timelock.rs
@@ -1,0 +1,296 @@
+//! Tests for the two-step / timelocked contract upgrade (#316).
+//!
+//! Before #316 `upgrade()` was instant: a compromised owner key could swap the
+//! contract WASM immediately with no recovery window. The upgrade now follows
+//! the same timelock pattern as the agent update (#317):
+//!
+//!   1. `schedule_upgrade(owner, new_wasm_hash)` records the pending hash and an
+//!      expiry ledger, emitting `UpgradeScheduledEvent`.
+//!   2. `execute_upgrade(owner)` applies the WASM only once
+//!      `ledger().sequence() >= UpgradeTimelockExpiry`.
+//!   3. `cancel_upgrade(owner)` clears a pending proposal at any point in the
+//!      window — the recovery path against a malicious or mistaken schedule.
+//!
+//! These tests cover the schedule and cancel flows end-to-end and the execute
+//! flow's authorization, pause, and timelock gating. (Applying a real WASM
+//! binary requires an on-chain installed hash and is exercised at deployment,
+//! mirroring how the previous instant `upgrade()` was only unit-tested for its
+//! guards.)
+
+use super::utils::*;
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, BytesN, Env};
+
+fn fake_hash(env: &Env, fill: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[fill; 32])
+}
+
+// ── schedule flow ─────────────────────────────────────────────────────────────
+
+/// A successful schedule stores the pending hash and records an expiry ledger.
+#[test]
+fn test_schedule_upgrade_stores_pending() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let hash = fake_hash(&env, 7);
+    let sequence = env.ledger().sequence();
+    client.schedule_upgrade(&owner, &hash);
+
+    let pending = client.get_pending_upgrade();
+    assert!(pending.is_some(), "pending upgrade should be recorded");
+    let (pending_hash, expiry) = pending.unwrap();
+    assert_eq!(pending_hash, hash, "pending hash mismatch");
+    assert!(
+        expiry > sequence,
+        "expiry ledger must be in the future (after the timelock)"
+    );
+}
+
+/// `get_pending_upgrade` returns None before any proposal is made.
+#[test]
+fn test_get_pending_upgrade_none_initially() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    assert!(
+        client.get_pending_upgrade().is_none(),
+        "no pending upgrade should exist initially"
+    );
+}
+
+/// Scheduling while another upgrade is pending must be rejected (TimelockAlreadyPending, #48).
+#[test]
+#[should_panic(expected = "Error(Contract, #48)")]
+fn test_schedule_while_pending_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.schedule_upgrade(&owner, &fake_hash(&env, 1));
+    // Second schedule while the first is pending → TimelockAlreadyPending (#48).
+    client.schedule_upgrade(&owner, &fake_hash(&env, 2));
+}
+
+/// Only the owner can schedule an upgrade (#34).
+#[test]
+#[should_panic(expected = "Error(Contract, #34)")]
+fn test_schedule_non_owner_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let stranger = Address::generate(&env);
+    client.schedule_upgrade(&stranger, &fake_hash(&env, 3));
+}
+
+/// Scheduling is blocked while the vault is paused (#35).
+#[test]
+#[should_panic(expected = "Error(Contract, #35)")]
+fn test_schedule_blocked_while_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.pause(&owner);
+    client.schedule_upgrade(&owner, &fake_hash(&env, 4));
+}
+
+// ── execute flow ──────────────────────────────────────────────────────────────
+
+/// Executing before the timelock has elapsed must be rejected (TimelockNotExpired, #50).
+#[test]
+#[should_panic(expected = "Error(Contract, #50)")]
+fn test_execute_before_timelock_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.schedule_upgrade(&owner, &fake_hash(&env, 5));
+    // Immediately try to execute — timelock not elapsed yet.
+    client.execute_upgrade(&owner);
+}
+
+/// Executing with no pending upgrade must be rejected (NoTimelockPending, #49).
+#[test]
+#[should_panic(expected = "Error(Contract, #49)")]
+fn test_execute_with_no_pending_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.execute_upgrade(&owner);
+}
+
+/// Only the owner can execute an upgrade (#34).
+///
+/// The owner check is enforced ahead of the pending/timelock checks, so a
+/// non-owner is rejected with `CallerIsNotOwner` (#34) regardless of timelock
+/// state — no ledger advance is needed (advancing far enough would archive the
+/// contract instance in the test env).
+#[test]
+#[should_panic(expected = "Error(Contract, #34)")]
+fn test_execute_non_owner_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.schedule_upgrade(&owner, &fake_hash(&env, 6));
+
+    let stranger = Address::generate(&env);
+    client.execute_upgrade(&stranger);
+}
+
+/// Once the timelock has elapsed the execute gate is cleared: the call no longer
+/// fails with `TimelockNotExpired` (#50) and instead proceeds to apply the
+/// WASM hash (which traps here because the dummy hash is not installed on-chain).
+/// This proves the timelock window is the only thing holding execution back.
+#[test]
+#[should_panic]
+fn test_execute_after_timelock_passes_gate() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.schedule_upgrade(&owner, &fake_hash(&env, 8));
+
+    // Before expiry the gate rejects with the timelock error.
+    let before = client.try_execute_upgrade(&owner);
+    assert!(
+        before.is_err(),
+        "execute before the timelock must be rejected"
+    );
+
+    // Advance past the timelock window: the gate is now open and execution
+    // proceeds to the WASM swap, which traps on the uninstalled dummy hash.
+    let (_, expiry) = client.get_pending_upgrade().unwrap();
+    env.ledger().set_sequence_number(expiry);
+    client.execute_upgrade(&owner);
+}
+
+// ── cancel flow ───────────────────────────────────────────────────────────────
+
+/// Cancel clears the pending proposal.
+#[test]
+fn test_cancel_clears_pending_upgrade() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.schedule_upgrade(&owner, &fake_hash(&env, 9));
+    assert!(client.get_pending_upgrade().is_some());
+
+    client.cancel_upgrade(&owner);
+    assert!(
+        client.get_pending_upgrade().is_none(),
+        "pending state must be cleared after cancel"
+    );
+}
+
+/// After cancel, a fresh upgrade can be scheduled.
+#[test]
+fn test_new_schedule_allowed_after_cancel() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.schedule_upgrade(&owner, &fake_hash(&env, 10));
+    client.cancel_upgrade(&owner);
+
+    client.schedule_upgrade(&owner, &fake_hash(&env, 11));
+    let (pending_hash, _) = client.get_pending_upgrade().unwrap();
+    assert_eq!(pending_hash, fake_hash(&env, 11));
+}
+
+/// Cancel with no pending proposal must be rejected (NoTimelockPending, #49).
+#[test]
+#[should_panic(expected = "Error(Contract, #49)")]
+fn test_cancel_with_no_pending_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.cancel_upgrade(&owner);
+}
+
+/// Only the owner can cancel a pending upgrade (#34).
+#[test]
+#[should_panic(expected = "Error(Contract, #34)")]
+fn test_cancel_non_owner_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.schedule_upgrade(&owner, &fake_hash(&env, 12));
+
+    let stranger = Address::generate(&env);
+    client.cancel_upgrade(&stranger);
+}
+
+// ── events ────────────────────────────────────────────────────────────────────
+
+/// Scheduling emits `UpgradeScheduledEvent`; cancelling emits `UpgradeCancelledEvent`.
+#[test]
+fn test_schedule_and_cancel_emit_events() {
+    use crate::{UpgradeCancelledEvent, UpgradeScheduledEvent};
+    use soroban_sdk::TryFromVal;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let hash = fake_hash(&env, 13);
+    client.schedule_upgrade(&owner, &hash);
+
+    let scheduled = find_events_by_topic(env.events().all(), &env, crate::TOPIC_UPGRADE_SCHEDULED);
+    assert_eq!(
+        scheduled.len(),
+        1,
+        "exactly one UpgradeScheduledEvent expected"
+    );
+    let (_, _, data) = &scheduled[0];
+    let ev = UpgradeScheduledEvent::try_from_val(&env, data).expect("UpgradeScheduledEvent decode");
+    assert_eq!(ev.new_wasm_hash, hash);
+    assert!(ev.effective_ledger > env.ledger().sequence());
+
+    client.cancel_upgrade(&owner);
+
+    let cancelled = find_events_by_topic(env.events().all(), &env, crate::TOPIC_UPGRADE_CANCELLED);
+    assert_eq!(
+        cancelled.len(),
+        1,
+        "exactly one UpgradeCancelledEvent expected"
+    );
+    let (_, _, data) = &cancelled[0];
+    let ev = UpgradeCancelledEvent::try_from_val(&env, data).expect("UpgradeCancelledEvent decode");
+    assert_eq!(ev.cancelled_wasm_hash, hash);
+}

--- a/neurowealth-vault/contracts/vault/src/topics.rs
+++ b/neurowealth-vault/contracts/vault/src/topics.rs
@@ -40,3 +40,5 @@ pub const TOPIC_REBALANCE_FAILED: Symbol = symbol_short!("reb_fail");
 pub const TOPIC_AGENT_UPDATE_PROPOSED: Symbol = symbol_short!("agt_prop");
 pub const TOPIC_AGENT_UPDATE_CONFIRMED: Symbol = symbol_short!("agt_conf");
 pub const TOPIC_AGENT_UPDATE_CANCELLED: Symbol = symbol_short!("agt_cncl");
+pub const TOPIC_UPGRADE_SCHEDULED: Symbol = symbol_short!("upg_sched");
+pub const TOPIC_UPGRADE_CANCELLED: Symbol = symbol_short!("upg_cncl");


### PR DESCRIPTION
# Add upgrade timelock (#316) + DEX event/ApprovalTtl test coverage (#340, #341)

Closes #316
Closes #340
Closes #341

> Base branch: the project's CONTRIBUTING targets `develop`. This fork only has
> `main`; pick whichever base the upstream repo expects when opening the PR.

## Summary

This PR bundles one security fix and two test-coverage additions that share the
DEX/timelock surface area.

### #316 — Timelock for `upgrade()`
The old `upgrade()` applied new WASM instantly, so a compromised owner key could
swap the contract code with no recovery window. It is replaced by a two-step,
timelocked flow with a cancel path (mirroring the agent-update timelock, #317):

- **`schedule_upgrade(owner, new_wasm_hash)`** — records a pending hash and an
  expiry ledger (`UPGRADE_TIMELOCK_LEDGERS` ≈ 24 h); emits `UpgradeScheduledEvent`.
- **`execute_upgrade(owner)`** — applies the WASM only once
  `ledger().sequence() >= UpgradeTimelockExpiry`, then bumps `Version` and emits
  `UpgradedEvent`.
- **`cancel_upgrade(owner)`** — clears a pending upgrade at any point in the
  window (the recovery path); emits `UpgradeCancelledEvent`.
- **`get_pending_upgrade()`** — view returning `(hash, expiry)` if pending.

New storage keys: `DataKey::PendingUpgradeHash`, `DataKey::UpgradeTimelockExpiry`.

**Error-code note:** the SDK caps `#[contracterror]` enums at 50 cases and the
enum was already full at 50. Rather than failing to compile, error codes 48–50
are generalized from agent-specific names to shared timelock names
(`TimelockAlreadyPending`, `NoTimelockPending`, `TimelockNotExpired`) and reused
by both the agent (#317) and upgrade timelocks. **Numeric codes are unchanged**,
so existing `Error(Contract, #48/#49/#50)` expectations still hold.

### #340 — DEX event payload snapshot tests
Added snapshot-style regression tests pinning the topic and full field set of
`DexSupplyEvent`, `DexWithdrawEvent`, and `DexPoolConfiguredEvent` in
`test_event_payloads.rs`, mirroring the existing Blend event snapshots. Verified
EVENTS.md already documents these events to match `lib.rs`.

### #341 — DEX ApprovalTtl coverage
Added tests in `test_approval_ttl.rs` mirroring the Blend approval-TTL coverage
for the DEX supply path (`rebalance("dex", ..)` → `add_liquidity`): default TTL
applied on supply, configured TTL respected, and min/max bound rejection.

## Tests

- New: 14 upgrade-timelock tests (schedule / execute / cancel flows + guards),
  5 DEX ApprovalTtl tests, 3 DEX event snapshot tests — all passing.
- Full `cargo test` is unchanged relative to `main` except for the 22 added
  passing tests; the pre-existing environment-dependent failures on `main`
  (ledger-TTL archival and `update_agent` event expectations) are untouched and
  unrelated to this change.

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` for the contract behavior,
  event, and error-name changes.
- [x] This PR does not bump `get_version()` (additive, pre-mainnet).
- [x] Release entry matches the expected contract `Version` storage value (no bump).
- [x] Included tests for the new contract behavior.
- [x] New events reflected in `EVENTS.md` (`UpgradeScheduledEvent`,
  `UpgradeCancelledEvent`).
