### PR TITLE
docs: confirm shares-only balance accounting (Issue #184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ This changelog is tied to the vault contract `Version` storage value. Each relea
 ## [Unreleased]
 <!-- Add entries below. Format: `- Short description (Issue #N).` -->
 <!-- If this PR bumps get_version(), note the new Version value here. -->
+- **Shares-only balance accounting (Issue #184):** `DataKey::Balance(Address)`
+  is confirmed deprecated and unused by core deposit/withdraw/getter logic;
+  the discriminant is retained only to preserve the serialized `DataKey`
+  layout across upgrades. `get_balance(user)` derives principal purely from
+  `Shares(user)` and the current total-assets/total-shares exchange rate.
+  `test_balance_shares_invariant.rs` asserts `get_balance(user)` stays within
+  rounding tolerance of `convert_to_assets(get_shares(user))` across the
+  vault lifecycle, closing the audit concern about drift between principal
+  and shares.
 - **Timelocked contract upgrade (Issue #316):** the instant `upgrade()` is
   replaced by a two-step, timelocked flow with a cancel path so a compromised
   owner key can no longer swap WASM with no recovery window.


### PR DESCRIPTION
# docs: confirm shares-only balance accounting (Issue #184)

Closes #184

## Summary

Investigated the concern raised in #184 about `Balance(user)` (principal) and `Shares(user)` drifting apart after yield accrual, complicating audits.

**Finding:** the vault's core logic already implements shares-only accounting. No behavioral code change was needed — this PR documents that fact in the changelog so it's clear and traceable.

## Evidence

- `DataKey::Balance(Address)` is explicitly marked deprecated in its doc comment: retained only to preserve the serialized `DataKey` layout across upgrades, and new accounting must not read or write it.
- No deposit, withdraw, or getter path in `lib.rs` reads or writes `DataKey::Balance`.
- `get_balance(user)` derives principal purely from `Shares(user)` and the live `total_assets / total_shares` exchange rate — there is no separate stored principal value to drift.
- `test_balance_shares_invariant.rs` already asserts `get_balance(user)` stays within rounding tolerance of `convert_to_assets(get_shares(user))` across the vault lifecycle.
- `test_upgrade_compatibility.rs` documents that the `Balance` discriminant is kept only for storage-layout compatibility across upgrades.

## Acceptance criteria (from #184)

- [x] Scope: `DataKey::Balance`, deposit/withdraw paths, getters — confirmed unused outside storage-layout compatibility
- [x] Migration plan: principal is derived from shares (chosen over removing the key outright, to preserve upgrade compatibility)
- [x] Tests prove `get_balance()` matches share-derived assets

## Changes

- Added a `CHANGELOG.md` entry under `[Unreleased]` documenting the above for audit/upgrade-note purposes.