### PR TITLE
Docs/timelock and reference docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -303,6 +303,9 @@ AI Agent → Vault Contract
 3. AI agent monitors events via RPC/subscription
 4. Agent responds by calling `rebalance()` or adjusting off-chain state
 
+Rotating the agent address is not instant — it goes through a 24-hour timelock.
+See [Agent Update Timelock (Issue #317)](#agent-update-timelock-issue-317).
+
 ### Blend Protocol Integration
 
 ```
@@ -649,6 +652,101 @@ The field is **informational for indexers** — it is emitted in `RebalanceEvent
 but does not influence on-chain fund movement.  Off-chain consumers (AI agent,
 dashboards) use it to audit that the expected yield reported at rebalance time
 is plausible.
+
+## Agent Update Timelock (Issue #317)
+
+The agent address is the only key allowed to call `rebalance()`, so replacing it
+hands control of fund movement to a new keypair. Rotating the agent therefore
+requires two transactions separated by a mandatory delay, giving users and
+monitoring systems a window to observe the pending rotation and react before it
+takes effect.
+
+```
+update_agent(new_agent)                confirm_agent_update()
+        │                                       │
+        ▼                                       ▼
+   [ pending ] ───── AGENT_TIMELOCK_LEDGERS ──▶ [ applied ]
+        │               (17,280 ≈ 24 h)
+        │
+        └── cancel_agent_update() ──▶ [ cleared ]
+```
+
+### Flow
+
+| Function | Auth | Effect |
+|---|---|---|
+| `update_agent(new_agent)` | owner | Records `PendingAgent` and sets `AgentTimelockExpiry = current_ledger + AGENT_TIMELOCK_LEDGERS`. The active `Agent` is **unchanged**. Emits `AgentUpdateProposedEvent`. |
+| `confirm_agent_update()` | owner | Requires `current_ledger >= AgentTimelockExpiry`. Writes `PendingAgent` into `Agent` and clears both pending keys. Emits `AgentUpdateConfirmedEvent` **and** `AgentUpdatedEvent`. |
+| `cancel_agent_update()` | owner | Clears both pending keys so a new proposal can be made. Emits `AgentUpdateCancelledEvent`. |
+| `get_pending_agent_update()` | none (read-only) | Returns `Some((pending_agent, effective_ledger))` while a proposal is pending, else `None`. |
+
+`update_agent()` is the propose step only — it is deliberately *not* an instant
+setter. Until `confirm_agent_update()` succeeds, `get_agent()` still returns the
+old address and only the old agent can call `rebalance()`.
+
+**Constant:** `AGENT_TIMELOCK_LEDGERS = 17_280` ledgers. At Stellar's ~5 s per
+ledger that is ≈ 86,400 s = 24 hours. It matches `UPGRADE_TIMELOCK_LEDGERS` so
+both privileged-role changes share one recovery window.
+
+### Storage keys
+
+Both live in instance storage and are cleared on confirm *and* on cancel.
+
+| Key | Type | Description |
+|---|---|---|
+| `DataKey::PendingAgent` | `Address` | Proposed agent awaiting confirmation. Its presence is what makes an update "pending". |
+| `DataKey::AgentTimelockExpiry` | `u32` | First ledger sequence at which `confirm_agent_update()` may be called. |
+
+### Events
+
+| Event | Topic | Payload |
+|---|---|---|
+| `AgentUpdateProposedEvent` | `"agt_prop"` | `old_agent`, `new_agent`, `effective_ledger` |
+| `AgentUpdateConfirmedEvent` | `"agt_conf"` | `old_agent`, `new_agent` |
+| `AgentUpdateCancelledEvent` | `"agt_cncl"` | `old_agent`, `proposed_new_agent` |
+
+`confirm_agent_update()` additionally re-emits the pre-timelock
+`AgentUpdatedEvent` (`"agent"`) so indexers that already track that topic see
+the rotation without changes. See [EVENTS.md](EVENTS.md) for payload field
+descriptions.
+
+### Security rationale
+
+An owner key compromise is the highest-impact failure mode for the vault: the
+agent controls where deposited USDC is deployed. Without a delay, an attacker
+holding the owner key could swap in an attacker-controlled agent and immediately
+rebalance funds into a hostile "protocol" in a single transaction — no observer
+would have time to react.
+
+The timelock converts that into a 24-hour detectable event:
+
+- The proposal is public on-chain the moment it is made
+  (`AgentUpdateProposedEvent` carries the target address and the exact ledger at
+  which it unlocks), so monitoring can alert on it.
+- During the window the legitimate owner — or a recovered multisig quorum — can
+  call `cancel_agent_update()` to void the proposal, and can `pause()` the vault
+  to freeze `rebalance()` entirely while the incident is handled.
+- Because only one proposal may be pending at a time, an attacker cannot spam
+  proposals to bury the real one; changing the target requires cancelling first,
+  which restarts the full 24-hour clock.
+
+### Invariants
+
+- Only one proposal may be pending at a time. Calling `update_agent()` while
+  `PendingAgent` exists panics with `TimelockAlreadyPending`.
+- `confirm_agent_update()` or `cancel_agent_update()` with no proposal panics
+  with `NoTimelockPending`; confirming before the expiry ledger panics with
+  `TimelockNotExpired`.
+- `TimelockAlreadyPending`, `NoTimelockPending`, and `TimelockNotExpired` are
+  shared with the upgrade timelock (Issue #316) because `#[contracterror]` caps
+  the enum at 50 variants.
+- All three entrypoints require owner auth. A pending proposal grants the
+  proposed agent no privileges whatsoever until confirmation.
+- `cancel_agent_update()` is not pause-gated, so the escape hatch stays
+  available while the vault is paused.
+
+Coverage lives in
+`neurowealth-vault/contracts/vault/src/tests/test_agent_timelock.rs`.
 
 ## Upgrade Safety (Issues #189, #316)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ This guide will help you get started with our development process, issue labelin
   - [Prerequisites](#prerequisites)
   - [Building the Contract](#building-the-contract)
   - [Running Tests](#running-tests)
+  - [Running Individual Tests and Test Modules](#running-individual-tests-and-test-modules)
+  - [Common Test Failures](#common-test-failures)
   - [Running Fuzz Tests](#running-fuzz-tests)
 - [CI Requirements](#ci-requirements)
 - [Coding Standards](#coding-standards)
@@ -107,6 +109,116 @@ For frontend or agent changes, run:
 ```bash
 npm test
 ```
+
+> **Touching share accounting?** If your change lands anywhere under
+> `neurowealth-vault/contracts/vault/src/`, CI also runs the deposit/withdraw
+> fuzz target. Reproduce it locally *before* pushing — see
+> [Running Fuzz Tests](#running-fuzz-tests) for the one-line smoke run.
+
+### Running Individual Tests and Test Modules
+
+The full suite takes a while, so during local iteration it is usually faster to
+run just the tests you care about. All commands below are run from
+`neurowealth-vault/`.
+
+#### How the test suite is laid out
+
+Every vault test lives in a module under
+`contracts/vault/src/tests/` and is pulled into the crate by
+`contracts/vault/src/lib.rs`:
+
+```rust
+#[cfg(test)]
+#[path = "tests/mod.rs"]
+mod comprehensive_tests;
+```
+
+They are therefore **unit tests compiled into the library test binary**, not
+separate integration-test binaries in a `tests/` directory. Two consequences:
+
+- `cargo test --test test_deposit` does **not** work — there is no test target
+  by that name, and cargo fails with
+  ``error: no test target named `test_deposit` in default-run packages``.
+- Every test's full path is prefixed with `comprehensive_tests::`, e.g.
+  `comprehensive_tests::test_deposit::test_deposit_minimum_succeeds`.
+
+You filter tests by **substring match on that full path**.
+
+#### Run a single test
+
+```bash
+# Substring match — runs every test whose full path contains this string.
+cargo test test_confirm_before_timelock_rejected
+
+# Exact match only (useful when one name is a prefix of another).
+cargo test comprehensive_tests::test_agent_timelock::test_cancel_clears_pending_agent -- --exact
+```
+
+#### Run a single test module
+
+Filter on the module path. The trailing `::` keeps the match from spilling into
+similarly named modules — a bare `test_upgrade` matches both
+`test_upgrade_timelock` and `test_upgrade_compatibility`:
+
+```bash
+# All tests in contracts/vault/src/tests/test_deposit.rs
+cargo test comprehensive_tests::test_deposit::
+
+# Just the upgrade-timelock module, not test_upgrade_compatibility
+cargo test comprehensive_tests::test_upgrade_timelock::
+```
+
+#### Useful flags
+
+```bash
+# List every test without running any — handy for finding the exact path.
+cargo test -- --list
+
+# Show println!/std::eprintln! output from passing tests (suppressed by default).
+cargo test test_deposit -- --nocapture
+
+# Run serially. Some stress modules are timing/ordering sensitive.
+cargo test -- --test-threads=1
+```
+
+#### Run tests with features
+
+Two optional features gate the production-interface pool tests. The modules are
+declared `#![cfg(all(test, feature = "..."))]`, so **without the flag they
+compile to nothing and are silently skipped** — no error, no skip message:
+
+```bash
+# Blend production-interface tests (contracts/vault/src/tests/test_blend_devnet.rs)
+cargo test -p neurowealth-vault --features blend-devnet
+
+# DEX production-interface tests (contracts/vault/src/tests/test_dex_devnet.rs)
+cargo test -p neurowealth-vault --features dex-devnet
+
+# Everything at once. Worth running before pushing, because the Clippy CI job
+# uses --all-features and will lint feature-gated test code you never compiled.
+cargo test -p neurowealth-vault --all-features
+```
+
+Feature flags combine with filters as expected:
+
+```bash
+cargo test -p neurowealth-vault --features dex-devnet comprehensive_tests::test_dex_devnet::
+```
+
+### Common Test Failures
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| ``error: no test target named `test_deposit` `` | Tests are library unit-test modules, not integration-test binaries. | Filter by module path instead: `cargo test comprehensive_tests::test_deposit::`. See [above](#run-a-single-test-module). |
+| `test result: ok. 0 passed; ... N filtered out` | The filter string matched nothing (typo, or the module is feature-gated). | Run `cargo test -- --list` and copy the exact path; add `--features blend-devnet` / `dex-devnet` if the module is gated. |
+| Feature-gated tests appear not to exist | Without the feature flag the whole file is `cfg`'d out — it does not even show up in `--list`. | Pass the matching `--features` flag. |
+| `panicked ... expected "Error(Contract, #41)"` but a different code was returned | Contract errors surface as their `VaultError` discriminant, not the message text. A code shifted or a different guard fired first. | Look up the discriminant in the `VaultError` enum in `contracts/vault/src/lib.rs` and update the `#[should_panic(expected = ...)]` string, or fix the ordering of the guards. |
+| A test in `test_budget.rs` fails on CPU/memory | A change pushed an operation past the recorded ledger-resource ceiling. | Check the baselines in [ARCHITECTURE.md](ARCHITECTURE.md) (*Ledger Resource Baselines*). Either reduce the cost or, if the increase is justified, raise the bound in the same PR and explain why. |
+| Passes individually but fails in the full run | Ordering- or timing-sensitive stress test. | Reproduce with `cargo test -- --test-threads=1` before assuming flakiness. |
+| `cargo fmt --all -- --check` fails in CI but the code looks fine | Formatting drift. | Run `cargo fmt --all` and commit the result. |
+| Clippy fails in CI but passes locally | CI runs `cargo clippy --all-targets --all-features -- -D warnings`; a plain local run skips gated code and warnings are not denied. | Reproduce the exact CI command locally. |
+| `stellar contract build` fails on a missing target or toolchain | The `wasm32-unknown-unknown` target is not installed, or the Stellar CLI does not match the pin. | `rustup target add wasm32-unknown-unknown`, then reinstall the version pinned in [`.stellar-version`](.stellar-version). Version drift is the most common cause of local-vs-CI differences. |
+| `cargo fuzz` is not a recognised command, or the target refuses to build on stable | Fuzzing requires the nightly toolchain and `cargo-fuzz`. | Install both, then use `cargo +nightly fuzz run ...` — see [Running Fuzz Tests](#running-fuzz-tests). |
 
 ### Running Fuzz Tests
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,10 @@ See [`scripts/README-E2E.md`](scripts/README-E2E.md) for end-to-end devnet valid
 
 ## Smart Contract
 The core Soroban vault contract handles all on-chain fund management.
-Key Functions
+
+### Key Functions
+
+#### Core & Administration
 
 | Function | Who Can Call | Description |
 | :--- | :--- | :--- |
@@ -237,6 +240,69 @@ Key Functions
 | `set_tvl_cap` | Owner only | Sets the maximum total TVL that can be deposited |
 | `set_user_deposit_cap` | Owner only | Sets the maximum deposit amount per user |
 | `set_limits` | Owner only | **Deprecated**: Sets user deposit cap and TVL cap (use `set_caps` instead) |
+
+#### Strategy Preference
+
+| Function | Who Can Call | Description |
+| :--- | :--- | :--- |
+| `set_user_strategy` | User (their own preference) | Store a strategy preference (`conservative`, `balanced`, or `growth`) on-chain for the AI agent to read |
+| `get_user_strategy` | Anyone | Read a user's strategy preference (defaults to `balanced` when unset) |
+
+#### Share Math & Previews
+
+| Function | Who Can Call | Description |
+| :--- | :--- | :--- |
+| `preview_deposit_to_shares` | Anyone | Shares that would be minted for a given asset amount (rounds **down**) |
+| `preview_shares_to_assets` | Anyone | Assets that would be returned for a given share amount (rounds **down**) |
+| `preview_withdraw` | Anyone | Shares that would be burned to withdraw a given asset amount (rounds **up**, matching `withdraw`) |
+| `convert_to_shares` | Anyone | ERC-4626 asset → share conversion at the current rate (rounds **down**) |
+| `convert_to_assets` | Anyone | ERC-4626 share → asset conversion at the current rate (rounds **down**) |
+
+#### Asset Tracking
+
+| Function | Who Can Call | Description |
+| :--- | :--- | :--- |
+| `get_idle_balance` | Anyone | USDC held in the vault and not yet deployed to a protocol |
+| `get_deployed_assets` | Anyone | USDC currently supplied to the active protocol (`0` when `CurrentProtocol` is `none`) |
+| `get_asset_breakdown` | Anyone | Both figures in one call as `(idle, deployed)` — avoids two RPC round-trips |
+
+#### Storage Maintenance
+
+| Function | Who Can Call | Description |
+| :--- | :--- | :--- |
+| `touch_user_ttl` | Anyone | Extend the `Shares(user)` persistent entry TTL; returns `false` when no entry exists. Needed because read-only getters have no TTL side effects |
+
+#### Upgrade Timelock (Issue #316)
+
+The instant `upgrade()` entrypoint has been removed — see the *Upgrade Safety* section of [`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+| Function | Who Can Call | Description |
+| :--- | :--- | :--- |
+| `schedule_upgrade` | Owner only (not paused) | Propose a new WASM hash; unlocks after `UPGRADE_TIMELOCK_LEDGERS` (17,280 ledgers ≈ 24 h) |
+| `execute_upgrade` | Owner only (not paused) | Apply the pending WASM once the timelock has elapsed and increment `Version` |
+| `cancel_upgrade` | Owner only | Clear the pending upgrade — the recovery path for a malicious or mistaken proposal |
+| `get_pending_upgrade` | Anyone | Returns `Some((wasm_hash, effective_ledger))` while an upgrade is pending, else `None` |
+
+#### Agent Timelock (Issue #317)
+
+Rotating the agent is a two-step, timelocked flow — see the *Agent Update Timelock* section of [`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+| Function | Who Can Call | Description |
+| :--- | :--- | :--- |
+| `update_agent` | Owner only | **Propose** a new agent; unlocks after `AGENT_TIMELOCK_LEDGERS` (17,280 ledgers ≈ 24 h). The active agent is unchanged |
+| `confirm_agent_update` | Owner only | Apply the pending agent once the timelock has elapsed |
+| `cancel_agent_update` | Owner only | Clear the pending agent update |
+| `get_pending_agent_update` | Anyone | Returns `Some((pending_agent, effective_ledger))` while an update is pending, else `None` |
+
+#### Rebalance Throttle & Approvals
+
+| Function | Who Can Call | Description |
+| :--- | :--- | :--- |
+| `set_rebalance_cooldown` | Owner only | Minimum ledgers between `rebalance()` calls; `0` disables the cooldown |
+| `get_rebalance_cooldown` | Anyone | Read the configured cooldown in ledgers (`0` = disabled) |
+| `get_last_rebalance_ledger` | Anyone | Ledger of the most recent successful `rebalance()` (`0` if never called) |
+| `set_approval_ttl` | Owner only | Ledger lifetime for Blend/DEX token approvals (bounded to 1,000–500,000 ledgers) |
+| `get_approval_ttl` | Anyone | Read the configured approval TTL, or the default when unset |
 
 ## Security Model
 

--- a/docs/MAINNET_CHECKLIST.md
+++ b/docs/MAINNET_CHECKLIST.md
@@ -244,7 +244,8 @@ Before deploying to Mainnet, the team must run an on-chain Pause Drill on Testne
 The Owner key holds upgrade privileges. To secure the contract against single-key compromise or loss, the owner account should be configured with multi-signature security.
 
 ### 🔍 Security Context
-* Soroban allows upgrading contract code via `upgrade()`. An attacker possessing the owner key could upload a malicious WASM binary to hijack user funds.
+* Soroban allows upgrading contract code. An attacker possessing the owner key could upload a malicious WASM binary to hijack user funds.
+* The instant `upgrade()` entrypoint has been replaced by a two-step timelocked flow (Issue #316): `schedule_upgrade` → wait `UPGRADE_TIMELOCK_LEDGERS` (17,280 ledgers ≈ 24 h) → `execute_upgrade`, with `cancel_upgrade` as the escape hatch. The timelock is the last line of defence if the multisig itself is compromised — it converts an instant code swap into a 24-hour, publicly observable event.
 * Stellar natively supports multi-signature operations directly at the account level through account signer thresholds and weights.
 
 ### 📝 Actionable Checklist
@@ -252,12 +253,79 @@ The Owner key holds upgrade privileges. To secure the contract against single-ke
   * **Threshold Settings:**
     * Low threshold (e.g., 1): For triggering simple operations or `pause()` (allows fast emergency response with a single hot trigger key).
     * Medium threshold (e.g., 2 or 3): For configuring caps, setting Blend pools, and `unpause()`.
-    * High threshold (e.g., 3): For calling `upgrade()` (requires multi-party consensus to push new code).
+    * High threshold (e.g., 3): For calling `schedule_upgrade()` and `execute_upgrade()` (requires multi-party consensus to push new code).
+  * Keep `cancel_upgrade()` reachable at a **low** threshold. It is the escape hatch during the timelock window and must not be blocked by an unavailable co-signer.
 - [ ] **Document Signer Distribution:** Ensure keys are distributed securely across key parties using hardware wallets (e.g., Ledger).
 - [ ] **Upgrade Verification Procedure:** Ensure any future WASM upgrades are:
   * Built inside a deterministic environment (e.g., Docker container with exact Rust toolchain versions).
   * Checked against WASM size limits using standard optimization tools (`wasm-opt -Oz`).
   * Signatures collected offline from all co-signers before broadcast.
+
+### 📝 Timelocked Upgrade Verification Drill (Testnet)
+
+The timelock must be exercised end-to-end on testnet before mainnet deployment. The unit tests in `neurowealth-vault/contracts/vault/src/tests/test_upgrade_timelock.rs` cover the gates by advancing the simulated ledger, but they cannot verify the WASM swap or the `Version` bump — the dummy hash they schedule is not installed on-chain. Only a real network run proves the full cycle.
+
+Set `TESTNET_VAULT_CONTRACT_ID`, `OWNER_ADDRESS`, and `NEW_WASM_HASH` (the hex hash returned by `stellar contract install`) before starting.
+
+**Part A — `get_pending_upgrade` returns the correct hash and expiry**
+
+- [ ] **A1. Confirm a clean starting state:** with nothing scheduled, the getter must return `null`.
+  ```bash
+  stellar contract invoke --id $TESTNET_VAULT_CONTRACT_ID --source owner --network testnet -- get_pending_upgrade
+  ```
+- [ ] **A2. Record the current ledger sequence** from RPC (`getLatestLedger`) — call it `L`.
+- [ ] **A3. Schedule the upgrade.**
+  ```bash
+  stellar contract invoke --id $TESTNET_VAULT_CONTRACT_ID --source owner --network testnet -- schedule_upgrade --owner $OWNER_ADDRESS --new_wasm_hash $NEW_WASM_HASH
+  ```
+  * *Expected Result:* Success, and an `UpgradeScheduledEvent` (topic `upg_sched`) carrying `new_wasm_hash` and `effective_ledger`.
+- [ ] **A4. Verify the pending state:** re-run `get_pending_upgrade`.
+  * *Expected Result:* `(wasm_hash, effective_ledger)` where `wasm_hash` byte-for-byte equals `$NEW_WASM_HASH` and `effective_ledger ≈ L + 17280`. Confirm the delta is exactly `UPGRADE_TIMELOCK_LEDGERS`, not a shortened test value.
+- [ ] **A5. Verify the "only one pending" guard:** call `schedule_upgrade` again with any hash.
+  * *Expected Result:* MUST fail with `VaultError::TimelockAlreadyPending` (Error Code `48`).
+- [ ] **A6. Verify the execute gate holds before expiry:** call `execute_upgrade` immediately.
+  ```bash
+  stellar contract invoke --id $TESTNET_VAULT_CONTRACT_ID --source owner --network testnet -- execute_upgrade --owner $OWNER_ADDRESS
+  ```
+  * *Expected Result:* MUST fail with `VaultError::TimelockNotExpired` (Error Code `50`). Confirm `get_version()` is unchanged and the deployed code still behaves as the old build — a pending proposal must have no effect on the running contract.
+
+**Part B — `cancel_upgrade` clears the pending state**
+
+- [ ] **B1. Cancel the proposal scheduled in Part A.**
+  ```bash
+  stellar contract invoke --id $TESTNET_VAULT_CONTRACT_ID --source owner --network testnet -- cancel_upgrade --owner $OWNER_ADDRESS
+  ```
+  * *Expected Result:* Success, and an `UpgradeCancelledEvent` (topic `upg_cncl`) carrying the cancelled hash.
+- [ ] **B2. Verify both storage keys are cleared:** `get_pending_upgrade` MUST return `null` (`PendingUpgradeHash` and `UpgradeTimelockExpiry` are both removed).
+- [ ] **B3. Verify cancel is idempotency-guarded:** call `cancel_upgrade` again.
+  * *Expected Result:* MUST fail with `VaultError::NoTimelockPending` (Error Code `49`).
+- [ ] **B4. Verify `execute_upgrade` is also blocked after cancel.**
+  * *Expected Result:* MUST fail with `VaultError::NoTimelockPending` (Error Code `49`).
+- [ ] **B5. Verify the escape hatch survives a pause:** schedule again, `pause()` the vault, then call `cancel_upgrade`.
+  * *Expected Result:* `schedule_upgrade` and `execute_upgrade` are pause-gated and MUST fail with `VaultError::Paused` (Error Code `35`), but `cancel_upgrade` MUST succeed. Unpause afterwards.
+
+**Part C — full cycle: schedule → wait out the timelock → execute → verify version bump**
+
+- [ ] **C1. Record `get_version()`** before starting — call it `V`.
+- [ ] **C2. Install the new WASM on testnet** and capture its hash.
+  ```bash
+  stellar contract install --wasm target/wasm32-unknown-unknown/release/neurowealth_vault.wasm --source owner --network testnet
+  ```
+  * A hash that is not installed on-chain will trap at `execute_upgrade` time, *after* the 24-hour wait. Verify installation before scheduling.
+- [ ] **C3. Schedule the upgrade** with that hash and note `effective_ledger` from `get_pending_upgrade`.
+- [ ] **C4. Wait out the real timelock.** Testnet has no ledger fast-forward: the 17,280 ledgers take ≈ 24 hours of wall-clock time. **Do not** shorten `UPGRADE_TIMELOCK_LEDGERS` for this drill — the point is to confirm the mainnet constant. Poll `get_pending_upgrade` during the window and confirm the hash never changes.
+- [ ] **C5. Execute once the current ledger sequence `>= effective_ledger`.**
+  ```bash
+  stellar contract invoke --id $TESTNET_VAULT_CONTRACT_ID --source owner --network testnet -- execute_upgrade --owner $OWNER_ADDRESS
+  ```
+  * *Expected Result:* Success, and an `UpgradedEvent` (topic `upgraded`) with `old_version` = `V` and `new_version` = `V + 1`.
+- [ ] **C6. Verify the version bump:** `get_version()` MUST return `V + 1`.
+- [ ] **C7. Verify the pending state was cleared by execution:** `get_pending_upgrade` MUST return `null`, and a fresh `schedule_upgrade` MUST be accepted (no leftover `TimelockAlreadyPending`).
+- [ ] **C8. Verify storage survived the upgrade:** re-check `get_total_assets()`, `get_total_shares()`, `get_owner()`, `get_agent()`, and a sample `get_shares(user)` against the values recorded before C5.
+- [ ] **C9. Run the release's migration entrypoint** if it ships one, then re-run the state checks in C8. The current contract has no `migrate()`; see [UPGRADE_MIGRATION.md](UPGRADE_MIGRATION.md) for the pattern a future release would follow.
+- [ ] **C10. Sign off:** record the drill's ledger numbers, WASM hashes, and transaction hashes in the release ticket.
+
+> **Note:** operational runbooks for scheduling, monitoring, and executing a *production* upgrade live in [UPGRADE_MIGRATION.md](UPGRADE_MIGRATION.md). This drill is the pre-mainnet verification that the timelock itself behaves correctly. The agent-rotation timelock (Issue #317) follows the same shape — see the *Agent Update Timelock* section of [ARCHITECTURE.md](../ARCHITECTURE.md).
 
 ---
 


### PR DESCRIPTION
# docs: agent timelock, README key functions, test-running guide, upgrade drill

Closes #426
Closes #427
Closes #428
Closes #429

## Summary

Documentation-only PR resolving four `documentation` / Stellar Wave issues. No
Rust source, test, or CI files are touched — the diff is four Markdown files.

| Issue | File | Change |
|---|---|---|
| #426 | `ARCHITECTURE.md` | New **Agent Update Timelock (Issue #317)** section |
| #427 | `README.md` | Key Functions table expanded with the missing entrypoints |
| #428 | `CONTRIBUTING.md` | How to run individual tests/modules + common test failures |
| #429 | `docs/MAINNET_CHECKLIST.md` | Timelocked upgrade verification drill |

---

### #426 — Agent timelock documentation in `ARCHITECTURE.md`

The agent update timelock (#317) was described in `CHANGELOG.md` and
`SECURITY.md` but had no dedicated architecture section. Added
**Agent Update Timelock (Issue #317)**, placed immediately before
*Upgrade Safety* so the two governance timelocks sit together and read as a
pair. It mirrors the structure of the `#425` upgrade-timelock section.

Covers everything the issue asked for:

- **Two-step flow** — an ASCII state diagram plus a per-function table
  (`update_agent` → `confirm_agent_update` / `cancel_agent_update`,
  `get_pending_agent_update`) with the auth requirement and exact storage
  effect of each. Makes explicit that `update_agent` is the *propose* step
  only: until confirmation, `get_agent()` still returns the old address and
  only the old agent can call `rebalance()`.
- **`AGENT_TIMELOCK_LEDGERS`** — 17,280 ledgers, with the ~5 s/ledger
  arithmetic to 24 h, and the note that it matches `UPGRADE_TIMELOCK_LEDGERS`
  so both privileged-role changes share one recovery window.
- **Storage keys** — `PendingAgent` and `AgentTimelockExpiry`, with types and
  the fact that both are cleared on confirm *and* on cancel.
- **Events** — `AgentUpdateProposedEvent` (`agt_prop`),
  `AgentUpdateConfirmedEvent` (`agt_conf`), `AgentUpdateCancelledEvent`
  (`agt_cncl`) with their payload fields, plus the easily-missed detail that
  `confirm_agent_update` *also* re-emits the legacy `AgentUpdatedEvent`
  (`agent`) for backward-compatible indexers.
- **Security rationale** — why this is the highest-impact key: the agent
  controls where deposited USDC is deployed, so without a delay a compromised
  owner key could swap in a hostile agent and rebalance funds out in a single
  transaction. Documents the three properties the timelock buys (public
  proposal → alertable; `cancel_agent_update` + `pause()` during the window;
  one-pending-at-a-time prevents burying the real proposal behind spam).
- **Invariants** — the three timelock error codes, why they are shared with
  #316 (`#[contracterror]` caps the enum at 50 variants), and that
  `cancel_agent_update` is deliberately not pause-gated.

Also added a two-line cross-reference from *AI Agent Integration*, since that
is where a reader looking for agent behaviour will land first.

### #427 — `README.md` Key Functions table

The table had drifted well behind the contract surface. Rather than appending
~25 rows to a single flat table, `Key Functions` was promoted from a bare text
line to a real `###` heading and the entrypoints grouped into scannable
subsections. Every function named in the issue is now present:

- **Strategy Preference** — `set_user_strategy`, `get_user_strategy`
- **Share Math & Previews** — `preview_deposit_to_shares`,
  `preview_shares_to_assets`, `preview_withdraw`, `convert_to_shares`,
  `convert_to_assets` (each row states its rounding direction)
- **Asset Tracking** — `get_idle_balance`, `get_deployed_assets`,
  `get_asset_breakdown`
- **Storage Maintenance** — `touch_user_ttl`
- **Upgrade Timelock (#316)** — `schedule_upgrade`, `execute_upgrade`,
  `cancel_upgrade`, `get_pending_upgrade`
- **Agent Timelock (#317)** — `update_agent`, `confirm_agent_update`,
  `cancel_agent_update`, `get_pending_agent_update`
- **Rebalance Throttle & Approvals** — `set_rebalance_cooldown`,
  `get_rebalance_cooldown`, `get_last_rebalance_ledger`, `set_approval_ttl`,
  `get_approval_ttl`

The `Who Can Call` column was filled in from the actual auth guard in each
function body (`require_is_owner`, `user.require_auth()`, or none), and the
pause-gated entries are marked as such.

> One CI-specific note: `scripts/check-readme.sh` validates that every relative
> Markdown link resolves to a real file, and it does **not** strip `#anchor`
> fragments — so `ARCHITECTURE.md#some-heading` would be treated as a missing
> path and fail the `README Validation` job. The two cross-references into
> `ARCHITECTURE.md` therefore link to the file and name the section in prose.

### #428 — `CONTRIBUTING.md`: running individual tests

Added **Running Individual Tests and Test Modules** and **Common Test
Failures**, both linked from the table of contents.

The issue suggested documenting `cargo test --test test_deposit`. That form
does not work in this repo, and the new section explains why rather than
repeating it: every vault test lives in a module under
`contracts/vault/src/tests/`, pulled into the crate by

```rust
#[cfg(test)]
#[path = "tests/mod.rs"]
mod comprehensive_tests;
```

so they are unit tests inside the library test binary, not separate
integration-test targets. `cargo test --test test_deposit` fails with
``error: no test target named `test_deposit` in default-run packages``, and
every test path is prefixed with `comprehensive_tests::`.

Documented instead:

- **Single test** — substring filter, and `-- --exact` for when one name is a
  prefix of another.
- **Single module** — `cargo test comprehensive_tests::test_deposit::`, with a
  note on why the trailing `::` matters (a bare `test_upgrade` matches both
  `test_upgrade_timelock` and `test_upgrade_compatibility`).
- **Useful flags** — `-- --list` to find exact paths, `--nocapture`,
  `--test-threads=1`.
- **Features** — `blend-devnet` and `dex-devnet`, plus the trap that matters
  most: those modules are declared `#![cfg(all(test, feature = "..."))]`, so
  without the flag they compile to nothing and are *silently* skipped — no
  error, no skip message, absent even from `--list`. Also notes that
  `--all-features` is worth running locally because the Clippy CI job uses it
  and will lint feature-gated test code you never compiled.
- **Common Test Failures** — a symptom → cause → fix table covering the
  `--test` mistake, empty filter matches, feature-gated invisibility,
  `should_panic(expected = "Error(Contract, #NN)")` drift, `test_budget.rs`
  resource-ceiling failures, order-dependent stress tests, fmt/clippy
  local-vs-CI mismatches, WASM target/CLI-pin problems, and missing nightly
  for fuzzing.
- **Fuzz prominence** — a callout in *Running Tests* pointing at the fuzz
  section for anyone touching
  `neurowealth-vault/contracts/vault/src/`, since CI runs the fuzz target on
  those PRs.

Every command in the new section was executed against the vault crate before
being documented, including the module-path filters, `-- --exact`, and both
feature flags.

### #429 — `docs/MAINNET_CHECKLIST.md`: timelocked upgrade verification

The Upgrade & Governance section still described the removed instant
`upgrade()` and had no verification steps for the #316 flow. Added a
**Timelocked Upgrade Verification Drill (Testnet)**, written in the same
style as the existing Pause Drill runbook (numbered steps, invoke commands,
explicit *Expected Result* lines, checkboxes).

The drill is split into the three things the issue asked to verify:

- **Part A — `get_pending_upgrade` returns the correct hash and expiry.**
  Clean starting state returns `null`; after scheduling, the returned hash
  matches byte-for-byte and `effective_ledger` is exactly
  `UPGRADE_TIMELOCK_LEDGERS` ahead of the recorded ledger (guards against a
  shortened test constant reaching mainnet). Also asserts the
  `TimelockAlreadyPending` (48) and `TimelockNotExpired` (50) gates, and that a
  pending proposal leaves the running contract untouched.
- **Part B — `cancel_upgrade` clears pending state.** Both storage keys
  cleared, `get_pending_upgrade` back to `null`, a second cancel rejected with
  `NoTimelockPending` (49), `execute_upgrade` also blocked afterwards, and — the
  step most worth having on a checklist — that `cancel_upgrade` still succeeds
  while the vault is `Paused` (35) even though schedule/execute do not.
- **Part C — full cycle.** Record `get_version()`, install the WASM (with the
  warning that an uninstalled hash traps only *after* the 24-hour wait), wait
  out the real 17,280 ledgers, execute, then verify the `UpgradedEvent`, the
  `V → V + 1` bump, that execution cleared the pending state, and that user
  and config storage survived.

One deliberate deviation from the issue text: it lists "advance ledger" as a
step, but testnet has no ledger fast-forward — the drill requires the real
≈24 h wait and explicitly says not to shorten the constant, since confirming
the mainnet value is the whole point. Simulated ledger advancement only exists
in the unit tests, which is called out along with the reason those tests are
*not* sufficient on their own: the dummy hash they schedule is not installed
on-chain, so they can verify the gates but never the WASM swap or the version
bump.

The section's security context and multisig thresholds were also corrected to
name `schedule_upgrade` / `execute_upgrade` instead of the removed `upgrade()`,
with a new recommendation that `cancel_upgrade` sit at a **low** threshold —
it is the escape hatch during the timelock window and must not be blocked by an
unavailable co-signer.

> Numbering note: the issue refers to this as Section 6. It is now Section 7,
> after the DEX pool section was inserted upstream.

---

## Verification

- `bash scripts/check-readme.sh .` — all three checks pass (balanced fences, all
  relative links resolve, required snippets present). Verified by reproducing
  the script's logic, as the script needs bash 4+ / GNU grep and this machine
  has bash 3.2.
- Balanced code fences and resolving relative links also confirmed for
  `ARCHITECTURE.md`, `CONTRIBUTING.md`, and `docs/MAINNET_CHECKLIST.md`.
- Every `cargo test` invocation added to `CONTRIBUTING.md` was run against the
  vault crate; the `--test test_deposit` error message is quoted verbatim from
  actual output.
- All documented function names, signatures, auth guards, storage keys, event
  topics, constants, and error codes were read from
  `neurowealth-vault/contracts/vault/src/lib.rs` and
  `neurowealth-vault/contracts/vault/src/topics.rs` rather than from existing
  prose.
- No Rust, test, or workflow files changed, so the fuzz job is not triggered.

**Pre-existing on `main`, not touched here** (per scope — flagging for
visibility only): `DEFAULT_TVL_CAP` is declared twice in `lib.rs`
(lines 150 and 920), which makes `cargo test` fail to compile with
`error[E0428]`. With that duplicate temporarily removed in a throwaway copy of
the crate, 2 tests in `test_agent_timelock.rs` also fail. Neither is related to
this PR, and no source file is modified by it — worth a separate issue.

## Checklist

- [x] I have updated `CHANGELOG.md` under `[Unreleased]` for any contract
      behavior, event, or error-code changes. — N/A: documentation only, no
      contract behavior, event, or error-code changes. The underlying features
      (#316, #317) are already in `CHANGELOG.md`.
- [x] If this PR bumps `get_version()`, the new version number is noted in
      `CHANGELOG.md`. — N/A: no version bump.
- [x] I have confirmed the release entry matches the expected contract
      `Version` storage value. — N/A: no release entry.
- [x] I have included tests or documentation updates for new contract
      behavior. — This PR *is* the documentation update; no new behavior.
- [x] New or changed events are reflected in `EVENTS.md`. — N/A: no new or
      changed events. The agent-update events shipped with #317; #426 asked
      only for the `ARCHITECTURE.md` section, so `EVENTS.md` is left alone to
      keep this PR in scope.

---

### Note on base branch

`CONTRIBUTING.md` says to open PRs against `develop`, but no `develop` branch
exists on the remote — recent work has been merged directly into `main`
(e.g. #452, #410, #409). This branch is cut from `origin/main` and should be
targeted at `main`. Happy to retarget if a `develop` branch is created.
