### PR TITLE
chore: add typed pool errors and wasm size tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "0 3 * * 0"
 
+permissions:
+  contents: write
+
 env:
   # Maximum allowed size in bytes for the optimised contract WASM.
   # Raise this in the same PR as any deliberate feature addition that grows
@@ -124,6 +127,54 @@ jobs:
 
               WASM_SIZE=$(stat -c%s "$WASM_FILE")
               LIMIT="${WASM_SIZE_LIMIT_BYTES:-1500000}"
+              BASE_BRANCH="${GITHUB_BASE_REF:-${GITHUB_REF_NAME}}"
+              BASELINE_FILE=".github/wasm-size-history.json"
+              BASELINE_SOURCE_FILE="$BASELINE_FILE"
+              BASELINE_SIZE=""
+              DELTA_BYTES=""
+              DELTA_DISPLAY="n/a"
+
+              if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+                git fetch origin "$BASE_BRANCH" --depth=1 >/dev/null 2>&1 || true
+                if git show "origin/$BASE_BRANCH:$BASELINE_SOURCE_FILE" > "$RUNNER_TEMP/wasm-size-baseline.json" 2>/dev/null; then
+                  BASELINE_FILE="$RUNNER_TEMP/wasm-size-baseline.json"
+                else
+                  BASELINE_FILE="$BASELINE_SOURCE_FILE"
+                fi
+              fi
+
+              if [ -f "$BASELINE_FILE" ]; then
+                BASELINE_SIZE=$(python3 - "$BASELINE_FILE" "$BASE_BRANCH" <<'PY'
+import json
+import sys
+
+path, branch = sys.argv[1], sys.argv[2]
+try:
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+except (FileNotFoundError, json.JSONDecodeError):
+    print("")
+    raise SystemExit(0)
+
+entry = data.get(branch, {}).get("latest")
+if entry:
+    print(entry.get("size_bytes", ""))
+else:
+    print("")
+PY
+)
+              fi
+
+              if [ -n "$BASELINE_SIZE" ]; then
+                DELTA_BYTES=$((WASM_SIZE - BASELINE_SIZE))
+                if [ "$DELTA_BYTES" -gt 0 ]; then
+                  DELTA_DISPLAY="+$DELTA_BYTES bytes"
+                elif [ "$DELTA_BYTES" -lt 0 ]; then
+                  DELTA_DISPLAY="$DELTA_BYTES bytes"
+                else
+                  DELTA_DISPLAY="0 bytes"
+                fi
+              fi
 
               {
                 echo "## WASM Size Report"
@@ -132,6 +183,13 @@ jobs:
                 echo "|--------|-------|"
                 echo "| Optimised size | ${WASM_SIZE} bytes |"
                 echo "| Limit          | ${LIMIT} bytes |"
+                if [ -n "$BASELINE_SIZE" ]; then
+                  echo "| Baseline (${BASE_BRANCH}) | ${BASELINE_SIZE} bytes |"
+                  echo "| Delta vs ${BASE_BRANCH} | ${DELTA_DISPLAY} |"
+                else
+                  echo "| Baseline (${BASE_BRANCH}) | n/a |"
+                  echo "| Delta vs ${BASE_BRANCH} | n/a |"
+                fi
               } >> "$GITHUB_STEP_SUMMARY"
 
               if [ "$WASM_SIZE" -gt "$LIMIT" ]; then
@@ -141,6 +199,48 @@ jobs:
               else
                 echo "| Status | :white_check_mark: OK |" >> "$GITHUB_STEP_SUMMARY"
                 echo "Optimised WASM is ${WASM_SIZE} bytes — within the ${LIMIT}-byte limit."
