### PR TITLE
test: add dedicated test for withdraw_all

### DIFF
--- a/neurowealth-vault/contracts/vault/src/tests/test_withdraw.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_withdraw.rs
@@ -125,7 +125,7 @@ fn test_withdraw_with_no_balance_panics() {
 }
 
 #[test]
-fn test_withdraw_all_returns_correct_amount() {
+fn test_withdraw_all_detailed_invariants() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -137,12 +137,19 @@ fn test_withdraw_all_returns_correct_amount() {
 
     mint_and_deposit(&env, &client, &usdc_token, &user, deposit_amount);
 
-    let expected_balance = client.get_balance(&user);
+    let original_shares = client.get_shares(&user);
+    let original_total_shares = client.get_total_shares();
+    let original_total_assets = client.get_total_assets();
+    
+    let expected_usdc = client.convert_to_assets(&original_shares);
+    
     let withdrawn = client.withdraw_all(&user);
 
-    assert_eq!(withdrawn, expected_balance);
-    assert_eq!(client.get_shares(&user), 0);
-    assert_eq!(client.get_balance(&user), 0);
+    assert_eq!(client.get_shares(&user), 0, "After withdraw_all, user shares are exactly 0");
+    assert_eq!(client.get_balance(&user), 0, "After withdraw_all, user balance is exactly 0");
+    assert_eq!(withdrawn, expected_usdc, "USDC returned equals convert_to_assets(original_shares)");
+    assert_eq!(client.get_total_shares(), original_total_shares - original_shares, "total_shares decreases by exactly original shares");
+    assert_eq!(client.get_total_assets(), original_total_assets - withdrawn, "total_assets decreases by exactly USDC returned");
 }
 
 #[test]


### PR DESCRIPTION
Closes #419 

This PR introduces a dedicated and highly focused test for the `withdraw_all` function within `test_withdraw.rs`. 

Previously, `withdraw_all` was tested for its basic functional behavior (returning the expected amount and zeroing out user balances), but it lacked a comprehensive check against the smart contract's broader state invariants, particularly around how share conversions and total aggregate balances are updated. 

To prevent potential regressions related to rounding-specific bugs or off-by-one errors in the all-shares-burned path, this new test explicitly enforces strict accounting invariants on both a per-user and a protocol-wide level.

### Key Invariants Tested:

1. **Complete Share Liquidation**: Asserts that `client.get_shares(&user) == 0` after withdrawal.
2. **Complete Balance Liquidation**: Asserts that `client.get_balance(&user) == 0` after withdrawal.
3. **Exact Asset Conversion**: Asserts that the withdrawn USDC amount is exactly equal to the result of the `convert_to_assets(original_shares)` math calculation, ensuring no value is lost or gained due to rounding discrepancies when cashing out 100% of a user's position.
4. **Aggregate Shares Tracking**: Asserts that the protocol's global `total_shares` decreases by the **exact** amount of the original shares the user held prior to the withdrawal.
5. **Aggregate Assets Tracking**: Asserts that the protocol's global `total_assets` decreases by the **exact** USDC value returned to the user.

## Changes Made
- **[MODIFY]** `test_withdraw.rs`: Replaced the more basic `test_withdraw_all_returns_correct_amount` with `test_withdraw_all_detailed_invariants` to cover all of the requested invariant checks in one dedicated flow.

## Testing
- [x] Ran `cargo test test_withdraw_all_detailed_invariants` to verify all state transitions and invariant assertions pass.