### PR TITLE
test: add pool-rotation fund-stranding tests (#383)

### DIFF
--- a/neurowealth-vault/contracts/vault/src/tests/test_rebalance.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_rebalance.rs
@@ -746,3 +746,147 @@ fn test_dex_approval_expires_at_next_ledger_after_boundary() {
         "DEX approval should expire once the ledger advances past the TTL boundary"
     );
 }
+
+// ─── Issue #383: pool-address rotation while funds are deployed ─────────────
+//
+// Companion to the `set_blend_pool`/`set_dex_pool` fund-stranding issue.
+// Neither setter currently guards against rotating the configured pool
+// address while a nonzero position is still deployed to the *old* pool:
+// every internal lookup (`get_protocol_balance`, `withdraw_from_blend`,
+// `withdraw_from_dex`) reads the pool address from storage *at call time*,
+// so once the address is rotated the vault permanently loses any way to see
+// or reach funds sitting in the old pool contract.
+//
+// Pre-fix, these tests document the stranding: the rotation succeeds
+// silently, and a subsequent `rebalance("none")` "succeeds" without
+// recovering any funds because the vault only ever queries the new (empty)
+// pool. Once a guard lands that rejects rotation while a position is
+// deployed, flip these assertions to expect the rotation call itself to
+// panic instead.
+
+#[test]
+fn test_blend_pool_rotation_while_deployed_strands_funds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, usdc_token, old_pool) =
+        setup_vault_with_token_and_blend(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+    let old_pool_client = MockBlendPoolClient::new(&env, &old_pool);
+
+    client.set_blend_pool(&owner, &old_pool);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 10_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
+
+    // Deploy funds to the old pool.
+    client.rebalance(&symbol_short!("blend"), &500_i128, &0_i128);
+    assert_eq!(old_pool_client.supplied(&usdc_token), deposit_amount);
+    assert_eq!(client.get_current_protocol(), symbol_short!("blend"));
+
+    // Rotate to a brand new pool while the position is still fully deployed
+    // to `old_pool`. No guard currently exists — this succeeds.
+    let new_pool = env.register_contract(None, MockBlendPool);
+    client.set_blend_pool(&owner, &new_pool);
+    assert_eq!(client.get_blend_pool(), Some(new_pool.clone()));
+
+    // The funds never moved — they are still sitting in `old_pool` — but the
+    // vault's only pointer to a Blend pool now targets `new_pool`.
+    assert_eq!(
+        old_pool_client.supplied(&usdc_token),
+        deposit_amount,
+        "deployed funds remain in the old pool, untouched by the rotation"
+    );
+    let new_pool_client = MockBlendPoolClient::new(&env, &new_pool);
+    assert_eq!(new_pool_client.supplied(&usdc_token), 0);
+
+    // Attempting to exit the position now silently "succeeds" without
+    // recovering anything: withdraw_from_protocol queries `new_pool` (via
+    // DataKey::BlendPool), sees a 0 balance, treats the exit as complete, and
+    // flips CurrentProtocol to "none" — even though the real funds are stuck
+    // in `old_pool`.
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
+
+    assert_eq!(
+        client.get_current_protocol(),
+        symbol_short!("none"),
+        "vault believes it exited the position cleanly"
+    );
+    assert_eq!(
+        token_client.balance(&contract_id),
+        0,
+        "no funds were actually recovered to the vault"
+    );
+    assert_eq!(
+        old_pool_client.supplied(&usdc_token),
+        deposit_amount,
+        "funds remain permanently stranded in the old pool"
+    );
+}
+
+#[test]
+fn test_dex_pool_rotation_while_deployed_strands_funds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, usdc_token, old_pool) =
+        setup_vault_with_token_and_dex(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+    let old_pool_client = MockDexPoolClient::new(&env, &old_pool);
+
+    client.set_dex_pool(&owner, &old_pool);
+
+    let user = Address::generate(&env);
+    let deposit_amount = 10_000_000_i128;
+    mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
+
+    // Deploy funds to the old pool.
+    client.rebalance(&symbol_short!("dex"), &500_i128, &0_i128);
+    assert_eq!(
+        old_pool_client.balance(&usdc_token, &contract_id),
+        deposit_amount
+    );
+    assert_eq!(client.get_current_protocol(), symbol_short!("dex"));
+
+    // Rotate to a brand new pool while the position is still fully deployed
+    // to `old_pool`. No guard currently exists — this succeeds.
+    let new_pool = env.register_contract(None, MockDexPool);
+    client.set_dex_pool(&owner, &new_pool);
+    assert_eq!(client.get_dex_pool(), Some(new_pool.clone()));
+
+    // The funds never moved — they are still sitting in `old_pool` — but the
+    // vault's only pointer to a DEX pool now targets `new_pool`.
+    assert_eq!(
+        old_pool_client.balance(&usdc_token, &contract_id),
+        deposit_amount,
+        "deployed funds remain in the old pool, untouched by the rotation"
+    );
+    let new_pool_client = MockDexPoolClient::new(&env, &new_pool);
+    assert_eq!(new_pool_client.balance(&usdc_token, &contract_id), 0);
+
+    // Attempting to exit the position now silently "succeeds" without
+    // recovering anything: withdraw_from_protocol queries `new_pool` (via
+    // DataKey::DexPool), sees a 0 balance, treats the exit as complete, and
+    // flips CurrentProtocol to "none" — even though the real funds are stuck
+    // in `old_pool`.
+    client.rebalance(&symbol_short!("none"), &0_i128, &0_i128);
+
+    assert_eq!(
+        client.get_current_protocol(),
+        symbol_short!("none"),
+        "vault believes it exited the position cleanly"
+    );
+    assert_eq!(
+        token_client.balance(&contract_id),
+        0,
+        "no funds were actually recovered to the vault"
+    );
+    assert_eq!(
+        old_pool_client.balance(&usdc_token, &contract_id),
+        deposit_amount,
+        "funds remain permanently stranded in the old pool"
+    );
+}


### PR DESCRIPTION
closes #383 

Companion to the set_blend_pool/set_dex_pool fund-stranding issue. Neither setter guards against rotating the pool address while a nonzero position is deployed to the old pool, so every internal balance/withdraw lookup silently starts reading the new (empty) pool and the vault permanently loses any way to reach funds left behind.

These tests deploy funds to Blend/DEX, rotate the pool address, and demonstrate the stranding: rotation succeeds silently, and a follow-up rebalance("none") "succeeds" without recovering anything. Once a guard lands rejecting rotation while a position is deployed, flip these assertions to expect a panic on set_blend_pool/set_dex_pool.

## Summary

Describe the purpose of this PR and the changes included.

## Checklist

- [ ] I have updated `CHANGELOG.md` under `[Unreleased]` for any contract behavior, event, or error-code changes.
- [ ] If this PR bumps `get_version()`, the new version number is noted in `CHANGELOG.md`.
- [ ] I have confirmed the release entry matches the expected contract `Version` storage value.
- [ ] I have included tests or documentation updates for new contract behavior.
- [ ] New or changed events are reflected in `EVENTS.md`.