+              fi
+
+              if [ "$GITHUB_EVENT_NAME" = "push" ] && { [ "$GITHUB_REF_NAME" = "main" ] || [ "$GITHUB_REF_NAME" = "develop" ]; }; then
+                python3 - "$WASM_SIZE" "$GITHUB_SHA" "$GITHUB_REF_NAME" "$BASELINE_FILE" <<'PY'
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+size, sha, branch, path = int(sys.argv[1]), sys.argv[2], sys.argv[3], sys.argv[4]
+
+payload = {}
+if os.path.exists(path):
+    with open(path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+history = payload.get(branch, {}).get("history", [])
+history.append({"sha": sha, "size_bytes": size})
+updated_history = history[-20:]
+
+payload[branch] = {
+    "latest": {
+        "sha": sha,
+        "size_bytes": size,
+        "timestamp_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    },
+    "history": updated_history,
+}
+
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2)
+    handle.write("\n")
+
+subprocess.run(["git", "config", "user.name", "github-actions[bot]"], check=True)
+subprocess.run(["git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"], check=True)
+subprocess.run(["git", "add", path], check=True)
+
+if subprocess.run(["git", "diff", "--cached", "--quiet"]).returncode != 0:
+    subprocess.run(["git", "commit", "-m", f"chore(ci): update wasm size baseline for {branch}"], check=True)
+    subprocess.run(["git", "push", "origin", f"HEAD:{branch}"], check=True)
+PY
               fi
 
               # Export the WASM path for the artifact upload step.

--- a/docs/WASM_SIZE.md
+++ b/docs/WASM_SIZE.md
@@ -6,6 +6,10 @@ The CI pipeline fails if the optimised contract WASM exceeds **1.5 MB** (configu
 
 Stellar's Soroban network enforces a `maxContractSizeBytes` network parameter that caps how large a contract WASM can be when uploaded via `stellar contract upload`. The CI gate sits well below that limit to catch unintentional bloat early and leave room for future feature additions.
 
+## Trend Tracking
+
+The CI workflow now records the latest optimised WASM size for merged commits in `.github/wasm-size-history.json` and uses that baseline when a PR runs. The PR check reports the size delta versus the base branch in the workflow summary so gradual growth is visible even when the binary stays under the hard limit.
+
 ## Why This Matters
 
 | Issue | Consequence |

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -4751,11 +4751,10 @@ impl NeuroWealthVault {
             return 0;
         }
 
-        let pool_address: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::BlendPool)
-            .expect("vault: blend pool not configured");
+        let pool_address: Address = env.storage().instance().get(&DataKey::BlendPool).unwrap_or_else(|| {
+            panic_with_error!(env, VaultError::BlendPoolNotConfigured);
+            unreachable!()
+        });
 
         let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
         let vault_address = env.current_contract_address();
@@ -4873,11 +4872,10 @@ impl NeuroWealthVault {
     /// - Panics if Blend pool address is not configured
     /// - Emits BlendWithdrawEvent with success status and actual amount received
     fn withdraw_from_blend(env: &Env, amount: i128, min_out: i128) -> i128 {
-        let pool_address: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::BlendPool)
-            .expect("vault: blend pool not configured");
+        let pool_address: Address = env.storage().instance().get(&DataKey::BlendPool).unwrap_or_else(|| {
+            panic_with_error!(env, VaultError::BlendPoolNotConfigured);
+            unreachable!()
+        });
 
         let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
         let vault_address = env.current_contract_address();
@@ -4953,11 +4951,10 @@ impl NeuroWealthVault {
             return 0;
         }
 
-        let pool_address: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::DexPool)
-            .expect("vault: dex pool not configured");
+        let pool_address: Address = env.storage().instance().get(&DataKey::DexPool).unwrap_or_else(|| {
+            panic_with_error!(env, VaultError::DexPoolNotConfigured);
+            unreachable!()
+        });
 
         let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
         let vault_address = env.current_contract_address();
@@ -5072,11 +5069,10 @@ impl NeuroWealthVault {
     /// - Panics with `MinOutNotMet` if the realized amount is below `min_out`
     /// - Emits `DexWithdrawEvent` with success status and actual amount received
     fn withdraw_from_dex(env: &Env, amount: i128, min_out: i128) -> i128 {
-        let pool_address: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::DexPool)
-            .expect("vault: dex pool not configured");
+        let pool_address: Address = env.storage().instance().get(&DataKey::DexPool).unwrap_or_else(|| {
+            panic_with_error!(env, VaultError::DexPoolNotConfigured);
+            unreachable!()
+        });
 
         let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
         let vault_address = env.current_contract_address();

--- a/neurowealth-vault/contracts/vault/src/tests/test_asset_split.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_asset_split.rs
@@ -102,6 +102,48 @@ fn test_after_rebalance_to_blend_deployed_grows_idle_shrinks() {
 }
 
 // ============================================================================
+// get_deployed_assets and get_idle_balance after rebalance → dex
+// ============================================================================
+
+/// After rebalancing to the DEX all vault USDC is supplied to the pool, so:
+/// - `get_idle_balance` should drop to 0.
+/// - `get_deployed_assets` should be > 0 and match the original deposit.
+#[test]
+fn test_after_rebalance_to_dex_deployed_grows_idle_shrinks() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, usdc_token, dex_pool) = setup_vault_with_token_and_dex(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_dex_pool(&owner, &dex_pool);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 10_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
+
+    assert_eq!(client.get_idle_balance(), deposit_amount);
+    assert_eq!(client.get_deployed_assets(), 0_i128);
+
+    client.rebalance(&symbol_short!("dex"), &500_i128, &0_i128);
+
+    assert_eq!(
+        client.get_idle_balance(),
+        0_i128,
+        "vault should hold no idle USDC after full rebalance to the DEX"
+    );
+    assert!(
+        client.get_deployed_assets() > 0_i128,
+        "deployed assets should be positive after rebalance to the DEX"
+    );
+    assert_eq!(
+        client.get_deployed_assets(),
+        deposit_amount,
+        "deployed assets should equal the original deposit after full supply"
+    );
+}
+
+// ============================================================================
 // get_asset_breakdown
 // ============================================================================
 
@@ -157,5 +199,56 @@ fn test_get_asset_breakdown_matches_individual_getters() {
     assert_eq!(
         deployed_after, deposit_amount,
         "deployed should equal deposited amount after full supply to Blend"
+    );
+}
+
+/// `get_asset_breakdown` must also stay consistent when the vault is
+/// rebalanced into the DEX pool.
+#[test]
+fn test_get_asset_breakdown_matches_individual_getters_for_dex() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, usdc_token, dex_pool) = setup_vault_with_token_and_dex(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_dex_pool(&owner, &dex_pool);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 10_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
+
+    let (idle_before, deployed_before) = client.get_asset_breakdown();
+    assert_eq!(
+        idle_before,
+        client.get_idle_balance(),
+        "breakdown.idle should match get_idle_balance before rebalance"
+    );
+    assert_eq!(
+        deployed_before,
+        client.get_deployed_assets(),
+        "breakdown.deployed should match get_deployed_assets before rebalance"
+    );
+
+    client.rebalance(&symbol_short!("dex"), &500_i128, &0_i128);
+
+    let (idle_after, deployed_after) = client.get_asset_breakdown();
+    assert_eq!(
+        idle_after,
+        client.get_idle_balance(),
+        "breakdown.idle should match get_idle_balance after rebalance"
+    );
+    assert_eq!(
+        deployed_after,
+        client.get_deployed_assets(),
+        "breakdown.deployed should match get_deployed_assets after rebalance"
+    );
+    assert_eq!(
+        idle_after, 0_i128,
+        "idle should be 0 after full supply to the DEX"
+    );
+    assert_eq!(
+        deployed_after, deposit_amount,
+        "deployed should equal deposited amount after full supply to the DEX"
     );
 }

