### PR TITLE
docs: NatDoc for public API, event field descriptions, DEX + upgrade-timelock architecture (#422, #423, #424, #425)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,8 +19,9 @@ Instance storage is used for contract-wide configuration that is read frequently
 | `TotalDeposits` | i128 | Total USDC principal deposited (excluding yield) |
 | `TotalShares` | i128 | Total vault shares in circulation |
 | `TotalAssets` | i128 | Total managed assets (principal + yield) |
-| `CurrentProtocol`| Symbol | Active protocol symbol ("blend", "none") |
+| `CurrentProtocol`| Symbol | Active protocol symbol ("blend", "dex", "none") |
 | `BlendPool` | Address | Blend pool contract address |
+| `DexPool` | Address | DEX liquidity pool contract address (Issue #228) |
 | `Paused` | bool | Emergency pause state |
 | `Owner` | Address | Contract owner for administrative functions |
 | `PendingOwner` | Address | Pending owner for two-step transfer |
@@ -29,6 +30,12 @@ Instance storage is used for contract-wide configuration that is read frequently
 | `ApprovalTtl` | u32 | Shared ledger TTL used for Blend and DEX approvals (authoritative; `BlendApprovalTtl` retained for legacy fallback) |
 | `MinDeposit` | i128 | Minimum per-transaction deposit |
 | `MaxDeposit` | i128 | Maximum per-transaction deposit |
+| `MinRebalanceInterval` | u32 | Minimum ledgers between `rebalance()` calls; key absent = no cooldown (Issue #59) |
+| `LastRebalanceLedger` | u32 | Ledger of the most recent successful `rebalance()` (Issue #59) |
+| `PendingAgent` | Address | Agent awaiting timelock confirmation (Issue #317) |
+| `AgentTimelockExpiry` | u32 | Ledger at which the pending agent update becomes confirmable (Issue #317) |
+| `PendingUpgradeHash` | BytesN<32> | WASM hash awaiting timelock execution (Issue #316) |
+| `UpgradeTimelockExpiry` | u32 | Ledger at which the pending upgrade becomes executable (Issue #316) |
 | `Version` | u32 | Contract version for upgrade tracking |
 
 ### Persistent Storage
@@ -37,8 +44,9 @@ Persistent storage is used for per-user data that requires efficient access.
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `Balance(Address)` | i128 | User's principal USDC deposit amount |
+| `Balance(Address)` | i128 | Deprecated. Retained only to preserve the serialized `DataKey` layout across upgrades; no longer read or written |
 | `Shares(Address)` | i128 | User's share balance (proportional ownership) |
+| `UserStrategy(Address)` | Symbol | Per-user strategy preference ("conservative", "balanced", "growth") |
 
 ## Persistent Storage TTL Policy
 
@@ -95,7 +103,15 @@ pub enum DataKey {
     MaxDeposit,           // maximum transaction amount
     Version,              // contract version
     BlendPool,            // Blend pool contract address
-    CurrentProtocol,      // symbol of active protocol
+    DexPool,              // DEX liquidity pool contract address (#228)
+    CurrentProtocol,      // symbol of active protocol ("blend" | "dex" | "none")
+    UserStrategy(Address),// user -> strategy preference symbol
+    MinRebalanceInterval, // rebalance cooldown in ledgers (#59)
+    LastRebalanceLedger,  // ledger of last successful rebalance (#59)
+    PendingAgent,         // agent awaiting timelock confirmation (#317)
+    AgentTimelockExpiry,  // ledger the pending agent update unlocks at (#317)
+    PendingUpgradeHash,   // WASM hash awaiting timelock execution (#316)
+    UpgradeTimelockExpiry,// ledger the pending upgrade unlocks at (#316)
     Deployer,             // deployer address (init only)
 }
 ```
@@ -299,6 +315,120 @@ Vault Contract → Blend Protocol Contract
 
 The vault integrates with the Blend protocol to generate yield on deposited USDC. The AI agent triggers rebalancing to move funds into or out of Blend.
 
+### DEX Liquidity Pool Integration (Issue #228)
+
+```
+Vault Contract → DEX Liquidity Pool Contract
+                 ↑
+                 ├── add_liquidity(from, asset, amount, min_out)    - provide USDC liquidity
+                 ├── remove_liquidity(to, asset, amount, min_out)   - withdraw liquidity
+                 └── balance(asset, user)                           - current position size
+```
+
+Alongside Blend lending, the vault can deploy idle USDC as single-asset
+liquidity into a Stellar DEX pool. This backs the Balanced and Growth
+strategies described in the README. The two integrations are mutually exclusive
+at any point in time: `CurrentProtocol` names at most one of `"blend"`,
+`"dex"`, or `"none"`.
+
+See [`docs/DEX_INTEGRATION.md`](docs/DEX_INTEGRATION.md) for the full interface
+research and rationale.
+
+#### Storage
+
+| Key | Storage | Type | Description |
+|-----|---------|------|-------------|
+| `DataKey::DexPool` | Instance | Address | DEX liquidity pool contract address. Absent until `set_dex_pool` is called; any rebalance targeting `"dex"` panics with `DexPoolNotConfigured` while unset. |
+| `DataKey::CurrentProtocol` | Instance | Symbol | Set to `"dex"` once a supply leg succeeds. Shared with the Blend path — the vault is never deployed to both at once. |
+| `DataKey::ApprovalTtl` | Instance | u32 | Shared with Blend. Each supply leg approves the DEX pool to spend USDC until `current_ledger + ApprovalTtl`. |
+
+`set_dex_pool(owner, pool_address)` is owner-only and probes the candidate
+pool's `balance` entrypoint before storing the address, so a wrong or
+non-conforming address is rejected at configuration time rather than at the
+next rebalance. It initializes `CurrentProtocol` to `"none"` when unset and
+emits `DexPoolConfiguredEvent`. There is no separate `DexApprovalTtl` key:
+`set_approval_ttl` governs both integrations.
+
+#### DexPoolClient interface
+
+`DexPoolClient` is an internal adapter mirroring `BlendPoolClient`. It treats
+the pool as a single-asset venue and derives actual amounts from the **vault's
+own USDC balance delta** rather than trusting the pool's return value, so
+partial fills and slippage are observable on-chain.
+
+| Method | Pool call | Returns |
+|---|---|---|
+| `supply(pool, asset, amount, min_out, to)` | `add_liquidity(from, asset, amount, min_out)` | `balance_before - balance_after` (USDC actually supplied) |
+| `withdraw(pool, asset, amount, min_out, to)` | `remove_liquidity(to, asset, amount, min_out)` | `balance_after - balance_before` (USDC actually received) |
+| `get_balance(pool, asset, user)` | `balance(asset, user)` | The vault's current liquidity position |
+
+`min_out` is forwarded to the pool for its own slippage check, and the realized
+delta is re-checked locally by `require_min_out`, which panics with
+`MinOutNotMet` when `min_out > 0` and the leg came up short.
+
+#### Idle vs deployed tracking with DEX positions
+
+DEX positions participate in the same idle/deployed split described under
+[Idle vs Deployed Asset Tracking](#idle-vs-deployed-asset-tracking-issue-321):
+
+- `get_idle_balance()` reads the vault's own USDC token balance and is
+  protocol-agnostic — supplying liquidity moves value out of it.
+- `get_deployed_assets()` dispatches on `CurrentProtocol`. When it is `"dex"`,
+  the figure comes from a live `balance(asset, vault)` call on the configured
+  DEX pool.
+- If `CurrentProtocol` is `"dex"` but `DexPool` is unset, `get_deployed_assets()`
+  returns `0` rather than panicking. The read path tolerates an unconfigured
+  pool; the write path (`rebalance`) does not.
+- `get_asset_breakdown()` returns both figures from a single invocation, so
+  they cannot straddle a rebalance.
+
+Because `get_deployed_assets()` performs a cross-contract call, it costs
+materially more than a plain storage getter — roughly the same order as the
+Blend balance read in the resource table above.
+
+#### Rebalance flow for DEX deployments
+
+`rebalance("dex", expected_apy, min_out)` runs the same sequence as the Blend
+path:
+
+1. Guards: agent auth, not paused, `0 ≤ expected_apy ≤ 10 000`, `min_out ≥ 0`,
+   protocol in the `{"blend", "dex", "none"}` allowlist, and the rebalance
+   cooldown (`MinRebalanceInterval`) has elapsed.
+2. **Exit leg.** If `CurrentProtocol` is a different non-`"none"` protocol, the
+   vault fully exits it first. If a non-zero balance remains after the
+   withdrawal, `RebalanceFailedEvent` is emitted and the call **returns without
+   further state changes** — the transaction is not reverted, so the failure is
+   observable on-chain (Issue #145).
+3. Panic with `DexPoolNotConfigured` if `DataKey::DexPool` is unset.
+4. **Supply leg.** The entire idle USDC balance is supplied: the vault approves
+   the pool for `amount` until `current_ledger + ApprovalTtl`, authorizes the
+   nested `add_liquidity` → `transfer_from` invocation via
+   `authorize_as_current_contract`, then calls the pool. `CurrentProtocol` is
+   set to `"dex"` only when the realized amount is positive.
+5. **Noop case.** With zero idle USDC and nothing moved, `CurrentProtocol` is
+   still set to `"dex"` so tracking matches intent, and the rebalance reports
+   status `"noop"` (mirrors Blend, Issue #146).
+6. `RebalanceEvent` is emitted with status `"success"`, `"partial"` (realized
+   below the attempted amount), `"failed"` (realized zero), or `"noop"`.
+
+Withdrawals follow the reverse path: `withdraw_from_dex(amount, min_out)` pulls
+from the pool when idle USDC cannot cover a redemption, treating `amount == 0`
+as "withdraw the entire position".
+
+#### DEX-specific events
+
+| Event | Topic | Emitted by | Payload |
+|---|---|---|---|
+| `DexSupplyEvent` | `"dex_sup"` (`TOPIC_DEX_SUPPLY`) | supply leg of `rebalance("dex", ..)` | `asset`, `amount_actual` (balance-delta measured), `success` |
+| `DexWithdrawEvent` | `"dex_wd"` (`TOPIC_DEX_WITHDRAW`) | DEX exit leg of `rebalance` or a user redemption | `asset`, `amount_actual`, `success` |
+| `DexPoolConfiguredEvent` | `"dex_cfg"` (`TOPIC_DEX_POOL_CONFIGURED`) | `set_dex_pool` | `old_pool` (`None` on first configuration), `new_pool`, `owner` |
+
+These are emitted **in addition to** the protocol-agnostic `RebalanceEvent` and
+`ProtocolChangedEvent`. Indexers tracking which venue the vault is deployed to
+should treat `ProtocolChangedEvent` as authoritative rather than inferring it
+from supply/withdraw events. See [EVENTS.md](EVENTS.md) for full payload field
+descriptions.
+
 ## Asset Flow Diagrams
 
 ### Deposit Flow
@@ -323,10 +453,16 @@ The vault integrates with the Blend protocol to generate yield on deposited USDC
 ### Rebalance Flow (AI Agent)
 
 1. AI agent evaluates market conditions.
-2. Agent calls `rebalance(protocol, expected_apy)` on vault.
-3. Vault verifies caller is agent and protocol is supported.
-4. Vault executes on-chain movement (e.g., supply to or withdraw from Blend).
-5. `RebalanceEvent` emitted.
+2. Agent calls `rebalance(protocol, expected_apy, min_out)` on vault.
+3. Vault verifies caller is agent, protocol is in `{"blend", "dex", "none"}`,
+   and the `MinRebalanceInterval` cooldown has elapsed.
+4. If already deployed elsewhere, vault exits the current protocol first. An
+   incomplete exit emits `RebalanceFailedEvent` and aborts without further
+   state changes.
+5. Vault executes on-chain movement (supply to or withdraw from Blend or the
+   DEX pool), emitting the protocol-specific supply/withdraw event.
+6. `ProtocolChangedEvent` emitted if `CurrentProtocol` changed.
+7. `RebalanceEvent` emitted with the outcome status.
 
 ## Upgrade Model
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -474,8 +474,15 @@ When upgrading the contract, the following storage keys must be preserved:
 - `TotalDeposits`, `TotalShares`, `TotalAssets`
 - `Agent`, `UsdcToken`, `Owner`, `Paused`
 - `TvLCap`, `UserDepositCap`, `ApprovalTtl`, `MinDeposit`, `MaxDeposit`
-- `BlendPool`, `CurrentProtocol`
-- `Version` (incremented)
+- `BlendPool`, `DexPool`, `CurrentProtocol`
+- `UserStrategy(Address)`
+- `MinRebalanceInterval`, `LastRebalanceLedger`
+- `PendingAgent`, `AgentTimelockExpiry` (if an agent update is mid-flight)
+- `Version` (incremented by `execute_upgrade`)
+
+`PendingUpgradeHash` and `UpgradeTimelockExpiry` are deliberately **not**
+preserved: `execute_upgrade` clears them before applying the new WASM, so the
+upgraded contract starts with no proposal pending.
 
 ### Version History
 
@@ -484,6 +491,10 @@ When upgrading the contract, the following storage keys must be preserved:
 | 1 | Initial 1:1 balance accounting (no shares) | Historical — superseded |
 | 2 | ERC-4626 share accounting, Blend integration, rounding rules | **Current** |
 | 3 | (Planned) Multi-asset support and advanced rebalancing | Future |
+
+`Version` is incremented by `execute_upgrade`, not by `schedule_upgrade`.
+Scheduling an upgrade that is later cancelled leaves `Version` untouched, so
+`get_version()` always reflects the WASM actually running.
 
 ## Error Handling
 
@@ -639,10 +650,78 @@ but does not influence on-chain fund movement.  Off-chain consumers (AI agent,
 dashboards) use it to audit that the expected yield reported at rebalance time
 is plausible.
 
-## Upgrade Safety (Issue #189)
+## Upgrade Safety (Issues #189, #316)
 
-`upgrade()` is gated by `require_not_paused()`.  During an incident the operator
-pauses the vault to freeze user operations; the upgrade guard ensures that a
-compromised or mistaken WASM upgrade cannot be pushed while the vault is in a
-degraded state.  To upgrade: unpause → upgrade → re-pause if needed.
+Contract upgrades are protected by two independent guards: a pause guard
+(Issue #189) and a two-step timelock (Issue #316).
+
+### Pause guard (Issue #189)
+
+`schedule_upgrade()` and `execute_upgrade()` are both gated by
+`require_not_paused()`. During an incident the operator pauses the vault to
+freeze user operations; the upgrade guard ensures that a compromised or
+mistaken WASM upgrade cannot be pushed while the vault is in a degraded state.
+To upgrade: unpause → schedule → wait out the timelock → execute → re-pause if
+needed.
+
+`cancel_upgrade()` is deliberately **not** pause-gated, so the escape hatch
+stays available even while the vault is paused.
+
+### Two-step timelocked upgrade (Issue #316)
+
+The instant `upgrade(new_wasm_hash)` entrypoint has been removed. Replacing the
+contract's WASM now requires two transactions separated by a mandatory delay,
+which gives users and monitoring systems a window to observe a pending code
+change and react to a malicious or mistaken proposal before it takes effect.
+
+```
+schedule_upgrade(owner, hash)          execute_upgrade(owner)
+        │                                       │
+        ▼                                       ▼
+   [ pending ] ──── UPGRADE_TIMELOCK_LEDGERS ──▶ [ applied ]
+        │              (17,280 ≈ 24 h)
+        │
+        └── cancel_upgrade(owner) ──▶ [ cleared ]
+```
+
+| Function | Auth | Effect |
+|---|---|---|
+| `schedule_upgrade(owner, new_wasm_hash)` | owner, not paused | Records `PendingUpgradeHash` and sets `UpgradeTimelockExpiry = current_ledger + UPGRADE_TIMELOCK_LEDGERS`. Emits `UpgradeScheduledEvent`. |
+| `execute_upgrade(owner)` | owner, not paused | Requires `current_ledger >= UpgradeTimelockExpiry`. Clears both keys, applies the WASM, increments `Version`. Emits `UpgradedEvent`. |
+| `cancel_upgrade(owner)` | owner | Clears both keys so a new proposal can be scheduled. Emits `UpgradeCancelledEvent`. |
+| `get_pending_upgrade()` | none (read-only) | Returns `Some((wasm_hash, effective_ledger))` while a proposal is pending, else `None`. |
+
+**Constant:** `UPGRADE_TIMELOCK_LEDGERS = 17_280` ledgers. At Stellar's ~5 s
+per ledger that is ≈ 86,400 s = 24 hours. It matches `AGENT_TIMELOCK_LEDGERS`
+so both privileged-role changes share one recovery window.
+
+**Storage keys** (instance storage, both cleared on execute *and* on cancel):
+
+| Key | Type | Description |
+|---|---|---|
+| `DataKey::PendingUpgradeHash` | `BytesN<32>` | WASM hash awaiting execution. Its presence is what makes an upgrade "pending". |
+| `DataKey::UpgradeTimelockExpiry` | `u32` | First ledger sequence at which `execute_upgrade()` may be called. |
+
+**Events:** `UpgradeScheduledEvent` (`"upg_sched"`), `UpgradeCancelledEvent`
+(`"upg_cncl"`), and `UpgradedEvent` (`"upgraded"`, now emitted by
+`execute_upgrade` rather than the removed instant path). See
+[EVENTS.md](EVENTS.md) for payload fields.
+
+**Invariants:**
+
+- Only one proposal may be pending at a time. Scheduling while
+  `PendingUpgradeHash` exists panics with `TimelockAlreadyPending`; to change
+  the target hash, cancel first and re-schedule (restarting the 24-hour clock).
+- `execute_upgrade()` with no proposal panics with `NoTimelockPending`; before
+  the expiry ledger it panics with `TimelockNotExpired`.
+- `TimelockAlreadyPending`, `NoTimelockPending`, and `TimelockNotExpired` are
+  shared with the agent timelock (Issue #317) because `#[contracterror]` caps
+  the enum at 50 variants.
+- The pending keys are cleared *before* `update_current_contract_wasm` is
+  called, so a fresh proposal can always be scheduled after execution.
+- A pending proposal has no effect on the running code. Until
+  `execute_upgrade()` succeeds, the deployed WASM is unchanged.
+
+Operational runbooks for scheduling, monitoring, and executing an upgrade live
+in [docs/UPGRADE_MIGRATION.md](docs/UPGRADE_MIGRATION.md).
 4. Minimize state changes in single transaction

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -17,20 +17,32 @@ All events use short symbol topics (max 9 characters) for efficiency:
 - Payload contains detailed event data
 - Events are published from the vault contract address
 
-Canonical topics are declared in [neurowealth-vault/contracts/vault/src/lib.rs](neurowealth-vault/contracts/vault/src/lib.rs) as `TOPIC_*` constants and should be used as the single source of truth by emit sites and tests.
+Canonical topics are declared in [neurowealth-vault/contracts/vault/src/topics.rs](neurowealth-vault/contracts/vault/src/topics.rs) as `TOPIC_*` constants and should be used as the single source of truth by emit sites and tests. `lib.rs` imports them rather than redefining its own copies, so the on-chain symbols, that module, and this document cannot drift apart.
+
+Every event below lists its `TOPIC_*` constant alongside the literal symbol. Three events publish an additional indexed `Address` as topic 1 so indexers can filter per user without scanning payloads: `DepositEvent`, `WithdrawEvent`, and `UserStrategyUpdatedEvent`.
+
+### Field description convention
+
+Every field in every payload below carries a one-line description matching the
+NatDoc on the corresponding Rust struct in `lib.rs`. Amounts are in **USDC raw
+units with 7 decimals** unless stated otherwise (1 USDC = `10_000_000`), and
+`old_*` / `new_*` pairs are the values immediately before and after the state
+change that triggered the event.
 
 ## Core Events
 
 ### 1. VaultInitializedEvent
-**Topic:** `"init"`
+**Topic:** `"init"` (`TOPIC_INIT`)
 
-Emitted when the vault is initialized with core configuration.
+Emitted exactly once, by `initialize`, when the vault is set up with its core
+configuration.
 
 ```rust
 pub struct VaultInitializedEvent {
-    pub agent: Address,        // Authorized AI agent address
-    pub usdc_token: Address,   // USDC token contract address
-    pub tvl_cap: i128,        // Initial TVL cap (7 decimals)
+    pub owner: Address,        // Initial owner; authorized for every administrative entrypoint (pause, caps, pool configuration, upgrades, ownership transfer)
+    pub agent: Address,        // Authorized AI agent; the only address allowed to call rebalance and update_total_assets
+    pub usdc_token: Address,   // USDC token contract address; the only token the vault accepts
+    pub tvl_cap: i128,         // TVL cap applied at initialization, in USDC raw units (7 decimals)
 }
 ```
 
@@ -94,7 +106,7 @@ pub struct WithdrawEvent {
 - Indexers filter withdrawal history by user via topic[1]
 
 ### 4. RebalanceEvent
-**Topic:** `"rebalance"`
+**Topic:** `"rebalance"` (`TOPIC_REBALANCE`)
 
 Emitted when the AI agent rebalances funds between yield strategies.
 
@@ -122,14 +134,14 @@ pub struct RebalanceEvent {
 - Indexers monitor strategy changes for risk analysis
 
 ### 4a. ProtocolChangedEvent
-**Topic:** `"proto_chg"`
+**Topic:** `"proto_chg"` (`TOPIC_PROTOCOL_CHANGED`)
 
-Emitted when `CurrentProtocol` storage changes (supply to Blend, full withdraw, or explicit transition to `"none"`).
+Emitted when `CurrentProtocol` storage changes (supply to Blend or a DEX pool, full withdraw, or explicit transition to `"none"`).
 
 ```rust
 pub struct ProtocolChangedEvent {
-    pub old_protocol: Symbol,
-    pub new_protocol: Symbol,
+    pub old_protocol: Symbol,   // Protocol the vault was deployed to before the change ("blend", "dex", or "none")
+    pub new_protocol: Symbol,   // Protocol the vault is deployed to after the change ("blend", "dex", or "none")
 }
 ```
 
@@ -137,7 +149,7 @@ pub struct ProtocolChangedEvent {
 - Indexers record explicit protocol state transitions without inferring from rebalance events alone
 
 ### 4b. RebalanceFailedEvent
-**Topic:** `"reb_fail"`
+**Topic:** `"reb_fail"` (`TOPIC_REBALANCE_FAILED`)
 
 Emitted when a rebalance exits a protocol but the withdrawal leg leaves a non-zero balance behind (incomplete exit).
 
@@ -151,40 +163,41 @@ pub struct RebalanceFailedEvent {
 ## Administrative Events
 
 ### 5. VaultPausedEvent
-**Topic:** `"paused"`
+**Topic:** `"paused"` (`TOPIC_PAUSED`)
 
-Emitted when the vault is paused by the owner.
+Emitted by `pause` when the vault is paused by the owner.
 
 ```rust
 pub struct VaultPausedEvent {
-    pub owner: Address,   // Owner who triggered the pause
+    pub owner: Address,   // Owner address that triggered the pause, read from storage rather than the caller argument
 }
 ```
 
 ### 6. VaultUnpausedEvent
-**Topic:** `"unpaused"`
+**Topic:** `"unpaused"` (`TOPIC_UNPAUSED`)
 
-Emitted when the vault is unpaused by the owner.
+Emitted by `unpause` when the vault is unpaused by the owner.
 
 ```rust
 pub struct VaultUnpausedEvent {
-    pub owner: Address,   // Owner who triggered the unpause
+    pub owner: Address,   // Owner address that triggered the unpause, read from storage rather than the caller argument
 }
 ```
 
 ### 7. EmergencyPausedEvent
-**Topic:** `"emerg"`
+**Topic:** `"emerg"` (`TOPIC_EMERGENCY_PAUSED`)
 
-Emitted when the vault is emergency paused by the agent.
+Emitted by `emergency_pause`. Distinguished from `VaultPausedEvent` so
+monitoring can alert on emergency halts specifically.
 
 ```rust
 pub struct EmergencyPausedEvent {
-    pub owner: Address,   // Agent who triggered emergency pause
+    pub owner: Address,   // Owner address that triggered the emergency pause, read from storage rather than the caller argument
 }
 ```
 
 ### 8. LimitsUpdatedEvent
-**Topic:** `"l_upd"`
+**Topic:** `"l_upd"` (`TOPIC_LIMITS_UPDATED`)
 
 Emitted when per-transaction deposit limits are updated.
 
@@ -194,53 +207,53 @@ Emitted when per-transaction deposit limits are updated.
 
 ```rust
 pub struct LimitsUpdatedEvent {
-    pub old_min: i128,    // Previous minimum deposit limit
-    pub new_min: i128,    // New minimum deposit limit
-    pub old_max: i128,    // Previous maximum deposit limit
-    pub new_max: i128,    // New maximum deposit limit
+    pub old_min: i128,    // Minimum per-transaction deposit before the change (7 decimals)
+    pub new_min: i128,    // Minimum per-transaction deposit after the change (7 decimals)
+    pub old_max: i128,    // Maximum per-transaction deposit before the change (7 decimals)
+    pub new_max: i128,    // Maximum per-transaction deposit after the change (7 decimals)
 }
 ```
 
 ### 8a. DepositLimitsUpdatedEvent
-**Topic:** `"dep_lim"`
+**Topic:** `"dep_lim"` (`TOPIC_DEPOSIT_LIMITS_UPDATED`)
 
 Emitted when per-transaction deposit limits are updated via `set_deposit_limits`. This is the current, unambiguous replacement for the legacy `LimitsUpdatedEvent` topic above.
 
 ```rust
 pub struct DepositLimitsUpdatedEvent {
-    pub old_min: i128,    // Previous minimum deposit limit
-    pub new_min: i128,    // New minimum deposit limit
-    pub old_max: i128,    // Previous maximum deposit limit
-    pub new_max: i128,    // New maximum deposit limit
+    pub old_min: i128,    // Minimum per-transaction deposit before the change (7 decimals)
+    pub new_min: i128,    // Minimum per-transaction deposit after the change (7 decimals)
+    pub old_max: i128,    // Maximum per-transaction deposit before the change (7 decimals)
+    pub new_max: i128,    // Maximum per-transaction deposit after the change (7 decimals)
 }
 ```
 
 ### 8b. TvlCapUpdatedEvent
-**Topic:** `"tvl_cap"`
+**Topic:** `"tvl_cap"` (`TOPIC_TVL_CAP_UPDATED`)
 
-Emitted when the vault's total TVL cap is updated.
+Emitted by `set_tvl_cap` when the vault's total TVL cap is updated.
 
 ```rust
 pub struct TvlCapUpdatedEvent {
-    pub old_cap: i128,    // Previous TVL cap
-    pub new_cap: i128,    // New TVL cap
+    pub old_cap: i128,    // TVL cap before the change (7 decimals)
+    pub new_cap: i128,    // TVL cap after the change (7 decimals)
 }
 ```
 
 ### 8c. UserDepositCapUpdatedEvent
-**Topic:** `"user_cap"`
+**Topic:** `"user_cap"` (`TOPIC_USER_CAP_UPDATED`)
 
-Emitted when the per-user deposit cap is updated.
+Emitted by `set_user_deposit_cap` when the per-user deposit cap is updated.
 
 ```rust
 pub struct UserDepositCapUpdatedEvent {
-    pub old_cap: i128,    // Previous per-user cap
-    pub new_cap: i128,    // New per-user cap
+    pub old_cap: i128,    // Per-user deposit cap before the change (7 decimals)
+    pub new_cap: i128,    // Per-user deposit cap after the change (7 decimals)
 }
 ```
 
 ### 8d. CapsUpdatedEvent
-**Topic:** `"caps_upd"`
+**Topic:** `"caps_upd"` (`TOPIC_CAPS_UPDATED`)
 
 Emitted when user deposit and TVL caps are updated in a single transaction via `set_caps`.
 
@@ -255,121 +268,134 @@ pub struct CapsUpdatedEvent {
 
 
 ### 9. AgentUpdatedEvent
-**Topic:** `"agent"`
+**Topic:** `"agent"` (`TOPIC_AGENT_UPDATED`)
 
 Emitted when the AI agent address is updated. Also emitted alongside `AgentUpdateConfirmedEvent` upon timelock execution for backward compatibility with legacy indexers.
 
 ```rust
 pub struct AgentUpdatedEvent {
-    pub old_agent: Address,  // Previous agent address
-    pub new_agent: Address,  // New agent address
+    pub old_agent: Address,  // Agent address that was authorized before the change
+    pub new_agent: Address,  // Agent address authorized after the change
 }
 ```
 
 ### 9a. AgentUpdateProposedEvent
-**Topic:** `"agt_prop"`
+**Topic:** `"agt_prop"` (`TOPIC_AGENT_UPDATE_PROPOSED`)
 
 Emitted when an agent update proposal is scheduled via `update_agent` — step 1 of the two-step timelocked agent update flow.
 
 ```rust
 pub struct AgentUpdateProposedEvent {
-    pub old_agent: Address,       // Current active agent address
-    pub new_agent: Address,       // Proposed new agent address
-    pub effective_ledger: u32,    // Ledger at which confirm_agent_update becomes callable
+    pub old_agent: Address,       // Agent currently authorized; stays active for the whole timelock window
+    pub new_agent: Address,       // Proposed agent address, activated only by confirm_agent_update
+    pub effective_ledger: u32,    // Ledger sequence at which confirm_agent_update becomes callable
 }
 ```
 
 ### 9b. AgentUpdateConfirmedEvent
-**Topic:** `"agt_conf"`
+**Topic:** `"agt_conf"` (`TOPIC_AGENT_UPDATE_CONFIRMED`)
 
 Emitted when a pending agent update proposal is executed via `confirm_agent_update` after the timelock window has elapsed — step 2 of the timelocked flow.
 
 ```rust
 pub struct AgentUpdateConfirmedEvent {
-    pub old_agent: Address,       // Previous agent address
-    pub new_agent: Address,       // New active agent address
+    pub old_agent: Address,       // Agent address that was authorized before confirmation
+    pub new_agent: Address,       // Agent address now authorized to call rebalance and update_total_assets
 }
 ```
 
 ### 9c. AgentUpdateCancelledEvent
-**Topic:** `"agt_cncl"`
+**Topic:** `"agt_cncl"` (`TOPIC_AGENT_UPDATE_CANCELLED`)
 
 Emitted when a pending proposed agent update is cancelled via `cancel_agent_update` before it is executed.
 
 ```rust
 pub struct AgentUpdateCancelledEvent {
-    pub old_agent: Address,              // Active agent address (remains unchanged)
-    pub proposed_new_agent: Address,     // The proposed agent address whose update was cancelled
+    pub old_agent: Address,              // Agent that stays authorized; cancelling never changes the active agent
+    pub proposed_new_agent: Address,     // Proposed agent address that is now discarded
 }
 ```
 
 ### 10. AssetsUpdatedEvent
-**Topic:** `"assets"`
+**Topic:** `"assets"` (`TOPIC_ASSETS_UPDATED`)
 
-Emitted when total assets are updated (yield accrual).
+Emitted by `update_total_assets` when the agent reports new total assets (yield
+accrual or loss reporting). Because share price is derived from `TotalAssets`,
+this is the authoritative signal that the exchange rate has moved.
 
 ```rust
 pub struct AssetsUpdatedEvent {
-    pub old_total: i128,   // Previous total assets
-    pub new_total: i128,   // New total assets
+    pub old_total: i128,   // Total managed assets before the update (7 decimals)
+    pub new_total: i128,   // Total managed assets after the update (7 decimals)
 }
 ```
 
 ### 10a. UserStrategyUpdatedEvent
-**Topic:** `"usr_strat"`
+**Topics:** `("usr_strat", <user: Address>)` (`TOPIC_USER_STRATEGY_UPDATED`)
 
-Emitted when a user updates their investment strategy preference.
+Emitted by `set_user_strategy` when a user updates their investment strategy
+preference. The preference is advisory: it tells the AI agent where the user
+would like funds deployed, and does not by itself move assets.
+
+The user address is published as a second **indexed topic**, so agents can
+subscribe per user.
 
 ```rust
 pub struct UserStrategyUpdatedEvent {
     pub user: Address,          // The user who updated their strategy
-    pub old_strategy: Symbol,   // Previous strategy symbol ("conservative", "balanced", "growth", or "")
-    pub new_strategy: Symbol,   // New strategy symbol
+    pub old_strategy: Symbol,   // Strategy before the change: "conservative", "balanced", "growth", or "" the first time a user sets one
+    pub new_strategy: Symbol,   // Strategy after the change: "conservative", "balanced", or "growth"
 }
 ```
+
+**Topic tuple (position → value):**
+| Position | Type    | Value                        |
+|----------|---------|------------------------------|
+| 0        | Symbol  | `"usr_strat"`                |
+| 1        | Address | user whose strategy changed  |
 
 ## Ownership Transfer Events
 
 ### 11. OwnershipTransferInitiatedEvent
-**Topic:** `"own_init"`
+**Topic:** `"own_init"` (`TOPIC_OWNERSHIP_INITIATED`)
 
-Emitted when ownership transfer is initiated.
+Emitted by `transfer_ownership` — step 1 of the two-step ownership transfer.
 
 ```rust
 pub struct OwnershipTransferInitiatedEvent {
-    pub current_owner: Address,  // Current owner address
-    pub pending_owner: Address,  // Pending owner address
+    pub current_owner: Address,  // Owner that remains in control until the transfer is accepted
+    pub pending_owner: Address,  // Proposed owner, which must call accept_ownership to take over
 }
 ```
 
 ### 12. OwnershipTransferredEvent
-**Topic:** `"own_xfer"`
+**Topic:** `"own_xfer"` (`TOPIC_OWNERSHIP_TRANSFERRED`)
 
-Emitted when ownership transfer is completed.
+Emitted by `accept_ownership` — step 2 of the two-step ownership transfer.
 
 ```rust
 pub struct OwnershipTransferredEvent {
-    pub old_owner: Address,   // Previous owner address
-    pub new_owner: Address,   // New owner address
+    pub old_owner: Address,   // Owner that held control before the transfer
+    pub new_owner: Address,   // Owner now authorized for administrative entrypoints
 }
 ```
 
 ### 13. OwnershipTransferCancelledEvent
-**Topic:** `"own_cncl"`
+**Topic:** `"own_cncl"` (`TOPIC_OWNERSHIP_CANCELLED`)
 
-Emitted when ownership transfer is cancelled.
+Emitted by `cancel_ownership_transfer` when a pending transfer is discarded.
 
 ```rust
 pub struct OwnershipTransferCancelledEvent {
-    pub owner: Address,              // Current owner address
-    pub cancelled_pending: Address,  // Cancelled pending owner
+    pub owner: Address,              // Owner that stays in control; cancelling never changes the owner
+    pub cancelled_pending: Address,  // Pending owner address that was discarded
 }
 ```
 
 ## Protocol Integration Events
 
 ### 14. BlendSupplyEvent
-**Topic:** `"blend_sup"`
+**Topic:** `"blend_sup"` (`TOPIC_BLEND_SUPPLY`)
 
 Emitted when assets are supplied to Blend protocol.
 
@@ -382,7 +408,7 @@ pub struct BlendSupplyEvent {
 ```
 
 ### 15. BlendWithdrawEvent
-**Topic:** `"blend_wd"`
+**Topic:** `"blend_wd"` (`TOPIC_BLEND_WITHDRAW`)
 
 Emitted when assets are withdrawn from Blend protocol.
 
@@ -395,7 +421,7 @@ pub struct BlendWithdrawEvent {
 ```
 
 ### 15a. BlendPoolConfiguredEvent
-**Topic:** `"blend_cfg"`
+**Topic:** `"blend_cfg"` (`TOPIC_BLEND_POOL_CONFIGURED`)
 
 Emitted after `set_blend_pool` updates the configured Blend pool address.
 
@@ -408,7 +434,7 @@ pub struct BlendPoolConfiguredEvent {
 ```
 
 ### 15b. DexSupplyEvent
-**Topic:** `"dex_sup"`
+**Topic:** `"dex_sup"` (`TOPIC_DEX_SUPPLY`)
 
 Emitted when assets are supplied to a DEX liquidity pool (Issue #228).
 
@@ -421,7 +447,7 @@ pub struct DexSupplyEvent {
 ```
 
 ### 15c. DexWithdrawEvent
-**Topic:** `"dex_wd"`
+**Topic:** `"dex_wd"` (`TOPIC_DEX_WITHDRAW`)
 
 Emitted when assets are withdrawn from a DEX liquidity pool (Issue #228).
 
@@ -434,7 +460,7 @@ pub struct DexWithdrawEvent {
 ```
 
 ### 15d. DexPoolConfiguredEvent
-**Topic:** `"dex_cfg"`
+**Topic:** `"dex_cfg"` (`TOPIC_DEX_POOL_CONFIGURED`)
 
 Emitted after `set_dex_pool` updates the configured DEX pool address (Issue #228).
 
@@ -449,7 +475,7 @@ pub struct DexPoolConfiguredEvent {
 ## Upgrade Events
 
 ### 16. UpgradedEvent
-**Topic:** `"upgraded"`
+**Topic:** `"upgraded"` (`TOPIC_UPGRADED`)
 
 Emitted when the contract is upgraded to a new WASM implementation.
 
@@ -463,7 +489,7 @@ pub struct UpgradedEvent {
 Emitted by `execute_upgrade` once the upgrade timelock has elapsed (Issue #316).
 
 ### 16a. UpgradeScheduledEvent
-**Topic:** `"upg_sched"`
+**Topic:** `"upg_sched"` (`TOPIC_UPGRADE_SCHEDULED`)
 
 Emitted when an upgrade is scheduled via `schedule_upgrade` — step 1 of the
 two-step timelocked upgrade (Issue #316). The new WASM hash does not take effect
@@ -477,7 +503,7 @@ pub struct UpgradeScheduledEvent {
 ```
 
 ### 16b. UpgradeCancelledEvent
-**Topic:** `"upg_cncl"`
+**Topic:** `"upg_cncl"` (`TOPIC_UPGRADE_CANCELLED`)
 
 Emitted when a pending upgrade is cancelled via `cancel_upgrade` before it is
 executed — the recovery path against a malicious or mistaken schedule (Issue #316).
@@ -485,6 +511,51 @@ executed — the recovery path against a malicious or mistaken schedule (Issue #
 ```rust
 pub struct UpgradeCancelledEvent {
     pub cancelled_wasm_hash: BytesN<32>, // Hash of the WASM whose pending upgrade was cancelled
+}
+```
+
+## Declared but Never Emitted
+
+Two payload structs are part of the contract's `#[contracttype]` surface — so
+they appear in `contract-spec.json` and in generated client bindings — but are
+never published by any code path. **Do not subscribe to them**; no topic will
+ever fire.
+
+### PauseEvent
+
+A combined pause/unpause payload superseded by the three dedicated events above.
+`pause`, `unpause`, and `emergency_pause` publish `VaultPausedEvent`,
+`VaultUnpausedEvent`, and `EmergencyPausedEvent` respectively.
+
+```rust
+pub struct PauseEvent {
+    pub paused: bool,     // true if the vault is now paused, false if now unpaused
+    pub caller: Address,  // Address that triggered the pause/unpause transition
+}
+```
+
+### InitFailedEvent
+
+A failed `initialize` panics with a `VaultError` and the whole transaction is
+reverted, so no event survives to be indexed. Observe the transaction result
+code instead.
+
+```rust
+pub struct InitFailedEvent {
+    pub caller: Address,  // Address that attempted the initialization
+    pub reason: Symbol,   // Short reason code describing why initialization was rejected
+}
+```
+
+## Non-Event Payload Types
+
+`UserInfo` is a **return type**, not an event. It is returned by
+`get_user_info` and is never published to the event log.
+
+```rust
+pub struct UserInfo {
+    pub principal: i128,  // Deprecated: now the share-derived asset balance, not a separately stored principal record
+    pub shares: i128,     // The user's vault share balance (proportional ownership of TotalAssets)
 }
 ```
 
@@ -543,3 +614,24 @@ Event schemas are versioned to ensure backward compatibility:
 - Changing field types requires a major version bump
 
 Current event schema version: **v1**
+
+## Keeping This Document in Sync
+
+Event documentation lives in two places and must agree:
+
+1. The NatDoc on each `#[contracttype]` struct in
+   [`lib.rs`](neurowealth-vault/contracts/vault/src/lib.rs) — a `# Topics`
+   section naming the literal symbol and its `TOPIC_*` constant, plus a
+   one-line `///` description on **every** field.
+2. The corresponding section in this document.
+
+When adding an event or a field:
+
+- Declare the topic in
+  [`topics.rs`](neurowealth-vault/contracts/vault/src/topics.rs), never inline
+  at the emit site. Symbols are capped at 9 characters by `symbol_short!`.
+- Document every field on both sides, including units for `i128` amounts.
+- Add the event to this document in the section matching its category, keeping
+  the `(TOPIC_*)` annotation next to the literal symbol.
+- If the event publishes indexed topics beyond position 0, add a topic-tuple
+  table like the ones under `DepositEvent` and `WithdrawEvent`.

--- a/docs/UPGRADE_MIGRATION.md
+++ b/docs/UPGRADE_MIGRATION.md
@@ -165,6 +165,81 @@ pub fn migrate(env: Env) {
 
 ---
 
+## 6a. Migrating from the Instant `upgrade()` (Issue #316)
+
+Before Issue #316 the vault exposed a single entrypoint:
+
+```rust
+// Removed. Applied the new WASM in one transaction, with no delay.
+pub fn upgrade(env: Env, owner: Address, new_wasm_hash: BytesN<32>)
+```
+
+That entrypoint **no longer exists**. Any runbook, deploy script, multisig
+template, or CI job that still calls `upgrade` will fail at invocation time with
+an unknown-function error — not silently. Replace it with the two-step flow:
+
+| Before (instant) | After (timelocked) |
+|---|---|
+| `upgrade(owner, hash)` | `schedule_upgrade(owner, hash)` → wait ≥ 17,280 ledgers → `execute_upgrade(owner)` |
+| — | `cancel_upgrade(owner)` to abandon a pending proposal |
+| — | `get_pending_upgrade()` to read `(hash, effective_ledger)` |
+| Emitted `UpgradedEvent` | `UpgradeScheduledEvent` on schedule, `UpgradedEvent` on execute, `UpgradeCancelledEvent` on cancel |
+
+### What operators must change
+
+* **Split the transaction in two.** The upgrade can no longer complete inside a
+  single maintenance window. Budget for a ≥ 24-hour gap between scheduling and
+  execution, and make sure the signer set that schedules is still available to
+  execute.
+* **Do not pre-sign `execute_upgrade` at scheduling time** unless your process
+  can revoke it. The delay only provides safety if someone is actually watching
+  and able to call `cancel_upgrade`.
+* **Assign a monitor.** Subscribe to `UpgradeScheduledEvent` (`"upg_sched"`) or
+  poll `get_pending_upgrade()` for the duration of the window, and compare the
+  pending hash against the WASM you intended to ship.
+* **Keep the vault unpaused to schedule and execute.** Both entrypoints are
+  pause-gated. `cancel_upgrade` is not, so the escape hatch remains usable
+  during an incident.
+* **Run `migrate()` after `execute_upgrade`, not after `schedule_upgrade`.**
+  Scheduling changes no code; the storage schema is still the old one until
+  execution lands.
+
+### New failure modes to expect
+
+| Error | Cause | Resolution |
+|---|---|---|
+| `TimelockAlreadyPending` | `schedule_upgrade` called while a proposal is already pending. | `cancel_upgrade(owner)` first, then re-schedule. The 24-hour clock restarts. |
+| `NoTimelockPending` | `execute_upgrade` or `cancel_upgrade` called with nothing scheduled. | Check `get_pending_upgrade()`; the proposal was already executed or cancelled. |
+| `TimelockNotExpired` | `execute_upgrade` called before `UpgradeTimelockExpiry`. | Compare `get_pending_upgrade()`'s `effective_ledger` against the current ledger sequence and retry after it passes. |
+| `CallerIsNotOwner` | The authorizing address is not the stored owner. All three entrypoints take `owner` as an argument *and* check it against storage. | Confirm the signer matches `get_owner()`. |
+| `Paused` | `schedule_upgrade` or `execute_upgrade` called while the vault is paused. | Unpause first. `cancel_upgrade` is not pause-gated and stays available. |
+
+The first three errors are **shared with the agent timelock** (Issue #317)
+because `#[contracterror]` caps the enum at 50 variants. When debugging, confirm
+which of the two flows raised the error before assuming it was the upgrade path.
+
+### Storage impact
+
+`schedule_upgrade` writes two new instance keys, `DataKey::PendingUpgradeHash`
+and `DataKey::UpgradeTimelockExpiry`. Both are appended `DataKey` variants, so
+existing serialized entries are unaffected and **no storage migration is
+required** to adopt the timelock.
+
+Both keys are cleared by `execute_upgrade` (before the WASM swap) and by
+`cancel_upgrade`. A vault that has never scheduled an upgrade has neither key,
+and `get_pending_upgrade()` returns `None`.
+
+### Emergency guidance
+
+The timelock is a safety feature, not an obstacle to route around: there is no
+bypass, and none should be added. If a hostile or mistaken upgrade is
+scheduled, the response is `cancel_upgrade(owner)` within the window. If owner
+keys themselves are compromised, cancelling is not sufficient — pause the
+vault, transfer ownership to safe keys via `transfer_ownership` /
+`accept_ownership`, and only then cancel the pending proposal.
+
+---
+
 ## 7. Upgrade Checklist
 
 Use this practical checklist for every upgrade.

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -111,6 +111,21 @@
 //! vault_client.withdraw(&user, &amount);
 //! ```
 
+// `missing_docs` cannot be denied crate-wide: `#[contract]`, `#[contracttype]`,
+// and `#[contracterror]` each expand to an undocumented static and associated
+// function whose spans point at the attribute itself, so no source-level
+// `#[allow]` can annotate them. The crate-level allow below exists solely to
+// suppress that macro-generated noise — it is *not* a licence to ship
+// undocumented API:
+//
+// - `#[warn(missing_docs)]` on `impl NeuroWealthVault` (see below) re-enables
+//   the lint for every public contract entrypoint. CI runs clippy with
+//   `-D warnings`, so an undocumented `pub fn` fails the build.
+// - Every hand-written public item — event structs and their fields,
+//   `DataKey` variants, `VaultError` variants — is documented explicitly.
+//
+// Per-item `#[allow(missing_docs)]` attributes were removed in favour of this
+// single, explained crate-level allow (issues #422 / #423).
 #![allow(missing_docs)]
 #![no_std]
 #![allow(deprecated)]
@@ -138,7 +153,6 @@ const DEFAULT_TVL_CAP: i128 = 100_000_000_000;
 // ERROR TYPES
 // ============================================================================
 
-#[allow(missing_docs)]
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum VaultError {
@@ -258,7 +272,6 @@ pub enum VaultError {
 /// This enum defines all keys used for both instance and persistent storage.
 /// Instance storage is used for contract-wide configuration, while persistent
 /// storage is used for per-user data that requires efficient access.
-#[allow(missing_docs)]
 #[contracttype]
 pub enum DataKey {
     /// Legacy user's principal USDC balance (key: user Address).
@@ -360,8 +373,9 @@ pub enum DataKey {
 /// yield deployment. External indexers use this for transaction tracking.
 ///
 /// # Topics
-/// - `SymbolShort("deposit")` - Event identifier
-#[allow(missing_docs)]
+/// - `0`: `SymbolShort("deposit")` (`TOPIC_DEPOSIT`) - Event identifier
+/// - `1`: `Address` - the depositing user, published as an indexed topic so
+///   indexers can filter by user without scanning payloads
 #[contracttype]
 pub struct DepositEvent {
     /// The user who made the deposit
@@ -378,8 +392,9 @@ pub struct DepositEvent {
 /// External indexers use this for transaction tracking.
 ///
 /// # Topics
-/// - `SymbolShort("withdraw")` - Event identifier
-#[allow(missing_docs)]
+/// - `0`: `SymbolShort("withdraw")` (`TOPIC_WITHDRAW`) - Event identifier
+/// - `1`: `Address` - the withdrawing user, published as an indexed topic so
+///   indexers can filter by user without scanning payloads
 #[contracttype]
 pub struct WithdrawEvent {
     /// The user who made the withdrawal
@@ -397,8 +412,7 @@ pub struct WithdrawEvent {
 /// target allocation.
 ///
 /// # Topics
-/// - `SymbolShort("rebalance")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("rebalance")` (`TOPIC_REBALANCE`) - Event identifier
 #[contracttype]
 pub struct RebalanceEvent {
     /// The target protocol (supported: "blend", "none")
@@ -423,113 +437,141 @@ pub struct RebalanceEvent {
 /// events alone.
 ///
 /// # Topics
-/// - `SymbolShort("proto_chg")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("proto_chg")` (`TOPIC_PROTOCOL_CHANGED`) - Event identifier
 #[contracttype]
 pub struct ProtocolChangedEvent {
+    /// Protocol the vault was deployed to before the change
+    /// (`"blend"`, `"dex"`, or `"none"`)
     pub old_protocol: Symbol,
+    /// Protocol the vault is deployed to after the change
+    /// (`"blend"`, `"dex"`, or `"none"`)
     pub new_protocol: Symbol,
 }
 
-/// Emitted when the vault is paused or unpaused.
+/// Combined pause/unpause payload.
+///
+/// # Reserved
+/// This struct is part of the contract type surface but is **not currently
+/// emitted**. `pause`, `unpause`, and `emergency_pause` publish the dedicated
+/// [`VaultPausedEvent`], [`VaultUnpausedEvent`], and [`EmergencyPausedEvent`]
+/// payloads instead. Indexers should not subscribe to this type.
 ///
 /// # Topics
-/// - `SymbolShort("pause")` - Event identifier
-#[allow(missing_docs)]
+/// - None (never published).
 #[contracttype]
 pub struct PauseEvent {
-    /// True if vault is now paused, false if unpaused
+    /// `true` if the vault is now paused, `false` if it is now unpaused
     pub paused: bool,
-    /// Address that triggered the pause/unpause
+    /// Address that triggered the pause/unpause transition
     pub caller: Address,
 }
 
-/// Emitted when the vault is initialized.
+/// Emitted once when the vault is initialized via `initialize`.
 ///
 /// # Topics
-/// - `SymbolShort("vault_initialized")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("init")` (`TOPIC_INIT`) - Event identifier
 #[contracttype]
 pub struct VaultInitializedEvent {
+    /// Initial owner address, authorized for every administrative entrypoint
+    /// (pause, caps, pool configuration, upgrades, ownership transfer)
     pub owner: Address,
+    /// Authorized AI agent address; the only address allowed to call
+    /// `rebalance` and `update_total_assets`
     pub agent: Address,
+    /// USDC token contract address; the only token the vault accepts
     pub usdc_token: Address,
+    /// TVL cap applied at initialization, in USDC raw units (7 decimals)
     pub tvl_cap: i128,
 }
 
-/// Emitted when initialization fails due to invalid signature.
+/// Initialization-failure payload.
+///
+/// # Reserved
+/// This struct is part of the contract type surface but is **not currently
+/// emitted**. A failed `initialize` panics with a [`VaultError`] and the
+/// transaction is reverted, so no event survives. Indexers should observe the
+/// transaction result code instead.
 ///
 /// # Topics
-/// - `SymbolShort("init_fail")` - Event identifier
-#[allow(missing_docs)]
+/// - None (never published).
 #[contracttype]
 pub struct InitFailedEvent {
+    /// Address that attempted the initialization
     pub caller: Address,
+    /// Short reason code describing why initialization was rejected
     pub reason: Symbol,
 }
 
-/// Emitted when the vault is paused.
+/// Emitted when the vault is paused via `pause`.
 ///
 /// # Topics
-/// - `SymbolShort("vault_paused")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("paused")` (`TOPIC_PAUSED`) - Event identifier
 #[contracttype]
 pub struct VaultPausedEvent {
+    /// Owner address that triggered the pause (read from storage, not the caller argument)
     pub owner: Address,
 }
 
-/// Emitted when the vault is unpaused.
+/// Emitted when the vault is unpaused via `unpause`.
 ///
 /// # Topics
-/// - `SymbolShort("vault_unpaused")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("unpaused")` (`TOPIC_UNPAUSED`) - Event identifier
 #[contracttype]
 pub struct VaultUnpausedEvent {
+    /// Owner address that triggered the unpause (read from storage, not the caller argument)
     pub owner: Address,
 }
 
-/// Emitted when the vault is emergency paused.
+/// Emitted when the vault is emergency-paused via `emergency_pause`.
+///
+/// Distinguished from [`VaultPausedEvent`] so monitoring can alert on
+/// emergency halts specifically.
 ///
 /// # Topics
-/// - `SymbolShort("emergency_paused")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("emerg")` (`TOPIC_EMERGENCY_PAUSED`) - Event identifier
 #[contracttype]
 pub struct EmergencyPausedEvent {
+    /// Owner address that triggered the emergency pause (read from storage, not the caller argument)
     pub owner: Address,
 }
 
-/// Emitted when the TVL cap is updated.
+/// Emitted when the TVL cap is updated via `set_tvl_cap`.
 ///
 /// # Topics
-/// - `SymbolShort("tvl_cap_updated")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("tvl_cap")` (`TOPIC_TVL_CAP_UPDATED`) - Event identifier
 #[contracttype]
 pub struct TvlCapUpdatedEvent {
+    /// TVL cap before the change, in USDC raw units (7 decimals)
     pub old_cap: i128,
+    /// TVL cap after the change, in USDC raw units (7 decimals)
     pub new_cap: i128,
 }
 
-/// Emitted when the per-user deposit cap is updated.
+/// Emitted when the per-user deposit cap is updated via `set_user_deposit_cap`.
 ///
 /// # Topics
-/// - `SymbolShort("user_cap_updated")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("user_cap")` (`TOPIC_USER_CAP_UPDATED`) - Event identifier
 #[contracttype]
 pub struct UserDepositCapUpdatedEvent {
+    /// Per-user deposit cap before the change, in USDC raw units (7 decimals)
     pub old_cap: i128,
+    /// Per-user deposit cap after the change, in USDC raw units (7 decimals)
     pub new_cap: i128,
 }
 
 /// Emitted when both user deposit cap and TVL cap are updated.
 ///
 /// # Topics
-/// - `SymbolShort("caps_upd")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("caps_upd")` (`TOPIC_CAPS_UPDATED`) - Event identifier
 #[contracttype]
 pub struct CapsUpdatedEvent {
+    /// Per-user deposit cap before the change, in USDC raw units (7 decimals)
     pub old_user_cap: i128,
+    /// Per-user deposit cap after the change, in USDC raw units (7 decimals)
     pub new_user_cap: i128,
+    /// TVL cap before the change, in USDC raw units (7 decimals)
     pub old_tvl_cap: i128,
+    /// TVL cap after the change, in USDC raw units (7 decimals)
     pub new_tvl_cap: i128,
 }
 
@@ -542,13 +584,16 @@ pub struct CapsUpdatedEvent {
 /// indexers that still observe the `set_limits` call path.
 ///
 /// # Topics
-/// - `SymbolShort("l_upd")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("l_upd")` (`TOPIC_LIMITS_UPDATED`) - Event identifier
 #[contracttype]
 pub struct LimitsUpdatedEvent {
+    /// Minimum per-transaction deposit before the change, in USDC raw units (7 decimals)
     pub old_min: i128,
+    /// Minimum per-transaction deposit after the change, in USDC raw units (7 decimals)
     pub new_min: i128,
+    /// Maximum per-transaction deposit before the change, in USDC raw units (7 decimals)
     pub old_max: i128,
+    /// Maximum per-transaction deposit after the change, in USDC raw units (7 decimals)
     pub new_max: i128,
 }
 
@@ -556,35 +601,43 @@ pub struct LimitsUpdatedEvent {
 /// via `set_deposit_limits`.
 ///
 /// # Topics
-/// - `SymbolShort("dep_lim")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("dep_lim")` (`TOPIC_DEPOSIT_LIMITS_UPDATED`) - Event identifier
 #[contracttype]
 pub struct DepositLimitsUpdatedEvent {
+    /// Minimum per-transaction deposit before the change, in USDC raw units (7 decimals)
     pub old_min: i128,
+    /// Minimum per-transaction deposit after the change, in USDC raw units (7 decimals)
     pub new_min: i128,
+    /// Maximum per-transaction deposit before the change, in USDC raw units (7 decimals)
     pub old_max: i128,
+    /// Maximum per-transaction deposit after the change, in USDC raw units (7 decimals)
     pub new_max: i128,
 }
 
-/// Emitted when the AI agent is updated.
+/// Emitted when the AI agent address changes.
+///
+/// Published alongside [`AgentUpdateConfirmedEvent`] by `confirm_agent_update`
+/// so legacy indexers that only track this topic keep working.
 ///
 /// # Topics
-/// - `SymbolShort("agent_updated")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("agent")` (`TOPIC_AGENT_UPDATED`) - Event identifier
 #[contracttype]
 pub struct AgentUpdatedEvent {
+    /// Agent address that was authorized before the change
     pub old_agent: Address,
+    /// Agent address authorized after the change
     pub new_agent: Address,
 }
 
 /// Emitted when an agent update is proposed via `update_agent()` (timelock step 1).
 ///
 /// # Topics
-/// - `SymbolShort("agt_prop")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("agt_prop")` (`TOPIC_AGENT_UPDATE_PROPOSED`) - Event identifier
 #[contracttype]
 pub struct AgentUpdateProposedEvent {
+    /// Agent address currently authorized; remains active for the whole timelock window
     pub old_agent: Address,
+    /// Proposed agent address, activated only by `confirm_agent_update`
     pub new_agent: Address,
     /// Ledger at which `confirm_agent_update()` becomes callable.
     pub effective_ledger: u32,
@@ -593,74 +646,86 @@ pub struct AgentUpdateProposedEvent {
 /// Emitted when a pending agent update is confirmed via `confirm_agent_update()` (timelock step 2).
 ///
 /// # Topics
-/// - `SymbolShort("agt_conf")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("agt_conf")` (`TOPIC_AGENT_UPDATE_CONFIRMED`) - Event identifier
 #[contracttype]
 pub struct AgentUpdateConfirmedEvent {
+    /// Agent address that was authorized before confirmation
     pub old_agent: Address,
+    /// Agent address now authorized to call `rebalance` and `update_total_assets`
     pub new_agent: Address,
 }
 
 /// Emitted when a pending agent update is cancelled via `cancel_agent_update()`.
 ///
 /// # Topics
-/// - `SymbolShort("agt_cncl")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("agt_cncl")` (`TOPIC_AGENT_UPDATE_CANCELLED`) - Event identifier
 #[contracttype]
 pub struct AgentUpdateCancelledEvent {
+    /// Agent address that stays authorized; cancelling never changes the active agent
     pub old_agent: Address,
+    /// Agent address that had been proposed and is now discarded
     pub proposed_new_agent: Address,
 }
 
-/// Emitted when ownership transfer is initiated.
+/// Emitted when an ownership transfer is initiated via `transfer_ownership`
+/// (step 1 of the two-step transfer).
 ///
 /// # Topics
-/// - `SymbolShort("own_init")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("own_init")` (`TOPIC_OWNERSHIP_INITIATED`) - Event identifier
 #[contracttype]
 pub struct OwnershipTransferInitiatedEvent {
+    /// Owner address that remains in control until the transfer is accepted
     pub current_owner: Address,
+    /// Proposed owner address that must call `accept_ownership` to take over
     pub pending_owner: Address,
 }
 
-/// Emitted when ownership transfer is completed.
+/// Emitted when an ownership transfer completes via `accept_ownership`
+/// (step 2 of the two-step transfer).
 ///
 /// # Topics
-/// - `SymbolShort("own_xfer")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("own_xfer")` (`TOPIC_OWNERSHIP_TRANSFERRED`) - Event identifier
 #[contracttype]
 pub struct OwnershipTransferredEvent {
+    /// Owner address that held control before the transfer
     pub old_owner: Address,
+    /// Owner address now authorized for administrative entrypoints
     pub new_owner: Address,
 }
 
-/// Emitted when ownership transfer is cancelled.
+/// Emitted when a pending ownership transfer is cancelled via
+/// `cancel_ownership_transfer`.
 ///
 /// # Topics
-/// - `SymbolShort("own_cncl")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("own_cncl")` (`TOPIC_OWNERSHIP_CANCELLED`) - Event identifier
 #[contracttype]
 pub struct OwnershipTransferCancelledEvent {
+    /// Owner address that stays in control; cancelling never changes the owner
     pub owner: Address,
+    /// Pending owner address that was discarded
     pub cancelled_pending: Address,
 }
 
-/// Emitted when total assets are updated.
+/// Emitted when the agent reports new total assets via `update_total_assets`
+/// (yield accrual or loss reporting).
+///
+/// Because share price is derived from `TotalAssets`, this event is the
+/// authoritative signal that the exchange rate has moved.
 ///
 /// # Topics
-/// - `SymbolShort("assets_updated")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("assets")` (`TOPIC_ASSETS_UPDATED`) - Event identifier
 #[contracttype]
 pub struct AssetsUpdatedEvent {
+    /// Total managed assets before the update, in USDC raw units (7 decimals)
     pub old_total: i128,
+    /// Total managed assets after the update, in USDC raw units (7 decimals)
     pub new_total: i128,
 }
 
 /// Emitted when the contract is upgraded to a new WASM implementation.
 ///
 /// # Topics
-/// - `SymbolShort("upgraded")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("upgraded")` (`TOPIC_UPGRADED`) - Event identifier
 #[contracttype]
 pub struct UpgradedEvent {
     /// The contract version before the upgrade
@@ -672,8 +737,7 @@ pub struct UpgradedEvent {
 /// Emitted when an upgrade is scheduled via `schedule_upgrade()` (timelock step 1). (#316)
 ///
 /// # Topics
-/// - `SymbolShort("upg_sched")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("upg_sched")` (`TOPIC_UPGRADE_SCHEDULED`) - Event identifier
 #[contracttype]
 pub struct UpgradeScheduledEvent {
     /// Hash of the WASM binary that will be activated once the timelock elapses.
@@ -685,8 +749,7 @@ pub struct UpgradeScheduledEvent {
 /// Emitted when a pending upgrade is cancelled via `cancel_upgrade()`. (#316)
 ///
 /// # Topics
-/// - `SymbolShort("upg_cncl")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("upg_cncl")` (`TOPIC_UPGRADE_CANCELLED`) - Event identifier
 #[contracttype]
 pub struct UpgradeCancelledEvent {
     /// Hash of the WASM binary whose pending upgrade was cancelled.
@@ -696,8 +759,7 @@ pub struct UpgradeCancelledEvent {
 /// Emitted when assets are supplied to Blend protocol.
 ///
 /// # Topics
-/// - `SymbolShort("blend_sup")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("blend_sup")` (`TOPIC_BLEND_SUPPLY`) - Event identifier
 #[contracttype]
 pub struct BlendSupplyEvent {
     /// The asset address (USDC)
@@ -711,8 +773,7 @@ pub struct BlendSupplyEvent {
 /// Emitted when assets are withdrawn from Blend protocol.
 ///
 /// # Topics
-/// - `SymbolShort("blend_wd")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("blend_wd")` (`TOPIC_BLEND_WITHDRAW`) - Event identifier
 #[contracttype]
 pub struct BlendWithdrawEvent {
     /// The asset address (USDC)
@@ -726,8 +787,7 @@ pub struct BlendWithdrawEvent {
 /// Emitted when the Blend pool address is configured.
 ///
 /// # Topics
-/// - `SymbolShort("blend_cfg")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("blend_cfg")` (`TOPIC_BLEND_POOL_CONFIGURED`) - Event identifier
 #[contracttype]
 pub struct BlendPoolConfiguredEvent {
     /// Previous Blend pool address, or None if it was not configured
@@ -741,8 +801,7 @@ pub struct BlendPoolConfiguredEvent {
 /// Emitted when assets are supplied to a DEX liquidity pool.
 ///
 /// # Topics
-/// - `SymbolShort("dex_sup")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("dex_sup")` (`TOPIC_DEX_SUPPLY`) - Event identifier
 #[contracttype]
 pub struct DexSupplyEvent {
     /// The asset address (USDC)
@@ -756,8 +815,7 @@ pub struct DexSupplyEvent {
 /// Emitted when assets are withdrawn from a DEX liquidity pool.
 ///
 /// # Topics
-/// - `SymbolShort("dex_wd")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("dex_wd")` (`TOPIC_DEX_WITHDRAW`) - Event identifier
 #[contracttype]
 pub struct DexWithdrawEvent {
     /// The asset address (USDC)
@@ -771,8 +829,7 @@ pub struct DexWithdrawEvent {
 /// Emitted when the DEX pool address is configured.
 ///
 /// # Topics
-/// - `SymbolShort("dex_cfg")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("dex_cfg")` (`TOPIC_DEX_POOL_CONFIGURED`) - Event identifier
 #[contracttype]
 pub struct DexPoolConfiguredEvent {
     /// Previous DEX pool address, or None if it was not configured
@@ -789,8 +846,7 @@ pub struct DexPoolConfiguredEvent {
 /// reverting the transaction. State remains unchanged when this event fires.
 ///
 /// # Topics
-/// - `SymbolShort("reb_fail")` - Event identifier
-#[allow(missing_docs)]
+/// - `SymbolShort("reb_fail")` (`TOPIC_REBALANCE_FAILED`) - Event identifier
 #[contracttype]
 pub struct RebalanceFailedEvent {
     /// The protocol the vault was trying to exit
@@ -804,8 +860,9 @@ pub struct RebalanceFailedEvent {
 /// AI agents read this event to adjust yield deployment per user.
 ///
 /// # Topics
-/// - `SymbolShort("usr_strat")` - Event identifier
-#[allow(missing_docs)]
+/// - `0`: `SymbolShort("usr_strat")` (`TOPIC_USER_STRATEGY_UPDATED`) - Event identifier
+/// - `1`: `Address` - the user whose strategy changed, published as an indexed
+///   topic so agents can subscribe per user
 #[contracttype]
 pub struct UserStrategyUpdatedEvent {
     /// The user who updated their strategy
@@ -816,7 +873,10 @@ pub struct UserStrategyUpdatedEvent {
     pub new_strategy: Symbol,
 }
 
-#[allow(missing_docs)]
+/// Aggregate view of a single user's position, returned by
+/// [`NeuroWealthVault::get_user_info`].
+///
+/// This is a return type, not an event: it is never published to the event log.
 #[contracttype]
 pub struct UserInfo {
     /// Deprecated compatibility field.
@@ -825,6 +885,9 @@ pub struct UserInfo {
     /// stored principal record. Use `shares` plus share conversion helpers when
     /// exact accounting provenance matters.
     pub principal: i128,
+    /// The user's vault share balance, representing proportional ownership of
+    /// `TotalAssets`. Convert to USDC with
+    /// [`NeuroWealthVault::convert_to_assets`].
     pub shares: i128,
 }
 
@@ -844,7 +907,6 @@ pub struct UserInfo {
 struct BlendPoolClient;
 
 #[derive(Clone)]
-#[allow(missing_docs)]
 #[contracttype]
 struct BlendRequest {
     request_type: u32,
@@ -1130,11 +1192,14 @@ impl DexPoolClient {
 /// # Upgradeability
 ///
 /// This contract can be upgraded by the owner while preserving all storage state.
-#[allow(missing_docs)]
 #[contract]
 pub struct NeuroWealthVault;
 
 #[contractimpl]
+// Re-enables `missing_docs` for the contract's public entrypoints, which the
+// crate-level allow would otherwise silence. Keep this attribute: it is what
+// makes an undocumented `pub fn` fail CI (`clippy -D warnings`).
+#[warn(missing_docs)]
 impl NeuroWealthVault {
     #[inline]
     fn require(env: &Env, condition: bool, error: VaultError) {
@@ -2453,15 +2518,37 @@ impl NeuroWealthVault {
     ///
     /// # Events
     ///
-    /// - `BlendPoolConfiguredEvent`
+    /// None. The cooldown is configuration-only; read the effective value back
+    /// with [`get_rebalance_cooldown`](crate::NeuroWealthVault::get_rebalance_cooldown).
     ///
     /// # Errors
     ///
-    /// None.
+    /// None. Failures panic rather than returning a `Result`.
     ///
     /// # Panics
     ///
-    /// - If the caller is not the owner.
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    /// - [`VaultError::CallerIsNotOwner`] if the caller is not the stored owner.
+    ///
+    /// # Storage
+    ///
+    /// Writes [`DataKey::MinRebalanceInterval`] in instance storage, or removes
+    /// the key entirely when `interval == 0`. `rebalance` compares
+    /// [`DataKey::LastRebalanceLedger`] against this value and panics with
+    /// [`VaultError::RebalanceCooldownActive`] while the window is open.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Throttle the agent to roughly one rebalance per hour
+    /// // (720 ledgers x ~5 s per ledger = 3,600 s).
+    /// vault_client.set_rebalance_cooldown(&720);
+    /// assert_eq!(vault_client.get_rebalance_cooldown(), 720);
+    ///
+    /// // Disable the throttle again.
+    /// vault_client.set_rebalance_cooldown(&0);
+    /// assert_eq!(vault_client.get_rebalance_cooldown(), 0);
+    /// ```
     pub fn set_rebalance_cooldown(env: Env, interval: u32) {
         Self::require_initialized(&env);
         Self::require_is_owner(&env);
@@ -2486,6 +2573,14 @@ impl NeuroWealthVault {
     ///
     /// # Returns
     /// The minimum ledgers between rebalances, or `0` when disabled.
+    ///
+    /// # Events
+    ///
+    /// None.
+    ///
+    /// # Panics
+    ///
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
     pub fn get_rebalance_cooldown(env: Env) -> u32 {
         Self::require_initialized(&env);
         env.storage()
@@ -2502,6 +2597,14 @@ impl NeuroWealthVault {
     ///
     /// # Returns
     /// The ledger of the last rebalance, or `0`.
+    ///
+    /// # Events
+    ///
+    /// None.
+    ///
+    /// # Panics
+    ///
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
     pub fn get_last_rebalance_ledger(env: Env) -> u32 {
         Self::require_initialized(&env);
         env.storage()
@@ -2510,22 +2613,54 @@ impl NeuroWealthVault {
             .unwrap_or(0)
     }
 
-    /// Sets the number of ledgers that Blend token approvals remain valid.
+    /// Sets the shared lifetime, in ledgers, of the token approvals the vault
+    /// grants to external protocols.
     ///
-    /// Only the owner can call this function. The TTL is bounded to prevent
-    /// approvals from expiring too quickly or remaining valid for too long.
+    /// The TTL applies to **both** the Blend and DEX integrations: before each
+    /// supply leg the vault approves the pool to spend USDC until
+    /// `current_ledger + ttl`. A short TTL limits the blast radius of a
+    /// compromised pool; a long TTL avoids re-approving on every rebalance.
+    ///
+    /// Only the owner can call this function. The value is clamped to
+    /// `[1_000, 500_000]` ledgers (roughly 1.4 to 29 days at ~5 s per ledger).
     ///
     /// # Arguments
+    ///
     /// * `env` - The Soroban environment.
-    /// * `ttl` - Number of ledgers to add to the current ledger for approvals.
+    /// * `ttl` - Number of ledgers added to the current ledger when approving.
     ///
     /// # Returns
+    ///
     /// None.
     ///
+    /// # Events
+    ///
+    /// None.
+    ///
+    /// # Errors
+    ///
+    /// None. Failures panic rather than returning a `Result`.
+    ///
     /// # Panics
-    /// - If the caller is not the owner.
-    /// - If `ttl` is below 1,000 ledgers.
-    /// - If `ttl` is above 500,000 ledgers.
+    ///
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    /// - [`VaultError::CallerIsNotOwner`] if the caller is not the stored owner.
+    /// - [`VaultError::ApprovalTtlTooLow`] if `ttl < 1_000`.
+    /// - [`VaultError::ApprovalTtlTooHigh`] if `ttl > 500_000`.
+    ///
+    /// # Storage
+    ///
+    /// Writes [`DataKey::ApprovalTtl`]. The legacy
+    /// [`DataKey::BlendApprovalTtl`] key is only read as a fallback for vaults
+    /// initialized before the shared TTL existed, and is never written here.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Shorten approvals to ~1 day (17,280 ledgers x ~5 s).
+    /// vault_client.set_approval_ttl(&17_280);
+    /// assert_eq!(vault_client.get_approval_ttl(), 17_280);
+    /// ```
     pub fn set_approval_ttl(env: Env, ttl: u32) {
         Self::require_initialized(&env);
         Self::require_is_owner(&env);
@@ -2540,13 +2675,32 @@ impl NeuroWealthVault {
         env.storage().instance().set(&DataKey::ApprovalTtl, &ttl);
     }
 
-    /// Returns the configured Blend approval TTL, or the default if unset.
+    /// Returns the shared protocol approval TTL in ledgers.
+    ///
+    /// Resolution order: [`DataKey::ApprovalTtl`], then the legacy
+    /// [`DataKey::BlendApprovalTtl`] for vaults initialized before the shared
+    /// key existed, then the `100_000`-ledger default (~5.7 days).
     ///
     /// # Arguments
+    ///
     /// * `env` - The Soroban environment.
     ///
     /// # Returns
-    /// Number of ledgers added to the current ledger for Blend token approvals.
+    ///
+    /// Number of ledgers added to the current ledger when approving Blend or
+    /// DEX pools to spend the vault's USDC.
+    ///
+    /// # Events
+    ///
+    /// None.
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Panics
+    ///
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
     pub fn get_approval_ttl(env: Env) -> u32 {
         Self::require_initialized(&env);
         Self::get_approval_ttl_internal(&env)
@@ -2614,27 +2768,57 @@ impl NeuroWealthVault {
     // USER STRATEGY PREFERENCE
     // ==========================================================================
 
-    /// Sets the user's investment strategy preference.
+    /// Sets the caller's investment strategy preference.
     ///
-    /// Only the user themselves can set their own strategy (requires auth).
-    /// The strategy is stored on-chain for the AI agent to read.
+    /// Only the user themselves can set their own strategy (`require_auth`);
+    /// neither the owner nor the agent can set it on their behalf. The
+    /// preference is advisory: it is stored on-chain for the AI agent to read
+    /// when choosing where to deploy funds, and does not by itself move any
+    /// assets or restrict which protocol `rebalance` may target.
+    ///
+    /// Setting the same strategy twice is allowed and re-emits the event with
+    /// `old_strategy == new_strategy`.
     ///
     /// # Arguments
     ///
     /// * `env` - The Soroban environment.
-    /// * `user` - The user address (must authorize).
-    /// * `strategy` - The strategy symbol: "conservative", "balanced", or "growth".
+    /// * `user` - The user address; must authorize the call.
+    /// * `strategy` - One of `"conservative"`, `"balanced"`, or `"growth"`.
+    ///
+    /// # Returns
+    ///
+    /// None.
     ///
     /// # Events
     ///
-    /// Emits:
-    /// - `UserStrategyUpdatedEvent`
+    /// Emits [`UserStrategyUpdatedEvent`] with topics
+    /// `("usr_strat", user)`. `old_strategy` is the empty symbol `""` the first
+    /// time a user sets a preference.
+    ///
+    /// # Errors
+    ///
+    /// None. Failures panic rather than returning a `Result`.
     ///
     /// # Panics
     ///
-    /// - If the vault is not initialized.
-    /// - If the user does not authorize.
-    /// - If the strategy is not one of the valid options.
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    /// - If `user` does not authorize the call.
+    /// - [`VaultError::InvalidStrategy`] if `strategy` is not one of the three
+    ///   accepted symbols.
+    ///
+    /// # Storage
+    ///
+    /// Writes [`DataKey::UserStrategy`] in persistent storage, keyed by `user`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// vault_client.set_user_strategy(&user, &Symbol::new(&env, "growth"));
+    /// assert_eq!(
+    ///     vault_client.get_user_strategy(&user),
+    ///     Symbol::new(&env, "growth"),
+    /// );
+    /// ```
     pub fn set_user_strategy(env: Env, user: Address, strategy: Symbol) {
         Self::require_initialized(&env);
         user.require_auth();
@@ -2665,9 +2849,12 @@ impl NeuroWealthVault {
         );
     }
 
-    /// Returns the user's investment strategy preference.
+    /// Returns a user's investment strategy preference.
     ///
-    /// If the user has not set a strategy, returns the default ("balanced").
+    /// Read-only and unauthenticated: any caller may query any address. Users
+    /// who have never called [`set_user_strategy`](crate::NeuroWealthVault::set_user_strategy) are reported as
+    /// `"balanced"`, so callers cannot distinguish "never set" from
+    /// "explicitly set to balanced" through this function alone.
     ///
     /// # Arguments
     ///
@@ -2676,7 +2863,30 @@ impl NeuroWealthVault {
     ///
     /// # Returns
     ///
-    /// The strategy symbol ("conservative", "balanced", or "growth").
+    /// The strategy symbol: `"conservative"`, `"balanced"`, or `"growth"`.
+    /// Defaults to `"balanced"` when unset.
+    ///
+    /// # Events
+    ///
+    /// None.
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Panics
+    ///
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // A user who has never expressed a preference reads back as "balanced".
+    /// assert_eq!(
+    ///     vault_client.get_user_strategy(&fresh_user),
+    ///     Symbol::new(&env, "balanced"),
+    /// );
+    /// ```
     pub fn get_user_strategy(env: Env, user: Address) -> Symbol {
         Self::require_initialized(&env);
         env.storage()
@@ -2849,7 +3059,59 @@ impl NeuroWealthVault {
         );
     }
 
-    /// Returns the pending agent address and effective ledger, if a proposal is active. (#317)
+    /// Returns the pending agent proposal, if one is active. (#317)
+    ///
+    /// Lets operators and indexers observe a proposed agent change during the
+    /// 24-hour timelock window opened by [`update_agent`](crate::NeuroWealthVault::update_agent), and decide
+    /// whether to let it proceed or call [`cancel_agent_update`](crate::NeuroWealthVault::cancel_agent_update).
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment.
+    ///
+    /// # Returns
+    ///
+    /// * `Some((new_agent, effective_ledger))` while a proposal is pending,
+    ///   where `effective_ledger` is the first ledger at which
+    ///   [`confirm_agent_update`](crate::NeuroWealthVault::confirm_agent_update) may be called.
+    /// * `None` when no proposal is pending — either none was made, or it was
+    ///   already confirmed or cancelled.
+    ///
+    /// Compare `effective_ledger` against `env.ledger().sequence()` to tell a
+    /// still-waiting proposal from a ready-to-confirm one. The currently active
+    /// agent is unchanged until confirmation; read it with [`get_agent`](crate::NeuroWealthVault::get_agent).
+    ///
+    /// # Events
+    ///
+    /// None.
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Panics
+    ///
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    ///
+    /// # Storage
+    ///
+    /// Reads [`DataKey::PendingAgent`] and [`DataKey::AgentTimelockExpiry`].
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// match vault_client.get_pending_agent_update() {
+    ///     None => { /* no agent change in flight */ }
+    ///     Some((new_agent, effective_ledger)) => {
+    ///         if env.ledger().sequence() >= effective_ledger {
+    ///             vault_client.confirm_agent_update();
+    ///         } else {
+    ///             // Still inside the timelock window; cancel if unexpected.
+    ///             let _ = new_agent;
+    ///         }
+    ///     }
+    /// }
+    /// ```
     pub fn get_pending_agent_update(env: Env) -> Option<(Address, u32)> {
         Self::require_initialized(&env);
         let pending: Option<Address> = env.storage().instance().get(&DataKey::PendingAgent);
@@ -2933,7 +3195,7 @@ impl NeuroWealthVault {
 
     /// Configures the DEX liquidity pool contract address (owner only).
     ///
-    /// Mirrors [`Self::set_blend_pool`]. The pool interface is validated by probing
+    /// Mirrors [`set_blend_pool`](crate::NeuroWealthVault::set_blend_pool). The pool interface is validated by probing
     /// its `balance` entrypoint before the address is stored, so an invalid pool
     /// address is rejected at configuration time. `CurrentProtocol` is initialized
     /// to `"none"` when not already set.
@@ -3539,8 +3801,61 @@ impl NeuroWealthVault {
         );
     }
 
-    /// Returns the pending upgrade WASM hash and effective ledger, if a proposal
-    /// is active. (#316)
+    /// Returns the pending upgrade proposal, if one is active. (#316)
+    ///
+    /// This is the public monitoring hook for the two-step timelocked upgrade.
+    /// Users and watchtowers should poll it (or subscribe to
+    /// [`UpgradeScheduledEvent`]) to learn about a scheduled code change while
+    /// there is still time to exit the vault or for the owner to call
+    /// [`cancel_upgrade`](crate::NeuroWealthVault::cancel_upgrade).
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment.
+    ///
+    /// # Returns
+    ///
+    /// * `Some((new_wasm_hash, effective_ledger))` while an upgrade is pending,
+    ///   where `new_wasm_hash` is the WASM that [`execute_upgrade`](crate::NeuroWealthVault::execute_upgrade) will
+    ///   activate and `effective_ledger` is the first ledger at which it may be
+    ///   executed.
+    /// * `None` when no upgrade is pending — either none was scheduled, or it
+    ///   was already executed or cancelled.
+    ///
+    /// A `Some(..)` result does **not** mean the contract code has changed; the
+    /// running code is only replaced by [`execute_upgrade`](crate::NeuroWealthVault::execute_upgrade). Compare the
+    /// returned hash against the WASM you expect before allowing the timelock
+    /// to elapse.
+    ///
+    /// # Events
+    ///
+    /// None.
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Panics
+    ///
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    ///
+    /// # Storage
+    ///
+    /// Reads [`DataKey::PendingUpgradeHash`] and
+    /// [`DataKey::UpgradeTimelockExpiry`].
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// if let Some((wasm_hash, effective_ledger)) = vault_client.get_pending_upgrade() {
+    ///     let ledgers_remaining = effective_ledger.saturating_sub(env.ledger().sequence());
+    ///     if wasm_hash != expected_wasm_hash {
+    ///         // Unexpected code scheduled - cancel within the timelock window.
+    ///         vault_client.cancel_upgrade(&owner);
+    ///     }
+    ///     let _ = ledgers_remaining;
+    /// }
+    /// ```
     pub fn get_pending_upgrade(env: Env) -> Option<(BytesN<32>, u32)> {
         Self::require_initialized(&env);
         let pending: Option<BytesN<32>> =
@@ -3801,7 +4116,25 @@ impl NeuroWealthVault {
     ///
     /// # Panics
     ///
-    /// None.
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    ///
+    /// # Storage
+    ///
+    /// Extends the TTL of [`DataKey::Shares`] in persistent storage when the
+    /// entry exists. Never creates an entry, so calling this for an address
+    /// that has never deposited is a cheap no-op returning `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Keeper job: refresh every tracked holder, skipping addresses that
+    /// // hold no shares.
+    /// for user in tracked_users {
+    ///     if !vault_client.touch_user_ttl(&user) {
+    ///         // No Shares entry - drop the address from the keeper set.
+    ///     }
+    /// }
+    /// ```
     pub fn touch_user_ttl(env: Env, user: Address) -> bool {
         Self::require_initialized(&env);
         if !env
@@ -3845,16 +4178,27 @@ impl NeuroWealthVault {
         UserInfo { principal, shares }
     }
 
-    /// Previews the number of shares that would be minted for a given asset deposit.
+    /// Previews the number of shares that would be minted for a given deposit.
+    ///
+    /// Uses **floor** rounding, matching `deposit`: the caller may receive
+    /// fractionally fewer shares than exact division would give, and the
+    /// remainder accrues to the vault. This is the ERC-4626 convention.
+    ///
+    /// Read-only, but the preview is only valid for the current ledger state —
+    /// a deposit, withdrawal, or `update_total_assets` landing in between can
+    /// move the share price. Frontends should re-read immediately before
+    /// submitting.
     ///
     /// # Arguments
     ///
     /// * `env` - The Soroban environment.
-    /// * `assets` - The amount of USDC to deposit (7 decimal places).
+    /// * `assets` - The amount of USDC to deposit, in raw units (7 decimals).
     ///
     /// # Returns
     ///
-    /// Returns the number of shares that would be minted.
+    /// The number of shares that would be minted:
+    /// `floor(assets * total_shares / total_assets)`, or `assets` in the
+    /// bootstrap case where `total_shares == 0` or `total_assets == 0`.
     ///
     /// # Events
     ///
@@ -3866,22 +4210,36 @@ impl NeuroWealthVault {
     ///
     /// # Panics
     ///
-    /// None.
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    /// - If the intermediate `assets * total_shares` product overflows `i128`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Vault holding 1,100 USDC against 1,000 shares (10% yield accrued).
+    /// // Depositing 110 USDC mints ~100 shares.
+    /// let shares = vault_client.preview_deposit_to_shares(&1_100_000_000);
+    /// ```
     pub fn preview_deposit_to_shares(env: Env, assets: i128) -> i128 {
         Self::require_initialized(&env);
         Self::convert_to_shares_internal(&env, assets)
     }
 
-    /// Previews the number of assets that a given number of shares is worth.
+    /// Previews the USDC value of a given number of shares.
+    ///
+    /// Uses **floor** rounding, matching the redemption path. Use this to show
+    /// a holder's current position value; use [`preview_withdraw`](crate::NeuroWealthVault::preview_withdraw) to
+    /// show how many shares a *target withdrawal amount* would burn.
     ///
     /// # Arguments
     ///
     /// * `env` - The Soroban environment.
-    /// * `shares` - The number of shares.
+    /// * `shares` - The number of vault shares to value.
     ///
     /// # Returns
     ///
-    /// Returns the asset value of the shares (7 decimal places).
+    /// `floor(shares * total_assets / total_shares)` in USDC raw units
+    /// (7 decimals), or `0` when the vault holds no shares or no assets.
     ///
     /// # Events
     ///
@@ -3893,7 +4251,16 @@ impl NeuroWealthVault {
     ///
     /// # Panics
     ///
-    /// None.
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    /// - If the intermediate `shares * total_assets` product overflows `i128`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Display a user's position in USDC.
+    /// let shares = vault_client.get_shares(&user);
+    /// let value = vault_client.preview_shares_to_assets(&shares);
+    /// ```
     pub fn preview_shares_to_assets(env: Env, shares: i128) -> i128 {
         Self::require_initialized(&env);
         Self::convert_to_assets_internal(&env, shares)
@@ -3917,7 +4284,9 @@ impl NeuroWealthVault {
     ///
     /// # Returns
     ///
-    /// Returns the number of shares that would be burned.
+    /// The number of shares that would be burned:
+    /// `ceil(assets * total_shares / total_assets)`. Always at least `1` when
+    /// `assets > 0`, which is what makes dust withdrawals non-free.
     ///
     /// # Events
     ///
@@ -3929,23 +4298,42 @@ impl NeuroWealthVault {
     ///
     /// # Panics
     ///
-    /// None.
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    /// - If the intermediate `assets * total_shares` product overflows `i128`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Show the user the share cost of a withdrawal before they confirm.
+    /// let shares_burned = vault_client.preview_withdraw(&amount);
+    /// assert!(shares_burned <= vault_client.get_shares(&user));
+    ///
+    /// // Ceil burn: preview_withdraw is never smaller than the floor-rounded
+    /// // conversion of the same amount.
+    /// assert!(shares_burned >= vault_client.convert_to_shares(&amount));
+    /// ```
     pub fn preview_withdraw(env: Env, assets: i128) -> i128 {
         Self::require_initialized(&env);
         Self::convert_to_shares_internal_ceil(&env, assets)
     }
 
-    /// Converts an asset amount (USDC) to the corresponding number of shares,
-    /// using the current share price.
+    /// Converts a USDC amount to shares at the current share price.
+    ///
+    /// The ERC-4626 `convertToShares` equivalent: an idealised, fee-free
+    /// conversion for accounting and display. It is identical to
+    /// [`preview_deposit_to_shares`](crate::NeuroWealthVault::preview_deposit_to_shares) in this vault because deposits carry
+    /// no fee, and both round **down**. When previewing a *withdrawal*, use
+    /// [`preview_withdraw`](crate::NeuroWealthVault::preview_withdraw) instead — that path rounds up.
     ///
     /// # Arguments
     ///
     /// * `env` - The Soroban environment.
-    /// * `assets` - The asset amount.
+    /// * `assets` - The USDC amount in raw units (7 decimals).
     ///
     /// # Returns
     ///
-    /// Returns the number of shares.
+    /// `floor(assets * total_shares / total_assets)`, or `assets` in the
+    /// bootstrap case where `total_shares == 0` or `total_assets == 0`.
     ///
     /// # Events
     ///
@@ -3957,23 +4345,35 @@ impl NeuroWealthVault {
     ///
     /// # Panics
     ///
-    /// None.
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    /// - If the intermediate `assets * total_shares` product overflows `i128`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Round-tripping is lossy in the vault's favour, never the user's.
+    /// let shares = vault_client.convert_to_shares(&assets);
+    /// assert!(vault_client.convert_to_assets(&shares) <= assets);
+    /// ```
     pub fn convert_to_shares(env: Env, assets: i128) -> i128 {
         Self::require_initialized(&env);
         Self::convert_to_shares_internal(&env, assets)
     }
 
-    /// Converts a share amount to the corresponding asset amount (USDC),
-    /// using the current share price.
+    /// Converts a share amount to USDC at the current share price.
+    ///
+    /// The ERC-4626 `convertToAssets` equivalent, identical to
+    /// [`preview_shares_to_assets`](crate::NeuroWealthVault::preview_shares_to_assets) in this vault. Rounds **down**.
     ///
     /// # Arguments
     ///
     /// * `env` - The Soroban environment.
-    /// * `shares` - The number of shares.
+    /// * `shares` - The number of vault shares.
     ///
     /// # Returns
     ///
-    /// Returns the asset amount.
+    /// `floor(shares * total_assets / total_shares)` in USDC raw units
+    /// (7 decimals), or `0` when the vault holds no shares or no assets.
     ///
     /// # Events
     ///
@@ -3985,7 +4385,16 @@ impl NeuroWealthVault {
     ///
     /// # Panics
     ///
-    /// None.
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    /// - If the intermediate `shares * total_assets` product overflows `i128`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Value the whole supply: equals total_assets up to floor rounding.
+    /// let all = vault_client.convert_to_assets(&vault_client.get_total_shares());
+    /// assert!(all <= vault_client.get_total_assets());
+    /// ```
     pub fn convert_to_assets(env: Env, shares: i128) -> i128 {
         Self::require_initialized(&env);
         Self::convert_to_assets_internal(&env, shares)
@@ -4306,7 +4715,12 @@ impl NeuroWealthVault {
     ///
     /// # Returns
     ///
-    /// Returns the idle USDC balance in raw units (7 decimal places).
+    /// The idle USDC balance in raw units (7 decimals), read live from the USDC
+    /// token contract.
+    ///
+    /// This is the token balance, not an accounting figure: it is not the same
+    /// as `get_total_assets() - get_deployed_assets()`, and it is the amount a
+    /// withdrawal can be served from without exiting a protocol position.
     ///
     /// # Events
     ///
@@ -4318,7 +4732,15 @@ impl NeuroWealthVault {
     ///
     /// # Panics
     ///
-    /// None.
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    /// - If the USDC token contract traps on the `balance` call.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Can this withdrawal be served without touching the protocol position?
+    /// let instant = vault_client.get_idle_balance() >= amount;
+    /// ```
     pub fn get_idle_balance(env: Env) -> i128 {
         Self::require_initialized(&env);
         let usdc: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
@@ -4338,8 +4760,13 @@ impl NeuroWealthVault {
     ///
     /// # Returns
     ///
-    /// Returns the deployed USDC amount in raw units (7 decimal places), or `0`
-    /// when no funds are deployed.
+    /// The deployed USDC amount in raw units (7 decimals), queried live from
+    /// the active protocol's `balance` entrypoint.
+    ///
+    /// Returns `0` when [`DataKey::CurrentProtocol`] is `"none"`, when it names
+    /// a protocol the vault does not integrate, or when the matching pool
+    /// address ([`DataKey::BlendPool`] / [`DataKey::DexPool`]) is unset — an
+    /// unconfigured pool reads as zero rather than panicking.
     ///
     /// # Events
     ///
@@ -4351,7 +4778,19 @@ impl NeuroWealthVault {
     ///
     /// # Panics
     ///
-    /// None.
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    /// - If the configured pool contract traps on the cross-contract `balance`
+    ///   call. Because this is a cross-contract read, the call also costs more
+    ///   than a plain storage getter.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Yield to date, ignoring rounding, once funds are deployed.
+    /// let deployed = vault_client.get_deployed_assets();
+    /// let idle = vault_client.get_idle_balance();
+    /// let unreported = (idle + deployed) - vault_client.get_total_assets();
+    /// ```
     pub fn get_deployed_assets(env: Env) -> i128 {
         Self::require_initialized(&env);
         let protocol: Symbol = env
@@ -4364,7 +4803,7 @@ impl NeuroWealthVault {
 
     /// Returns the vault's asset breakdown as `(idle, deployed)`.
     ///
-    /// Combines [`Self::get_idle_balance`] and [`Self::get_deployed_assets`] into
+    /// Combines [`get_idle_balance`](crate::NeuroWealthVault::get_idle_balance) and [`get_deployed_assets`](crate::NeuroWealthVault::get_deployed_assets) into
     /// a single call for convenience. Useful for dashboards and AI agents that need
     /// both values atomically in one RPC round-trip.
     ///
@@ -4377,8 +4816,14 @@ impl NeuroWealthVault {
     ///
     /// # Returns
     ///
-    /// Returns `(idle, deployed)` where both values are in raw USDC units
-    /// (7 decimal places).
+    /// `(idle, deployed)`, both in USDC raw units (7 decimals). The two values
+    /// are read within one invocation, so they are consistent with each other —
+    /// unlike calling the two getters separately, which can straddle a
+    /// rebalance.
+    ///
+    /// Their sum is the vault's economic position and need not equal
+    /// [`get_total_assets`](crate::NeuroWealthVault::get_total_assets), which only moves when the agent reports it
+    /// via `update_total_assets`. A persistent gap means unreported yield.
     ///
     /// # Events
     ///
@@ -4390,7 +4835,20 @@ impl NeuroWealthVault {
     ///
     /// # Panics
     ///
-    /// None.
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    /// - If the USDC token or the configured pool contract traps on its
+    ///   `balance` call.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let (idle, deployed) = vault_client.get_asset_breakdown();
+    /// let deployed_pct = if idle + deployed == 0 {
+    ///     0
+    /// } else {
+    ///     deployed * 100 / (idle + deployed)
+    /// };
+    /// ```
     pub fn get_asset_breakdown(env: Env) -> (i128, i128) {
         Self::require_initialized(&env);
         let usdc: Address = env.storage().instance().get(&DataKey::UsdcToken).unwrap();
@@ -4608,13 +5066,13 @@ impl NeuroWealthVault {
     /// Uses floor division - safe for deposits (user gets fewer shares, vault benefits).
     ///
     /// # Inflation-attack note
-    /// Pricing reads the stored `TotalAssets` (see [`Self::get_total_assets_internal`]),
+    /// Pricing reads the stored `TotalAssets` (see [`get_total_assets_internal`](crate::NeuroWealthVault::get_total_assets_internal)),
     /// NOT the vault's live token balance. Direct "donations" (token transfers to
     /// the vault that bypass `deposit`) therefore do not move the share price, so
     /// the classic first-depositor/donation inflation attack does not apply here.
     /// Virtual-share / dead-share offsets (common mitigations for balance-based
     /// vaults) are unnecessary as a result. The `deposit` entrypoint additionally
-    /// rejects zero-share mints and enforces a minimum deposit; see [`Self::deposit`]
+    /// rejects zero-share mints and enforces a minimum deposit; see [`deposit`](crate::NeuroWealthVault::deposit)
     /// for the full mitigation rationale.
     #[inline]
     fn convert_to_shares_internal(env: &Env, assets: i128) -> i128 {
@@ -4927,10 +5385,10 @@ impl NeuroWealthVault {
 
     /// Internal helper: Supplies USDC to the DEX liquidity pool.
     ///
-    /// Mirrors [`Self::supply_to_blend`]: approves the pool to pull USDC, authorizes
+    /// Mirrors [`supply_to_blend`](crate::NeuroWealthVault::supply_to_blend): approves the pool to pull USDC, authorizes
     /// the cross-contract `add_liquidity` call (with its `transfer_from`
     /// sub-invocation), then supplies. The `min_out` floor is enforced both by
-    /// forwarding it to the pool and by [`Self::require_min_out`] on the realized
+    /// forwarding it to the pool and by [`require_min_out`](crate::NeuroWealthVault::require_min_out) on the realized
     /// amount, giving slippage protection on the DEX leg.
     ///
     /// # Arguments
@@ -5052,7 +5510,7 @@ impl NeuroWealthVault {
 
     /// Internal helper: Withdraws USDC from the DEX liquidity pool.
     ///
-    /// Mirrors [`Self::withdraw_from_blend`]. When `amount == 0` the full deployed
+    /// Mirrors [`withdraw_from_blend`](crate::NeuroWealthVault::withdraw_from_blend). When `amount == 0` the full deployed
     /// position is withdrawn.
     ///
     /// # Arguments
@@ -5148,7 +5606,7 @@ impl NeuroWealthVault {
     /// Internal helper: Withdraws a specific `amount` from the active protocol.
     ///
     /// Used by user-facing `withdraw`/`withdraw_all` to pull only the liquidity
-    /// needed to satisfy a redemption (as opposed to [`Self::withdraw_from_protocol`],
+    /// needed to satisfy a redemption (as opposed to [`withdraw_from_protocol`](crate::NeuroWealthVault::withdraw_from_protocol),
     /// which exits the full position). Dispatches to the protocol-specific helper.
     ///
     /// # Returns

--- a/neurowealth-vault/contracts/vault/src/topics.rs
+++ b/neurowealth-vault/contracts/vault/src/topics.rs
@@ -5,40 +5,85 @@
 //! redefining its own copies, so the on-chain symbols, this file, and
 //! `EVENTS.md` cannot drift apart. Symbols are limited to 9 characters
 //! (the `symbol_short!` limit).
+//!
+//! Most events publish a single-element topic tuple, `(TOPIC_X,)`. Three
+//! events additionally publish an indexed `Address` as topic 1 so indexers can
+//! filter per user without scanning payloads: [`TOPIC_DEPOSIT`],
+//! [`TOPIC_WITHDRAW`], and [`TOPIC_USER_STRATEGY_UPDATED`].
 
-#![allow(missing_docs)]
+#![warn(missing_docs)]
 
 use soroban_sdk::{symbol_short, Symbol};
 
+/// Topic for `VaultInitializedEvent`, published once by `initialize`.
 pub const TOPIC_INIT: Symbol = symbol_short!("init");
+/// Topic 0 for `DepositEvent`; topic 1 is the depositing user's `Address`.
 pub const TOPIC_DEPOSIT: Symbol = symbol_short!("deposit");
+/// Topic 0 for `WithdrawEvent`; topic 1 is the withdrawing user's `Address`.
+///
+/// Published by both `withdraw` and `withdraw_all`.
 pub const TOPIC_WITHDRAW: Symbol = symbol_short!("withdraw");
+/// Topic for `RebalanceEvent`, published by every `rebalance` outcome
+/// (including `"noop"`).
 pub const TOPIC_REBALANCE: Symbol = symbol_short!("rebalance");
+/// Topic for `VaultPausedEvent`, published by `pause`.
 pub const TOPIC_PAUSED: Symbol = symbol_short!("paused");
+/// Topic for `VaultUnpausedEvent`, published by `unpause`.
 pub const TOPIC_UNPAUSED: Symbol = symbol_short!("unpaused");
+/// Topic for `EmergencyPausedEvent`, published by `emergency_pause`.
 pub const TOPIC_EMERGENCY_PAUSED: Symbol = symbol_short!("emerg");
+/// Topic for `TvlCapUpdatedEvent`, published by `set_tvl_cap`.
 pub const TOPIC_TVL_CAP_UPDATED: Symbol = symbol_short!("tvl_cap");
+/// Topic for `UserDepositCapUpdatedEvent`, published by `set_user_deposit_cap`.
 pub const TOPIC_USER_CAP_UPDATED: Symbol = symbol_short!("user_cap");
+/// Topic for `LimitsUpdatedEvent`, published by the deprecated `set_limits`.
+///
+/// Prefer [`TOPIC_DEPOSIT_LIMITS_UPDATED`] for new indexers.
 pub const TOPIC_LIMITS_UPDATED: Symbol = symbol_short!("l_upd");
+/// Topic for `DepositLimitsUpdatedEvent`, published by `set_deposit_limits`.
 pub const TOPIC_DEPOSIT_LIMITS_UPDATED: Symbol = symbol_short!("dep_lim");
+/// Topic for `CapsUpdatedEvent`, published by `set_caps`.
 pub const TOPIC_CAPS_UPDATED: Symbol = symbol_short!("caps_upd");
+/// Topic for `AgentUpdatedEvent`, published by `confirm_agent_update` alongside
+/// [`TOPIC_AGENT_UPDATE_CONFIRMED`] for legacy indexer compatibility.
 pub const TOPIC_AGENT_UPDATED: Symbol = symbol_short!("agent");
+/// Topic for `OwnershipTransferInitiatedEvent`, published by `transfer_ownership`.
 pub const TOPIC_OWNERSHIP_INITIATED: Symbol = symbol_short!("own_init");
+/// Topic for `OwnershipTransferredEvent`, published by `accept_ownership`.
 pub const TOPIC_OWNERSHIP_TRANSFERRED: Symbol = symbol_short!("own_xfer");
+/// Topic for `OwnershipTransferCancelledEvent`, published by `cancel_ownership_transfer`.
 pub const TOPIC_OWNERSHIP_CANCELLED: Symbol = symbol_short!("own_cncl");
+/// Topic for `AssetsUpdatedEvent`, published by `update_total_assets`.
 pub const TOPIC_ASSETS_UPDATED: Symbol = symbol_short!("assets");
+/// Topic for `UpgradedEvent`, published by `execute_upgrade`.
 pub const TOPIC_UPGRADED: Symbol = symbol_short!("upgraded");
+/// Topic for `BlendSupplyEvent`, published when a rebalance supplies USDC to Blend.
 pub const TOPIC_BLEND_SUPPLY: Symbol = symbol_short!("blend_sup");
+/// Topic for `BlendWithdrawEvent`, published when a rebalance exits a Blend position.
 pub const TOPIC_BLEND_WITHDRAW: Symbol = symbol_short!("blend_wd");
+/// Topic for `BlendPoolConfiguredEvent`, published by `set_blend_pool`.
 pub const TOPIC_BLEND_POOL_CONFIGURED: Symbol = symbol_short!("blend_cfg");
+/// Topic for `DexSupplyEvent`, published when a rebalance adds DEX liquidity.
 pub const TOPIC_DEX_SUPPLY: Symbol = symbol_short!("dex_sup");
+/// Topic for `DexWithdrawEvent`, published when a rebalance removes DEX liquidity.
 pub const TOPIC_DEX_WITHDRAW: Symbol = symbol_short!("dex_wd");
+/// Topic for `DexPoolConfiguredEvent`, published by `set_dex_pool`.
 pub const TOPIC_DEX_POOL_CONFIGURED: Symbol = symbol_short!("dex_cfg");
+/// Topic for `ProtocolChangedEvent`, the authoritative signal that
+/// `DataKey::CurrentProtocol` changed.
 pub const TOPIC_PROTOCOL_CHANGED: Symbol = symbol_short!("proto_chg");
+/// Topic 0 for `UserStrategyUpdatedEvent`; topic 1 is the user's `Address`.
 pub const TOPIC_USER_STRATEGY_UPDATED: Symbol = symbol_short!("usr_strat");
+/// Topic for `RebalanceFailedEvent`, published when a protocol exit leg leaves
+/// a non-zero balance behind and the rebalance aborts without reverting.
 pub const TOPIC_REBALANCE_FAILED: Symbol = symbol_short!("reb_fail");
+/// Topic for `AgentUpdateProposedEvent`, published by `update_agent` (timelock step 1).
 pub const TOPIC_AGENT_UPDATE_PROPOSED: Symbol = symbol_short!("agt_prop");
+/// Topic for `AgentUpdateConfirmedEvent`, published by `confirm_agent_update` (timelock step 2).
 pub const TOPIC_AGENT_UPDATE_CONFIRMED: Symbol = symbol_short!("agt_conf");
+/// Topic for `AgentUpdateCancelledEvent`, published by `cancel_agent_update`.
 pub const TOPIC_AGENT_UPDATE_CANCELLED: Symbol = symbol_short!("agt_cncl");
+/// Topic for `UpgradeScheduledEvent`, published by `schedule_upgrade` (timelock step 1).
 pub const TOPIC_UPGRADE_SCHEDULED: Symbol = symbol_short!("upg_sched");
+/// Topic for `UpgradeCancelledEvent`, published by `cancel_upgrade`.
 pub const TOPIC_UPGRADE_CANCELLED: Symbol = symbol_short!("upg_cncl");


### PR DESCRIPTION
## Summary

Documentation-only PR covering four issues. No contract behaviour, event payload, topic symbol, or error code changes.

Closes #422
Closes #423
Closes #424
Closes #425

### #422 — NatDoc for public contract functions

Documented every entrypoint listed in the issue with arguments, return values, events, errors, panics, storage effects, and usage examples: `set_rebalance_cooldown`, `set_approval_ttl`, `set_user_strategy` / `get_user_strategy`, `touch_user_ttl`, `preview_deposit_to_shares` / `preview_shares_to_assets` / `preview_withdraw`, `convert_to_shares` / `convert_to_assets`, `get_idle_balance` / `get_deployed_assets` / `get_asset_breakdown`, `get_pending_agent_update` / `get_pending_upgrade`. Also picked up `get_rebalance_cooldown`, `get_last_rebalance_ledger`, and `get_approval_ttl` while in the area.

Doc bugs found and fixed while writing these:

- `set_rebalance_cooldown` claimed to emit `BlendPoolConfiguredEvent`. It emits nothing.
- `set_approval_ttl` was described as Blend-only. The TTL is shared by the Blend and DEX approval paths — there is no separate DEX key.
- Every getter documented `# Panics: None` despite `require_initialized` panicking with `NotInitialized`, and the preview/convert helpers omitted the `checked_mul` overflow panic.

**On removing `#![allow(missing_docs)]`:** it can't be removed outright. `#[contract]`, `#[contracttype]`, and `#[contracterror]` each expand to an undocumented static and associated function whose diagnostic spans point at the attribute itself, so no source-level `#[allow]` can annotate them — I verified this both before and after the attribute. Removing the crate-level allow produces 74 unfixable warnings, which under CI's `clippy -D warnings` is a hard build failure.

What this PR does instead:

- Removes the **39 redundant per-item** `#[allow(missing_docs)]` attributes.
- Documents the one remaining crate-level allow with the reason it must stay.
- Adds `#[warn(missing_docs)]` on `impl NeuroWealthVault`, which re-enables the lint for **every public contract entrypoint** with zero macro noise. Since CI runs clippy with `-D warnings`, an undocumented `pub fn` now fails the build. Verified with a temporary undocumented probe function.
- `topics.rs` drops its allow entirely for `#![warn(missing_docs)]`; every `TOPIC_` constant is documented with the event and emitting function it belongs to.

Happy to take a different call here if maintainers would rather keep the blanket allow — the enforcement attribute is one line to drop.

### #423 — Event payload field descriptions

Every field on every event struct now has a one-line description in both the Rust struct and `EVENTS.md`, with units stated for `i128` amounts.

Gaps closed:

- `VaultInitializedEvent` was missing its `owner` field entirely in `EVENTS.md` — the struct has four fields, the doc listed three.
- `ProtocolChangedEvent` had no field descriptions on either side, and omitted `"dex"` as a possible value.
- Cap, limit, agent, and ownership events had terse `Previous X` / `New X` comments with no units.

Additional accuracy fixes:

- **Eight event structs documented a topic symbol that does not exist.** The Rust docs said `"vault_initialized"`, `"vault_paused"`, `"vault_unpaused"`, `"emergency_paused"`, `"tvl_cap_updated"`, `"user_cap_updated"`, `"agent_updated"`, `"assets_updated"`. The symbols actually emitted are `"init"`, `"paused"`, `"unpaused"`, `"emerg"`, `"tvl_cap"`, `"user_cap"`, `"agent"`, `"assets"`. Every event now matches `topics.rs` and names its `TOPIC_` constant.
- `DepositEvent`, `WithdrawEvent`, and `UserStrategyUpdatedEvent` publish the user `Address` as an indexed second topic; only the first was documented.
- `PauseEvent` and `InitFailedEvent` are declared as `#[contracttype]` — so they appear in `contract-spec.json` and generated bindings — but **no code path publishes them**. Both are now marked reserved so integrators don't wait on a topic that will never fire.
- `UserInfo` is a `get_user_info` return type, not an event; documented as such.
- The "canonical topics" pointer in `EVENTS.md` referenced `lib.rs`; the constants live in `topics.rs`.
- Added a "Keeping This Document in Sync" section recording what a new event or field has to update.

### #424 — ARCHITECTURE.md DEX integration storage layout

New "DEX Liquidity Pool Integration" section covering `DataKey::DexPool` storage (plus the `CurrentProtocol` and `ApprovalTtl` keys shared with Blend), the `DexPoolClient` interface and why amounts are derived from the vault's own USDC balance delta, idle vs deployed tracking with DEX positions, the full rebalance flow including the `RebalanceFailedEvent` abort path and the `"noop"` case, and the three DEX-specific events.

The storage tables were also stale and are brought in line with `DataKey`: `DexPool`, `MinRebalanceInterval`, `LastRebalanceLedger`, `PendingAgent`, `AgentTimelockExpiry`, `PendingUpgradeHash`, and `UpgradeTimelockExpiry` were missing from instance storage; `UserStrategy(Address)` was missing from persistent storage; `Balance(Address)` was still described as the live principal record rather than a deprecated layout placeholder; `CurrentProtocol` was documented as `("blend", "none")`.

### #425 — Upgrade timelock documentation

**ARCHITECTURE.md** — the "Upgrade Safety" section still described the removed instant `upgrade()`. Reworked into a pause-guard subsection (#189) and a two-step timelock subsection (#316) with the `schedule_upgrade` / `execute_upgrade` / `cancel_upgrade` flow, `UPGRADE_TIMELOCK_LEDGERS` (17,280 ledgers ≈ 24 h), the `PendingUpgradeHash` / `UpgradeTimelockExpiry` keys, the events, and the invariants. Notes that `cancel_upgrade` is deliberately **not** pause-gated so the escape hatch survives an incident.

**docs/UPGRADE_MIGRATION.md** — new section 6a with before/after mapping from the removed `upgrade(owner, hash)`, what operators must change (split maintenance window, don't pre-sign `execute_upgrade`, assign a monitor, run `migrate()` after execute not schedule), the new failure modes with resolutions, confirmation that no storage migration is needed to adopt the timelock, and emergency guidance for a compromised owner key.

---

## ⚠️ Note on CI: `main` is currently red before this PR

CI will fail on this branch, but not because of these changes. Two pre-existing breakages on `upstream/main` block every job, and per the issue scope I have **not** fixed them:

1. **`lib.rs` does not compile.** `DEFAULT_TVL_CAP` is defined twice at module scope — [`lib.rs:135`](https://github.com/Neurowealth/NeuroWealth-Smartcontract/blob/main/neurowealth-vault/contracts/vault/src/lib.rs#L135) and [`lib.rs:858`](https://github.com/Neurowealth/NeuroWealth-Smartcontract/blob/main/neurowealth-vault/contracts/vault/src/lib.rs#L858) — giving `error[E0428]`. Looks like a merge artifact; the two values are identical, so deleting either one fixes it.
2. **The test suite does not compile.** `tests/test_tvl_cap_stress.rs` uses `std::panic::catch_unwind` in a `#![no_std]` crate, giving six `error[E0433]`.

The last three merges to `main` are red on both `ci.yml` and the contract-spec workflow. Happy to open a separate PR for either fix if useful.

### Verification

To confirm these changes are sound I patched both breakages **locally only** (never committed — the diff against `upstream/main` contains neither patch) and compared against an identically-patched `upstream/main` worktree:

| Check | `upstream/main` baseline | This branch |
|---|---|---|
| `cargo check --lib` errors | 0 | 0 |
| `cargo clippy --lib` warnings | 4 (`unreachable expression`) | 4 — unchanged |
| `missing_docs` warnings | n/a | **0** |
| `cargo doc` broken intra-doc links | 3 | **0** |
| `cargo fmt --check` diffs | 97 (local rustfmt 1.8.0 vs CI's) | 97 — unchanged |
| `cargo test --lib` | 490 passed / 21 failed | 490 passed / 21 failed — **identical failure set** |

The three pre-existing broken `[`Self::x`]` doc links are fixed too: `#[contractimpl]` wraps each function in a generated `__fn_name` module, so `Self::` never resolves. They now use `[`x`](crate::NeuroWealthVault::x)`, which renders as a working link.

Outside doc comments, the entire `lib.rs` diff is the lint attributes shown above — no logic, no signatures, and no topic symbol values changed.

## Checklist

- [x] I have updated `CHANGELOG.md` under `[Unreleased]` for any contract behavior, event, or error-code changes.
  - N/A — documentation only. No behaviour, event payload, topic, or error-code change. The upgrade timelock this PR documents already has its `CHANGELOG.md` entry.
- [x] If this PR bumps `get_version()`, the new version number is noted in `CHANGELOG.md`.
  - N/A — `get_version()` is unchanged.
- [x] I have confirmed the release entry matches the expected contract `Version` storage value.
  - N/A — no release entry needed.
- [x] I have included tests or documentation updates for new contract behavior.
  - This PR is the documentation update. No new behaviour, so no new tests; verified against the baseline that no existing test changed result.
- [x] New or changed events are reflected in `EVENTS.md`.
  - No events changed. `EVENTS.md` is corrected and completed for the existing ones.
