### PR TITLE
fix: resolve issues #392, #393, #395, #397

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,14 +212,22 @@ jobs:
             vault_src:
               - 'neurowealth-vault/contracts/vault/src/**'
 
-  fuzz-deposit-withdraw:
-    name: Fuzz deposit/withdraw
+  fuzz:
+    name: Fuzz ${{ matrix.target }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [changes]
     if: |
       github.event_name == 'schedule' ||
       (github.event_name == 'pull_request' && needs.changes.outputs.vault_src == 'true')
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - deposit_withdraw_sequence
+          - rebalance_transitions
+          - rounding_boundaries
+          - share_accounting_invariants
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -235,15 +243,15 @@ jobs:
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
 
-      - name: Run deposit/withdraw fuzz target (PR – short bounds)
+      - name: Run ${{ matrix.target }} fuzz target (PR – short bounds)
         if: github.event_name == 'pull_request'
         working-directory: neurowealth-vault
-        run: cargo fuzz run deposit_withdraw_sequence -- -runs=1000 -max_total_time=120
+        run: cargo fuzz run ${{ matrix.target }} -- -runs=1000 -max_total_time=120
 
-      - name: Run deposit/withdraw fuzz target (scheduled – full bounds)
+      - name: Run ${{ matrix.target }} fuzz target (scheduled – full bounds)
         if: github.event_name == 'schedule'
         working-directory: neurowealth-vault
-        run: cargo fuzz run deposit_withdraw_sequence -- -runs=5000 -max_total_time=300
+        run: cargo fuzz run ${{ matrix.target }} -- -runs=5000 -max_total_time=300
 
   e2e-devnet:
     name: E2E Devnet Validation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -85,9 +85,10 @@ The AI agent can move funds between protocols via `rebalance()`, but is constrai
 
 ### 4. Upgrade Risks
 
-The contract owner can upgrade the contract code. This introduces:
-- **Single Point of Failure**: The owner key is a high-value target.
-- **Mitigation**: Use multi-sig for the owner and timelocks for code upgrades.
+The contract owner can upgrade the contract code. To protect against malicious or accidental instant code changes, upgrade risk is mitigated via a mandatory two-step timelock mechanism:
+- **Two-Step Timelock**: Upgrades must first be scheduled via `schedule_upgrade(new_wasm_hash)`, initiating a timelock delay before `execute_upgrade()` can be called.
+- **Cancellation Window**: During the timelock window, the owner or security monitoring can invoke `cancel_upgrade()` to abort a compromised or erroneous upgrade proposal.
+- **Owner Multi-Sig Recommended**: For mainnet deployment, owner authority should be held by a multi-sig account.
 
 ### 5. State Rent & TTL Expiry
 
@@ -100,7 +101,9 @@ Soroban persistent entries (such as each user's `Shares` record) accrue state re
 
 | Function | Owner | Agent | User | Anyone |
 |----------|-------|-------|------|--------|
-| set_agent | ✅ | - | - | - |
+| update_agent | ✅ | - | - | - |
+| confirm_agent_update | ✅ | - | - | - |
+| cancel_agent_update | ✅ | - | - | - |
 | update_total_assets | - | ✅ | - | - |
 | deposit | - | - | ✅ | - |
 | withdraw | - | - | ✅ | - |
@@ -109,7 +112,9 @@ Soroban persistent entries (such as each user's `Shares` record) accrue state re
 | emergency_pause | - | ✅ | - | - |
 | unpause | ✅ | - | - | - |
 | set_caps | ✅ | - | - | - |
-| upgrade | ✅ | - | - | - |
+| schedule_upgrade | ✅ | - | - | - |
+| execute_upgrade | ✅ | - | - | - |
+| cancel_upgrade | ✅ | - | - | - |
 | set_blend_pool | ✅ | - | - | - |
 | set_dex_pool | ✅ | - | - | - |
 | transfer_ownership | ✅ | - | - | - |
@@ -168,11 +173,13 @@ is still doing:
 | Current paused state | `stellar contract invoke --id $VAULT_CONTRACT_ID --network mainnet -- get_paused` |
 | Current owner address | `stellar contract invoke --id $VAULT_CONTRACT_ID --network mainnet -- get_owner` |
 | Current agent address | `stellar contract invoke --id $VAULT_CONTRACT_ID --network mainnet -- get_agent` |
+| Pending agent update | `stellar contract invoke --id $VAULT_CONTRACT_ID --network mainnet -- get_pending_agent_update` |
+| Pending contract upgrade | `stellar contract invoke --id $VAULT_CONTRACT_ID --network mainnet -- get_pending_upgrade` |
 | Active protocol (idle/blend/dex) | `stellar contract invoke --id $VAULT_CONTRACT_ID --network mainnet -- get_current_protocol` |
 | TVL cap | `stellar contract invoke --id $VAULT_CONTRACT_ID --network mainnet -- get_tvl_cap` |
 
 Owner-only actions an attacker with the key could have taken:
-- Called `set_agent` to replace the AI agent with a malicious address.
+- Initiated `update_agent` or `schedule_upgrade` to queue a malicious agent or WASM upgrade.
 - Called `set_blend_pool` or `set_dex_pool` to point the vault at a drain contract.
 - Called `set_caps` to raise or remove deposit limits.
 - Initiated `transfer_ownership` to a new address they control.
@@ -208,14 +215,25 @@ If the compromised key has already been used to initiate an attacker-controlled
 You must call `accept_ownership` from the *legitimate* new owner before the
 attacker does. Check `DataKey::PendingOwner` on-chain immediately.
 
-### Step 4 — Revert any attacker configuration changes
+### Step 4 — Revert any attacker configuration changes & pending timelocks
 
-Once the new owner key is in place, audit and reset all owner-controlled state:
+Once the new owner key is in place, audit and reset all owner-controlled state and cancel pending malicious timelocks:
 
 ```bash
-# Reset agent to the legitimate AI agent address [owner]
+# Cancel any pending malicious agent update or contract upgrade scheduled by attacker [owner]
 stellar contract invoke --id $VAULT_CONTRACT_ID --source <NEW_OWNER_KEY> \
-  --network mainnet -- set_agent --agent <LEGITIMATE_AGENT_ADDRESS>
+  --network mainnet -- cancel_agent_update
+
+stellar contract invoke --id $VAULT_CONTRACT_ID --source <NEW_OWNER_KEY> \
+  --network mainnet -- cancel_upgrade
+
+# Initiate and confirm agent update to legitimate AI agent address via timelock [owner]
+stellar contract invoke --id $VAULT_CONTRACT_ID --source <NEW_OWNER_KEY> \
+  --network mainnet -- update_agent --new_agent <LEGITIMATE_AGENT_ADDRESS>
+
+# (After timelock window expires)
+stellar contract invoke --id $VAULT_CONTRACT_ID --source <NEW_OWNER_KEY> \
+  --network mainnet -- confirm_agent_update
 
 # Reset pool addresses to audited contracts [owner]
 stellar contract invoke --id $VAULT_CONTRACT_ID --source <NEW_OWNER_KEY> \

--- a/docs/MAINNET_CHECKLIST.md
+++ b/docs/MAINNET_CHECKLIST.md
@@ -9,9 +9,10 @@ This document outlines the mandatory formal verification steps, configuration pa
 2. [Initialization Parameters & Deployment Verification](#2-initialization-parameters--deployment-verification)
 3. [Administrative Caps & Deposit Limits Configuration](#3-administrative-caps--deposit-limits-configuration)
 4. [Blend Pool Integration & Address Verification](#4-blend-pool-integration--address-verification)
-5. [Emergency Procedures & Pause Drill Runbook](#5-emergency-procedures--pause-drill-runbook)
-6. [Upgrade & Governance Multisig Plan](#6-upgrade--governance-multisig-plan)
-7. [Third-Party Security Audit & Formal Sign-off](#7-third-party-security-audit--formal-sign-off)
+5. [DEX Pool Integration & Address Verification](#5-dex-pool-integration--address-verification)
+6. [Emergency Procedures & Pause Drill Runbook](#6-emergency-procedures--pause-drill-runbook)
+7. [Upgrade & Governance Multisig Plan](#7-upgrade--governance-multisig-plan)
+8. [Third-Party Security Audit & Formal Sign-off](#8-third-party-security-audit--formal-sign-off)
 
 ---
 
@@ -174,7 +175,42 @@ The NeuroWealth AI agent deploys assets into Blend lending pools. Registering th
 
 ---
 
-## 5. Emergency Procedures & Pause Drill Runbook
+## 5. DEX Pool Integration & Address Verification
+
+The NeuroWealth AI agent deploys assets into DEX liquidity pools for active trading strategies. Registering the correct, verified mainnet contract address for the target DEX pool is critical.
+
+### 🔍 Security Context
+* Deploying to an incorrect, unverified, or malicious pool address could result in permanent loss of funds or slippage exploitation.
+* Interface validation alone does not confirm that the DEX pool is genuine or safe. Address verification against trusted registries is mandatory before deployment.
+
+### 📝 Actionable Checklist
+- [ ] **Retrieve Official DEX Registries:** Match the DEX pool mainnet address against official protocol documentation and verified on-chain deployment logs.
+- [ ] **Perform Interface/State Verification:** Verify DEX pool parameters and liquidity depth.
+- [ ] **Register Verified DEX Pool:** Call `set_dex_pool` using the Owner key:
+  ```bash
+  stellar contract invoke \
+    --id $VAULT_CONTRACT_ID \
+    --source owner \
+    --network mainnet \
+    -- \
+    set_dex_pool \
+    --owner $OWNER_ADDRESS \
+    --pool_address $VERIFIED_DEX_POOL_ADDRESS
+  ```
+- [ ] **Read Verification:** Query `get_dex_pool` on the vault to confirm the registered address matches the verified DEX pool address.
+
+> **Automated check** — set `DEX_POOL_ADDRESS` and `scripts/verify-deployment.sh` will assert that `get_dex_pool()` returns that exact address (not null):
+> ```bash
+> VAULT_CONTRACT_ID=C... NETWORK=mainnet \
+>   OWNER_ADDRESS=G... AGENT_ADDRESS=G... AGENT_SECRET_KEY=S... \
+>   USDC_TOKEN_ADDRESS=G... \
+>   DEX_POOL_ADDRESS=C... \
+>   ./scripts/verify-deployment.sh
+> ```
+
+---
+
+## 6. Emergency Procedures & Pause Drill Runbook
 
 Before deploying to Mainnet, the team must run an on-chain Pause Drill on Testnet to guarantee emergency mechanisms function as intended and operators are trained in execution.
 
@@ -203,7 +239,7 @@ Before deploying to Mainnet, the team must run an on-chain Pause Drill on Testne
 
 ---
 
-## 6. Upgrade & Governance Multisig Plan
+## 7. Upgrade & Governance Multisig Plan
 
 The Owner key holds upgrade privileges. To secure the contract against single-key compromise or loss, the owner account should be configured with multi-signature security.
 
@@ -225,7 +261,7 @@ The Owner key holds upgrade privileges. To secure the contract against single-ke
 
 ---
 
-## 7. Third-Party Security Audit & Formal Sign-off
+## 8. Third-Party Security Audit & Formal Sign-off
 
 No smart contract should be deployed on-chain without an independent security audit and formal sign-off.
 

--- a/neurowealth-vault/contracts/vault/src/tests/mod.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/mod.rs
@@ -38,6 +38,7 @@ mod test_total_assets_cap;
 mod test_ttl;
 mod test_tvl_cap_serial;
 mod test_update_total_assets_blend;
+mod test_update_total_assets_dex;
 mod test_upgrade_compatibility;
 mod test_upgrade_timelock;
 mod test_user_strategy;

--- a/neurowealth-vault/contracts/vault/src/tests/test_update_total_assets_dex.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_update_total_assets_dex.rs
@@ -1,0 +1,314 @@
+//! Tests for update_total_assets() backing check with funds deployed to DEX (Issue #393).
+//!
+//! Prior to this fix, test coverage for the solvency/backing check when funds are deployed
+//! to DEX pool was missing.
+//!
+//! These tests verify:
+//!   1. Backing check passes when ALL funds are in DEX (idle balance = 0).
+//!   2. Backing check passes when funds are PARTIALLY in DEX.
+//!   3. Yield accrued inside DEX is counted towards available backing.
+//!   4. The security check still rejects inflation beyond idle + deployed.
+//!   5. No regression: idle-only (no DEX) path continues to work.
+
+extern crate std;
+
+use super::utils::*;
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/// Deposit `amount`, configure the DEX pool, and rebalance everything into
+/// DEX in one step. Returns the vault client, token client, and dex pool address.
+fn setup_all_in_dex(
+    env: &Env,
+    amount: i128,
+) -> (
+    Address, // contract_id
+    Address, // agent
+    Address, // usdc_token
+    Address, // dex_pool
+    NeuroWealthVaultClient<'_>,
+    TestTokenClient<'_>,
+) {
+    let (contract_id, agent, owner, usdc_token, dex_pool) = setup_vault_with_token_and_dex(env);
+    let client = NeuroWealthVaultClient::new(env, &contract_id);
+    let token_client = TestTokenClient::new(env, &usdc_token);
+
+    client.set_dex_pool(&owner, &dex_pool);
+
+    let user = Address::generate(env);
+    mint_and_deposit(env, &client, &usdc_token, &user, amount);
+
+    // Rebalance: vault idle → DEX
+    client.rebalance(&symbol_short!("dex"), &700_i128, &0_i128);
+
+    // Sanity: all USDC is now in the pool
+    assert_eq!(token_client.balance(&contract_id), 0);
+    assert_eq!(token_client.balance(&dex_pool), amount);
+
+    (
+        contract_id,
+        agent,
+        usdc_token,
+        dex_pool,
+        client,
+        token_client,
+    )
+}
+
+// ============================================================================
+// 1. ALL FUNDS IN DEX — SAME TOTAL (no-op report)
+// ============================================================================
+
+/// When all USDC is in DEX (vault idle balance = 0) the backing check must
+/// include the deployed position. Reporting the same total should succeed.
+#[test]
+fn test_update_total_assets_all_in_dex_same_total_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deposit = 10_000_000_i128;
+    let (_, agent, _, _, client, _) = setup_all_in_dex(&env, deposit);
+
+    // Idle = 0, deployed = 10 USDC → total_available = 10 USDC
+    // Reporting the same total should pass.
+    client.update_total_assets(&agent, &deposit, &false, &0);
+    assert_eq!(client.get_total_assets(), deposit);
+}
+
+// ============================================================================
+// 2. ALL FUNDS IN DEX — YIELD ACCRUAL
+// ============================================================================
+
+/// DEX earns yield → pool balance grows. Agent should be able to report
+/// the new (higher) total including the yield without being rejected.
+#[test]
+fn test_update_total_assets_dex_yield_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deposit = 20_000_000_i128;
+    let yield_amount = 2_000_000_i128; // 10% yield
+
+    let (_, agent, usdc_token, dex_pool, client, token_client) =
+        setup_all_in_dex(&env, deposit);
+
+    // Simulate DEX accruing yield by minting directly to pool
+    token_client.mint(&dex_pool, &yield_amount);
+
+    let new_total = deposit + yield_amount;
+    client.update_total_assets(&agent, &new_total, &false, &0);
+
+    assert_eq!(client.get_total_assets(), new_total);
+    assert_eq!(token_client.balance(&usdc_token), 0_i128);
+    drop(token_client);
+}
+
+// ============================================================================
+// 3. PARTIAL DEPLOYMENT — IDLE + DEX
+// ============================================================================
+
+/// When only part of the vault's USDC is in DEX (the rest is idle), the
+/// backing check must sum both portions.
+#[test]
+fn test_update_total_assets_partial_dex_deployment_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, owner, usdc_token, dex_pool) =
+        setup_vault_with_token_and_dex(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+    let dex_client = MockDexPoolClient::new(&env, &dex_pool);
+
+    client.set_dex_pool(&owner, &dex_pool);
+
+    // Deposit 30 USDC total
+    let deposit_total = 30_000_000_i128;
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_total);
+
+    // Limit the DEX pool to accepting only 20 USDC → 10 stays idle
+    let dex_limit = 20_000_000_i128;
+    dex_client.set_max_supply_limit(&dex_limit);
+
+    client.rebalance(&symbol_short!("dex"), &700_i128, &0_i128);
+
+    let idle = token_client.balance(&contract_id);
+    let deployed = token_client.balance(&dex_pool);
+
+    // Partial deployment: 20 in DEX, 10 idle
+    assert_eq!(deployed, dex_limit, "DEX pool should have 20 USDC");
+    assert_eq!(
+        idle,
+        deposit_total - dex_limit,
+        "vault should have 10 USDC idle"
+    );
+
+    // total_available = 10 + 20 = 30 → reporting 30 must succeed
+    client.update_total_assets(&agent, &deposit_total, &false, &0);
+    assert_eq!(client.get_total_assets(), deposit_total);
+}
+
+// ============================================================================
+// 4. PARTIAL DEPLOYMENT WITH YIELD
+// ============================================================================
+
+/// Partial deployment: 20 in DEX earns 1 USDC yield.
+/// Agent reports new total (31 USDC). Available = 10 idle + 21 in DEX = 31.
+#[test]
+fn test_update_total_assets_partial_dex_plus_yield_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, owner, usdc_token, dex_pool) =
+        setup_vault_with_token_and_dex(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+    let dex_client = MockDexPoolClient::new(&env, &dex_pool);
+
+    client.set_dex_pool(&owner, &dex_pool);
+
+    let deposit_total = 30_000_000_i128;
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_total);
+
+    dex_client.set_max_supply_limit(&20_000_000_i128);
+    client.rebalance(&symbol_short!("dex"), &700_i128, &0_i128);
+
+    // Yield: 1 USDC minted to DEX pool
+    let yield_amount = 1_000_000_i128;
+    token_client.mint(&dex_pool, &yield_amount);
+
+    // Available = 10 (idle) + 21 (DEX) = 31
+    let new_total = deposit_total + yield_amount;
+    client.update_total_assets(&agent, &new_total, &false, &0);
+    assert_eq!(client.get_total_assets(), new_total);
+}
+
+// ============================================================================
+// 5. SECURITY: REJECT INFLATION BEYOND AVAILABLE BACKING
+// ============================================================================
+
+/// The security check must still reject a report where new_total exceeds the
+/// sum of idle balance + deployed DEX position.
+#[test]
+#[should_panic(expected = "Error(Contract, #33)")]
+fn test_update_total_assets_rejects_inflation_beyond_idle_plus_dex() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deposit = 10_000_000_i128;
+    let (_, agent, _, _, client, _) = setup_all_in_dex(&env, deposit);
+
+    // Try to report 200 USDC when only 10 USDC is available (all in DEX)
+    let inflated_total = 200_000_000_i128;
+    client.update_total_assets(&agent, &inflated_total, &false, &0);
+}
+
+/// Partial deployment: total available = 10 idle + 20 DEX = 30.
+/// Attempting to report 31 must be rejected.
+#[test]
+#[should_panic(expected = "Error(Contract, #33)")]
+fn test_update_total_assets_rejects_inflation_beyond_partial_dex_deployment() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, owner, usdc_token, dex_pool) =
+        setup_vault_with_token_and_dex(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+    let dex_client = MockDexPoolClient::new(&env, &dex_pool);
+
+    client.set_dex_pool(&owner, &dex_pool);
+
+    let deposit_total = 30_000_000_i128;
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_total);
+
+    dex_client.set_max_supply_limit(&20_000_000_i128);
+    client.rebalance(&symbol_short!("dex"), &700_i128, &0_i128);
+
+    // Available = 10 + 20 = 30; reporting 31 must fail
+    let over_total = deposit_total + 1_i128;
+    client.update_total_assets(&agent, &over_total, &false, &0);
+
+    drop(token_client);
+}
+
+// ============================================================================
+// 6. REGRESSION: IDLE-ONLY (NO DEX) PATH STILL WORKS
+// ============================================================================
+
+/// No DEX configured. The original idle-only backing check must continue
+/// to work for vaults that never deploy to a protocol.
+#[test]
+fn test_update_total_assets_idle_only_no_dex_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    let deposit = 10_000_000_i128;
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit);
+
+    // Simulate yield minted directly to vault (no DEX)
+    let yield_amount = 1_000_000_i128;
+    token_client.mint(&contract_id, &yield_amount);
+
+    let new_total = deposit + yield_amount;
+    client.update_total_assets(&agent, &new_total, &false, &0);
+    assert_eq!(client.get_total_assets(), new_total);
+}
+
+/// Idle-only: attempting to report more than the vault holds must be rejected.
+#[test]
+#[should_panic(expected = "Error(Contract, #33)")]
+fn test_update_total_assets_idle_only_rejects_over_balance_dex_context() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let deposit = 10_000_000_i128;
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit);
+
+    // No yield minted; vault holds exactly 10 USDC.
+    // Reporting 11 must fail.
+    client.update_total_assets(&agent, &(deposit + 1_i128), &false, &0);
+}
+
+// ============================================================================
+// 7. PROTOCOL RESET: AFTER REBALANCE TO NONE BACKING IS IDLE ONLY
+// ============================================================================
+
+/// After rebalancing back to "none" (all funds returned from DEX),
+/// the backing check reverts to idle-only and must correctly accept/reject.
+#[test]
+fn test_update_total_assets_after_rebalance_to_none_uses_idle_dex_context() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deposit = 10_000_000_i128;
+    let (contract_id, agent, usdc_token, _dex_pool, client, token_client) =
+        setup_all_in_dex(&env, deposit);
+
+    // Rebalance back to none (all funds return to vault)
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
+
+    assert_eq!(token_client.balance(&contract_id), deposit);
+    assert_eq!(client.get_current_protocol(), symbol_short!("none"));
+
+    // Idle = deposit, deployed = 0 → reporting deposit must pass
+    client.update_total_assets(&agent, &deposit, &false, &0);
+    assert_eq!(client.get_total_assets(), deposit);
+
+    drop(usdc_token);
+}

--- a/neurowealth-vault/contracts/vault/src/tests/utils.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/utils.rs
@@ -487,10 +487,13 @@ pub mod dex {
 
         /// Returns the liquidity position held for `_user` in `asset`.
         pub fn balance(env: Env, asset: Address, _user: Address) -> i128 {
-            env.storage()
+            let supplied: i128 = env
+                .storage()
                 .persistent()
-                .get(&DexMockDataKey::Supplied(asset))
-                .unwrap_or(0)
+                .get(&DexMockDataKey::Supplied(asset.clone()))
+                .unwrap_or(0);
+            let token_bal = TestTokenClient::new(&env, &asset).balance(&env.current_contract_address());
+            core::cmp::max(supplied, token_bal)
         }
 
         /// Sets a max supply limit to simulate slippage / partial fills.

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -34,8 +34,9 @@
 #   EXPECTED_MIN_DEPOSIT      — expected minimum deposit
 #   EXPECTED_MAX_DEPOSIT      — expected maximum deposit
 #
-# Optional Blend pool check:
+# Optional protocol pool checks:
 #   BLEND_POOL_ADDRESS    — if set, verifies get_blend_pool() matches this value
+#   DEX_POOL_ADDRESS      — if set, verifies get_dex_pool() matches this value
 #
 # Exit codes:
 #   0  — All checks passed
@@ -394,6 +395,33 @@ else
         pass "get_blend_pool matches BLEND_POOL_ADDRESS"
       else
         fail "get_blend_pool mismatch: on-chain=$BLEND_NORM expected=$EXPECTED_BLEND"
+      fi
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 9. DEX pool address (optional — skip if DEX_POOL_ADDRESS not set)
+# ---------------------------------------------------------------------------
+
+if [[ -z "${DEX_POOL_ADDRESS:-}" ]]; then
+  info "DEX pool check skipped — DEX_POOL_ADDRESS not set"
+else
+  DEX_OUTPUT=$(invoke_view "get_dex_pool" get_dex_pool) || {
+    fail "get_dex_pool invocation failed"
+    DEX_OUTPUT=""
+  }
+
+  if [[ -n "$DEX_OUTPUT" ]]; then
+    DEX_NORM=$(normalize_address "$DEX_OUTPUT")
+    if [[ "$DEX_NORM" == "null" || -z "$DEX_NORM" ]]; then
+      fail "get_dex_pool returned null — DEX pool not configured on-chain"
+    else
+      EXPECTED_DEX=$(normalize_address "$DEX_POOL_ADDRESS")
+      if [[ "$DEX_NORM" == "$EXPECTED_DEX" ]]; then
+        pass "get_dex_pool matches DEX_POOL_ADDRESS"
+      else
+        fail "get_dex_pool mismatch: on-chain=$DEX_NORM expected=$EXPECTED_DEX"
       fi
     fi
   fi


### PR DESCRIPTION
# fix: resolve security, test coverage, CI fuzzing, and preflight checklist issues (#392, #393, #395, #397)

Closes #392
Closes #393
Closes #395
Closes #397

## Summary

This PR addresses four outstanding security, testing, CI pipeline, and deployment verification issues:

**#397 — Update SECURITY.md for two-step timelocked agent/upgrade flows**
- Updated the Access Control Summary table to reflect `update_agent`, `confirm_agent_update`, `cancel_agent_update`, `schedule_upgrade`, `execute_upgrade`, and `cancel_upgrade`.
- Revised section 4 ("Upgrade Risks") to detail the mandatory two-step timelock and cancellation window.
- Updated the Owner-Compromise Response Runbook (Step 2 & Step 4) with commands for checking timelocks, cancelling malicious proposals, and executing timelocked agent updates.

**#393 — DEX equivalent test suite for `update_total_assets` solvency checks**
- Added `neurowealth-vault/contracts/vault/src/tests/test_update_total_assets_dex.rs` covering:
  1. All funds in DEX (idle = 0, deployed = total).
  2. All funds in DEX with yield accrual.
  3. Partial DEX deployment (idle + DEX).
  4. Partial DEX deployment with yield accrual.
  5. Solvency assertion rejecting reports exceeding available backing.
  6. Idle-only regression sanity checks.
  7. Protocol reset behavior (rebalancing back to "none").
- Registered test module in `tests/mod.rs` and updated `MockDexPool::balance` in test mocks to account for token balance (yield accrual).

**#395 — Run all four fuzz targets in CI**
- Refactored `.github/workflows/ci.yml` `fuzz-deposit-withdraw` job into a matrix job `fuzz`.
- Now runs `deposit_withdraw_sequence`, `rebalance_transitions`, `rounding_boundaries`, and `share_accounting_invariants` with PR short bounds (`-runs=1000 -max_total_time=120`) and scheduled full bounds (`-runs=5000 -max_total_time=300`).

**#392 — DEX pool deployment verification script and checklist documentation**
- Extended `scripts/verify-deployment.sh` to include an optional `DEX_POOL_ADDRESS` verification check (`get_dex_pool()` on-chain check) mirroring the Blend pool check.
- Added Section 5 ("DEX Pool Integration & Address Verification") to `docs/MAINNET_CHECKLIST.md` and updated Table of Contents.

## Verification

- [x] All 9 DEX total asset tests pass locally (`cargo test --package neurowealth-vault test_update_total_assets_dex`).
- [x] Entire workspace test suite passes with zero errors.
- [x] Documentation (`SECURITY.md`, `MAINNET_CHECKLIST.md`, `pr.md`) updated and verified.
