### PR TITLE
test: emergency_pause emits correct event and blocks operations

### DIFF
--- a/neurowealth-vault/contracts/vault/src/tests/test_pause.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_pause.rs
@@ -220,3 +220,64 @@ fn test_upgrade_unpaused_vault_clears_pause_guard() {
         "vault must be unpaused before upgrade is allowed"
     );
 }
+
+#[test]
+fn test_emergency_pause_blocks_operations_and_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    let user = Address::generate(&env);
+    let amount = 5_000_000_i128;
+
+    // Pre-fund the user and deposit some tokens to test withdrawal later
+    token_client.mint(&user, &amount);
+    client.deposit(&user, &amount);
+
+    assert!(!client.is_paused());
+
+    // 1. Calls emergency_pause as owner
+    client.emergency_pause(&owner);
+
+    // 2. Asserts is_paused() returns true
+    assert!(client.is_paused(), "Vault should be emergency paused");
+
+    // 3. Verifies the emitted event topic is "emerg"
+    let emergency_events = find_events_by_topic(env.events().all(), &env, TOPIC_EMERGENCY_PAUSED);
+    assert_eq!(
+        emergency_events.len(), 1,
+        "Exactly one emergency paused event should be emitted"
+    );
+    assert_eq!(
+        TOPIC_EMERGENCY_PAUSED,
+        soroban_sdk::symbol_short!("emerg"),
+        "Event topic must be 'emerg'"
+    );
+
+    // 4. Asserts a deposit attempt panics with VaultError::Paused (#35)
+    let deposit_res = client.try_deposit(&user, &amount);
+    assert_eq!(
+        deposit_res,
+        Err(Ok(soroban_sdk::Error::from_contract_error(35))),
+        "deposit attempt should panic with VaultError::Paused (#35)"
+    );
+
+    // 5. Asserts a withdrawal attempt panics with VaultError::Paused (#35)
+    let withdraw_res = client.try_withdraw(&user, &amount);
+    assert_eq!(
+        withdraw_res,
+        Err(Ok(soroban_sdk::Error::from_contract_error(35))),
+        "withdrawal attempt should panic with VaultError::Paused (#35)"
+    );
+
+    // 6. Asserts a rebalance attempt panics with VaultError::Paused (#35)
+    let rebalance_res = client.try_rebalance(&soroban_sdk::symbol_short!("blend"), &500_i128, &0_i128);
+    assert_eq!(
+        rebalance_res,
+        Err(Ok(soroban_sdk::Error::from_contract_error(35))),
+        "rebalance attempt should panic with VaultError::Paused (#35)"
+    );
+}


### PR DESCRIPTION
Closes #420 


This PR introduces a dedicated integration test for the `emergency_pause` functionality within the vault contract. While the standard `pause` and `unpause` logic was previously covered, `emergency_pause` has distinct event semantics and operational constraints that warrant their own focused coverage.

## Changes Made
Added `test_emergency_pause_blocks_operations_and_emits_event` to `tests/test_pause.rs`, which comprehensively validates the vault's behavior during an emergency state:

1. **State Transition Validation**
   - Calls `emergency_pause` as the vault owner.
   - Asserts that `is_paused()` accurately reflects the new state by returning `true`.

2. **Event Emission Validation**
   - Verifies that the correct `EmergencyPausedEvent` is emitted.
   - Validates that the emitted topic specifically matches `"emerg"` (using `TOPIC_EMERGENCY_PAUSED`), distinct from the standard pause event.

3. **Operation Blocking Validation (Security)**
   - Pre-funds the user and deposits funds prior to pausing to ensure state correctness.
   - Asserts that subsequent **deposit** attempts correctly panic and are blocked with `VaultError::Paused` (Error Code #35).
   - Asserts that **withdrawal** attempts panic and are blocked with `VaultError::Paused` (Error Code #35).
   - Asserts that **rebalance** attempts initiated by the AI agent panic and are blocked with `VaultError::Paused` (Error Code #35).

## Testing
- [x] Tested locally via `cargo test --test vault test_pause`. All assertions pass as expected.