### PR TITLE
test: extend property-based tests for share arithmetic round-trip consistency (#412)

### DIFF
--- a/neurowealth-vault/contracts/vault/src/tests/test_share_conversion_proptest.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_share_conversion_proptest.rs
@@ -1,4 +1,4 @@
-//! Property tests for share-conversion math (Issue #323).
+//! Property tests for share-conversion math (Issue #323, #412).
 //!
 //! These tests exercise the mathematical invariants of the vault's share-pricing
 //! formulas in isolation, using `proptest` to generate thousands of random inputs
@@ -18,6 +18,9 @@
 //!   (d) Monotonicity: more assets in → more-or-equal shares out.
 //!   (e) Zero input → zero output for all three directions.
 //!   (f) Conservation: shares minted for A assets, converted back, never exceed A.
+//!   (g) (#412) Ceil round-trip: assets → shares_ceil → assets ≤ assets.
+//!   (h) (#412) Deposit+withdraw cycle: user never receives more than deposited.
+//!   (i) (#412) Withdraw+deposit cycle: shares burned consistent with original.
 
 // The vault crate is `#![no_std]`; tests are run with the standard test harness
 // which links std, but we must declare it explicitly in no_std crates.
@@ -222,6 +225,137 @@ proptest! {
             "redemption exceeded deposit: deposited {} assets, minted {} shares, \
              redeemed {} assets (total_shares={}, total_assets={})",
             assets, shares_minted, assets_redeemed, total_shares, total_assets
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // (g)  Ceil round-trip: assets → shares_ceil → assets ≤ assets  (#412)
+    // -----------------------------------------------------------------------
+
+    /// The withdrawal path uses ceil conversion for shares (vault protection)
+    /// and floor for assets. This invariant verifies that even with ceil rounding
+    /// on the share side, the user never gets back more than they deposited.
+    #[test]
+    fn prop_ceil_round_trip_no_excess(
+        assets       in 1i128..=MAX_VAL,
+        total_shares in 1i128..=MAX_VAL,
+        total_assets in 1i128..=MAX_VAL,
+    ) {
+        let shares_ceil_val = shares_ceil(assets, total_shares, total_assets)
+            .expect("overflow not possible at tested bounds");
+        let assets_back = assets_from_shares(shares_ceil_val, total_shares, total_assets)
+            .expect("overflow not possible at tested bounds");
+
+        prop_assert!(
+            assets_back <= assets,
+            "ceil round-trip created value: {} assets → {} shares (ceil) → {} assets \
+             (total_shares={}, total_assets={})",
+            assets, shares_ceil_val, assets_back, total_shares, total_assets
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // (h)  Deposit+withdraw cycle: user never receives more than deposited (#412)
+    // -----------------------------------------------------------------------
+
+    /// Simulates a full deposit-then-withdraw cycle:
+    ///   1. Deposit `assets` → receive `shares_floor` shares.
+    ///   2. Immediately withdraw those exact shares → get back `assets_from_shares`.
+    ///   3. The amount received must be ≤ the amount deposited.
+    ///
+    /// This is the real user-facing invariant: no matter what the vault state is,
+    /// a deposit followed by a full withdrawal should never create value for the user.
+    #[test]
+    fn prop_deposit_withdraw_cycle_no_excess(
+        assets       in 1i128..=MAX_VAL,
+        total_shares in 1i128..=MAX_VAL,
+        total_assets in 1i128..=MAX_VAL,
+    ) {
+        let shares_minted = shares_floor(assets, total_shares, total_assets)
+            .expect("overflow not possible at tested bounds");
+
+        // Nothing to withdraw if no shares were minted.
+        if shares_minted == 0 {
+            return;
+        }
+
+        // Withdrawal burns shares_ceil(shares_minted, ...) shares.
+        // But in the real vault, the user specifies assets to withdraw,
+        // and the vault computes shares to burn via ceil.
+        // So we model: user wants to withdraw all their assets,
+        // which means burning their shares via ceil conversion.
+        let shares_to_burn = shares_ceil(shares_minted, total_shares, total_assets)
+            .expect("overflow not possible at tested bounds");
+
+        // The vault returns assets_from_shares(shares_burned)
+        let assets_returned = assets_from_shares(shares_to_burn, total_shares, total_assets)
+            .expect("overflow not possible at tested bounds");
+
+        prop_assert!(
+            assets_returned <= assets,
+            "deposit+withdraw cycle created value: deposited {}, got back {} \
+             (shares_minted={}, shares_burned={}, total_shares={}, total_assets={})",
+            assets, assets_returned, shares_minted, shares_to_burn,
+            total_shares, total_assets
+        );
+
+        // The user should never lose more than 1 unit to rounding per direction
+        // (floor + ceil = at most 2 units total rounding loss).
+        let max_loss = if assets >= 2 { 2i128 } else { assets };
+        let loss = assets - assets_returned;
+        prop_assert!(
+            loss <= max_loss,
+            "excessive rounding loss: deposited {}, got back {}, loss {} > max {} \
+             (total_shares={}, total_assets={})",
+            assets, assets_returned, loss, max_loss,
+            total_shares, total_assets
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // (i)  Withdraw+deposit cycle: shares burned consistent with original (#412)
+    // -----------------------------------------------------------------------
+
+    /// A user holds `held_shares`. The vault has total_shares and total_assets.
+    /// If the user withdraws an amount `assets` (computed from floor conversion of
+    /// their shares) and then immediately deposits those same assets back,
+    /// the new shares minted should be ≤ the original shares burned.
+    ///
+    /// This ensures the vault cannot inflate the share count through a
+    /// withdraw+deposit cycle.
+    #[test]
+    fn prop_withdraw_deposit_cycle_no_inflation(
+        held_shares  in 1i128..=MAX_VAL,
+        total_shares in 1i128..=MAX_VAL,
+        total_assets in 1i128..=MAX_VAL,
+    ) {
+        // The user's entitled assets (what they'd get on withdrawal)
+        let entitled_assets = assets_from_shares(held_shares, total_shares, total_assets)
+            .expect("overflow not possible at tested bounds");
+
+        if entitled_assets == 0 {
+            return;
+        }
+
+        // Withdrawal path: shares_to_burn = ceil(entitled_assets)
+        let shares_burned = shares_ceil(entitled_assets, total_shares, total_assets)
+            .expect("overflow not possible at tested bounds");
+
+        // The vault returns assets_from_shares(shares_burned) — floor
+        let assets_returned = assets_from_shares(shares_burned, total_shares, total_assets)
+            .expect("overflow not possible at tested bounds");
+
+        // Re-deposit: new_shares = floor(assets_returned)
+        let new_shares = shares_floor(assets_returned, total_shares, total_assets)
+            .expect("overflow not possible at tested bounds");
+
+        // New shares should never exceed the original shares that were burned.
+        prop_assert!(
+            new_shares <= held_shares,
+            "withdraw+deposit cycle inflated shares: held {} shares, burned {} for {} assets, \
+             re-deposited to {} shares (total_shares={}, total_assets={})",
+            held_shares, shares_burned, assets_returned, new_shares,
+            total_shares, total_assets
         );
     }
 }


### PR DESCRIPTION
Closes #412

## Summary
Extends the existing share-conversion proptest with three new invariant tests covering rounding edge cases.

## New invariants
### (g) Ceil round-trip: assets → shares_ceil → assets ≤ assets
Verifies that even with ceil rounding on the share side (the withdrawal path), the user never gets back more than they deposited.

### (h) Deposit+withdraw cycle: user never receives more than deposited
Full deposit-then-withdraw cycle simulation. Also asserts rounding loss is bounded to at most 2 units (floor + ceil).

### (i) Withdraw+deposit cycle: shares burned consistent with original
Verifies that after a withdraw-then-deposit cycle, new shares minted never exceed the original shares that were burned — preventing share count inflation.