### PR TITLE
chore: sync contract-spec.json after CallerIsNotPendingOwner docstring update

### DIFF
--- a/contract-spec.json
+++ b/contract-spec.json
@@ -2179,7 +2179,7 @@
     },
     "VaultError::CallerIsNotPendingOwner": {
       "code": 29,
-      "description": "Caller is not the pending owner."
+      "description": "Caller is not the pending owner (or no pending ownership transfer exists)."
     },
     "VaultError::OnlyAgentCanUpdateTotalAssets": {
       "code": 30,


### PR DESCRIPTION
Closes #366
Closes #367
Closes #368
Closes #369

## Summary

- Regenerates `contract-spec.json` to match the `CallerIsNotPendingOwner` docstring change introduced in #405.
- The CI `Generate & Validate Contract Spec` workflow detected this drift and tried to auto-commit it, but lacked write permission. This PR commits the 1-line spec update manually so CI stays green.