--- a/neurowealth-vault/contracts/vault/src/tests/test_blend_integration.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_blend_integration.rs
@@ -80,6 +80,41 @@ fn test_blend_integration_withdraw_via_rebalance() {
     assert_eq!(blend_wd_events.len(), 1);
 }
 
+/// The vault measures supply outcome via USDC balance delta, not the pool's
+/// reported return value. A Blend pool that lies about its return value from
+/// `submit_with_allowance` cannot inflate vault accounting.
+#[test]
+fn test_blend_balance_delta_against_lying_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, _agent, owner, usdc_token, blend_pool) = setup_vault_with_token_and_blend(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+    let blend_client = MockBlendPoolClient::new(&env, &blend_pool);
+
+    vault_client.set_blend_pool(&owner, &blend_pool);
+
+    let deposit_amount = 50_000_000_i128;
+    token_client.mint(&vault_id, &deposit_amount);
+
+    // Configure the pool to lie: it will actually transfer `deposit_amount`
+    // but report double that amount as its return value.
+    let lying_reported = deposit_amount * 2;
+    blend_client.set_reported_supply_amount(&lying_reported);
+
+    vault_client.rebalance(&Symbol::new(&env, "blend"), &850, &0_i128);
+
+    let total_assets = vault_client.get_total_assets();
+    assert_eq!(
+        total_assets, deposit_amount,
+        "vault must record actual balance delta, not the pool's reported amount"
+    );
+
+    assert_eq!(token_client.balance(&blend_pool), deposit_amount);
+    assert_eq!(token_client.balance(&vault_id), 0);
+}
+
 #[test]
 fn test_blend_integration_balance_read() {
     let env = Env::default();

--- a/neurowealth-vault/contracts/vault/src/tests/utils.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/utils.rs
@@ -37,6 +37,9 @@ enum BlendMockDataKey {
     MaxSupplyLimit,
     /// Configurable max withdraw limit per transaction (0 = no limit)
     MaxWithdrawLimit,
+    /// Override the return value of submit_with_allowance without changing the
+    /// actual transferred amount. Used to test balance-delta accounting.
+    ReportedSupplyOverride,
 }
 
 #[derive(Clone)]
@@ -251,7 +254,11 @@ pub mod blend {
 
             from.clone().require_auth();
 
-            actual_amount
+            let override_amount: Option<i128> = env
+                .storage()
+                .persistent()
+                .get(&BlendMockDataKey::ReportedSupplyOverride);
+            override_amount.unwrap_or(actual_amount)
         }
 
         /// Sets a max supply limit to simulate pool shortfall scenarios.
@@ -260,6 +267,16 @@ pub mod blend {
             env.storage()
                 .persistent()
                 .set(&BlendMockDataKey::MaxSupplyLimit, &limit);
+        }
+
+        /// Makes submit_with_allowance report `reported` as the return value
+        /// regardless of how much was actually transferred. Used to test that
+        /// the vault measures outcome via balance-delta rather than trusting the
+        /// pool's return value.
+        pub fn set_reported_supply_amount(env: Env, reported: i128) {
+            env.storage()
+                .persistent()
+                .set(&BlendMockDataKey::ReportedSupplyOverride, &reported);
         }
 
         /// Sets a max withdraw limit to simulate withdrawal failures/stuck funds.
@@ -492,7 +509,8 @@ pub mod dex {
                 .persistent()
                 .get(&DexMockDataKey::Supplied(asset.clone()))
                 .unwrap_or(0);
-            let token_bal = TestTokenClient::new(&env, &asset).balance(&env.current_contract_address());
+            let token_bal =
+                TestTokenClient::new(&env, &asset).balance(&env.current_contract_address());
             core::cmp::max(supplied, token_bal)
         }
 


### PR DESCRIPTION
Closes #399

---
closes #396 
closes #394 
closes #398 
## Summary
- route missing Blend/DEX pool configuration failures through typed contract errors instead of raw panics
- add regression coverage for DEX asset-split getters and Blend lying-pool balance deltas
- extend CI to track WASM size deltas against the base branch and report them in the job summary

## Testing
- rustfmt checks were run for the touched vault sources and tests
- full cargo test execution could not be completed locally in this environment because the Windows Rust linker/toolchain was unavailable