### PR TITLE
Fix/434 435 436 437 vault validation events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ This changelog is tied to the vault contract `Version` storage value. Each relea
 ## [Unreleased]
 <!-- Add entries below. Format: `- Short description (Issue #N).` -->
 <!-- If this PR bumps get_version(), note the new Version value here. -->
+- `initialize` now rejects the zero address (the unspendable all-zero ed25519
+  account) for `deployer`, `owner`, `agent`, and `usdc_token`, with dedicated
+  `VaultError` codes 62-65, so a vault can never be initialized with a
+  burned/unusable role address (Issue #434).
+- `set_deposit_limits` now rejects a `max` above a new `MAX_DEPOSIT_CEILING`
+  (100,000,000,000 raw units), via `VaultError::MaximumDepositExceedsCeiling`
+  (code 66), preventing a misconfigured astronomically-high per-transaction
+  maximum (Issue #435).
+- `set_rebalance_cooldown` now emits `RebalanceCooldownUpdatedEvent`
+  (`reb_cd`) with the old and new cooldown interval, so indexers can track
+  cooldown changes without polling storage (Issue #436).
+- `set_approval_ttl` now emits `ApprovalTtlUpdatedEvent` (`ttl_upd`) with the
+  old and new TTL, matching the event pattern already used by `set_caps` and
+  `set_deposit_limits` (Issue #437).
+- No `Version` bump (pre-mainnet).
 - **Shares-only balance accounting (Issue #184):** `DataKey::Balance(Address)`
   is confirmed deprecated and unused by core deposit/withdraw/getter logic;
   the discriminant is retained only to preserve the serialized `DataKey`

--- a/ERROR_STYLE_GUIDE.md
+++ b/ERROR_STYLE_GUIDE.md
@@ -85,6 +85,11 @@ Where:
 | 40 | `ExceedsUserDepositCap` | `vault: exceeds user deposit cap` |
 | 41 | `ExceedsTvlCap` | `vault: exceeds TVL cap` |
 | 42 | `MinOutNotMet` | `vault: <leg> received <actual> below min_out <min_out>` |
+| 62 | `DeployerCannotBeZeroAddress` | `vault: deployer cannot be zero address` |
+| 63 | `OwnerCannotBeZeroAddress` | `vault: owner cannot be zero address` |
+| 64 | `AgentCannotBeZeroAddress` | `vault: agent cannot be zero address` |
+| 65 | `UsdcTokenCannotBeZeroAddress` | `vault: usdc token cannot be zero address` |
+| 66 | `MaximumDepositExceedsCeiling` | `vault: maximum deposit exceeds ceiling` |
 
 ## Error Categories
 

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -267,6 +267,30 @@ pub struct CapsUpdatedEvent {
 ```
 
 
+### 8e. RebalanceCooldownUpdatedEvent
+**Topic:** `"reb_cd"` (`TOPIC_REBALANCE_COOLDOWN_UPDATED`)
+
+Emitted when the minimum rebalance cooldown is updated via `set_rebalance_cooldown`.
+
+```rust
+pub struct RebalanceCooldownUpdatedEvent {
+    pub old_interval: u32,   // Minimum ledgers between rebalances before the change, or 0 if disabled
+    pub new_interval: u32,   // Minimum ledgers between rebalances after the change, or 0 if disabled
+}
+```
+
+### 8f. ApprovalTtlUpdatedEvent
+**Topic:** `"ttl_upd"` (`TOPIC_APPROVAL_TTL_UPDATED`)
+
+Emitted when the shared Blend/DEX approval TTL is updated via `set_approval_ttl`.
+
+```rust
+pub struct ApprovalTtlUpdatedEvent {
+    pub old_ttl: u32,   // Approval TTL in ledgers before the change
+    pub new_ttl: u32,   // Approval TTL in ledgers after the change
+}
+```
+
 ### 9. AgentUpdatedEvent
 **Topic:** `"agent"` (`TOPIC_AGENT_UPDATED`)
 

--- a/contract-spec.json
+++ b/contract-spec.json
@@ -1706,6 +1706,40 @@
       ]
     },
     {
+      "name": "RebalanceCooldownUpdatedEvent",
+      "topic": "reb_cd",
+      "description": "Emitted by the contract.",
+      "fields": [
+        {
+          "name": "old_interval",
+          "type": "u32",
+          "description": "Minimum ledgers between rebalances before the change, or `0` if disabled"
+        },
+        {
+          "name": "new_interval",
+          "type": "u32",
+          "description": "Minimum ledgers between rebalances after the change, or `0` if disabled"
+        }
+      ]
+    },
+    {
+      "name": "ApprovalTtlUpdatedEvent",
+      "topic": "ttl_upd",
+      "description": "Emitted by the contract.",
+      "fields": [
+        {
+          "name": "old_ttl",
+          "type": "u32",
+          "description": "Approval TTL in ledgers before the change"
+        },
+        {
+          "name": "new_ttl",
+          "type": "u32",
+          "description": "Approval TTL in ledgers after the change"
+        }
+      ]
+    },
+    {
       "name": "AgentUpdatedEvent",
       "topic": "agent",
       "description": "Emitted by the contract.",
@@ -2264,6 +2298,70 @@
     "VaultError::TimelockNotExpired": {
       "code": 50,
       "description": "The timelock delay has not yet elapsed."
+    },
+    "VaultError::ShareConversionOverflow": {
+      "code": 51,
+      "description": "Share conversion intermediate product overflow (assets * total_shares)."
+    },
+    "VaultError::TotalDepositsOverflow": {
+      "code": 52,
+      "description": "Total deposits arithmetic overflow."
+    },
+    "VaultError::SharesOverflow": {
+      "code": 53,
+      "description": "User shares arithmetic overflow."
+    },
+    "VaultError::TotalSharesOverflow": {
+      "code": 54,
+      "description": "Total shares arithmetic overflow."
+    },
+    "VaultError::TotalAssetsOverflow": {
+      "code": 55,
+      "description": "Total assets arithmetic overflow."
+    },
+    "VaultError::ShareToAssetConversionOverflow": {
+      "code": 56,
+      "description": "Share conversion intermediate product overflow (shares * total_assets)."
+    },
+    "VaultError::ExchangeRateOverflow": {
+      "code": 57,
+      "description": "Exchange rate intermediate product overflow (total_assets * scalar)."
+    },
+    "VaultError::WithdrawalUnderflow": {
+      "code": 58,
+      "description": "Arithmetic underflow in withdrawal."
+    },
+    "VaultError::MaxDecreaseOverflow": {
+      "code": 59,
+      "description": "Maximum decrease calculation overflow."
+    },
+    "VaultError::TotalAvailableOverflow": {
+      "code": 60,
+      "description": "Total available balance overflow."
+    },
+    "VaultError::VersionOverflow": {
+      "code": 61,
+      "description": "Version counter overflow."
+    },
+    "VaultError::DeployerCannotBeZeroAddress": {
+      "code": 62,
+      "description": "Deployer address supplied to `initialize` is the zero address."
+    },
+    "VaultError::OwnerCannotBeZeroAddress": {
+      "code": 63,
+      "description": "Owner address supplied to `initialize` is the zero address."
+    },
+    "VaultError::AgentCannotBeZeroAddress": {
+      "code": 64,
+      "description": "Agent address supplied to `initialize` is the zero address."
+    },
+    "VaultError::UsdcTokenCannotBeZeroAddress": {
+      "code": 65,
+      "description": "USDC token address supplied to `initialize` is the zero address."
+    },
+    "VaultError::MaximumDepositExceedsCeiling": {
+      "code": 66,
+      "description": "Maximum per-transaction deposit exceeds the absolute configured ceiling."
     },
     "ValidationError": {
       "code": 100,

--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -136,7 +136,7 @@ use core::cmp::min;
 use soroban_sdk::{
     auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, token,
-    vec, Address, BytesN, Env, IntoVal, Symbol, Val, Vec,
+    vec, Address, BytesN, Env, IntoVal, String, Symbol, Val, Vec,
 };
 
 // ============================================================================
@@ -283,6 +283,16 @@ pub enum VaultError {
     TotalAvailableOverflow = 60,
     /// Version counter overflow.
     VersionOverflow = 61,
+    /// Deployer address supplied to `initialize` is the zero address.
+    DeployerCannotBeZeroAddress = 62,
+    /// Owner address supplied to `initialize` is the zero address.
+    OwnerCannotBeZeroAddress = 63,
+    /// Agent address supplied to `initialize` is the zero address.
+    AgentCannotBeZeroAddress = 64,
+    /// USDC token address supplied to `initialize` is the zero address.
+    UsdcTokenCannotBeZeroAddress = 65,
+    /// Maximum per-transaction deposit exceeds the absolute configured ceiling.
+    MaximumDepositExceedsCeiling = 66,
 }
 
 // ============================================================================
@@ -636,6 +646,32 @@ pub struct DepositLimitsUpdatedEvent {
     pub new_max: i128,
 }
 
+/// Emitted when the minimum rebalance cooldown is updated via
+/// `set_rebalance_cooldown`.
+///
+/// # Topics
+/// - `SymbolShort("reb_cd")` (`TOPIC_REBALANCE_COOLDOWN_UPDATED`) - Event identifier
+#[contracttype]
+pub struct RebalanceCooldownUpdatedEvent {
+    /// Minimum ledgers between rebalances before the change, or `0` if disabled
+    pub old_interval: u32,
+    /// Minimum ledgers between rebalances after the change, or `0` if disabled
+    pub new_interval: u32,
+}
+
+/// Emitted when the shared Blend/DEX approval TTL is updated via
+/// `set_approval_ttl`.
+///
+/// # Topics
+/// - `SymbolShort("ttl_upd")` (`TOPIC_APPROVAL_TTL_UPDATED`) - Event identifier
+#[contracttype]
+pub struct ApprovalTtlUpdatedEvent {
+    /// Approval TTL in ledgers before the change
+    pub old_ttl: u32,
+    /// Approval TTL in ledgers after the change
+    pub new_ttl: u32,
+}
+
 /// Emitted when the AI agent address changes.
 ///
 /// Published alongside [`AgentUpdateConfirmedEvent`] by `confirm_agent_update`
@@ -943,6 +979,12 @@ const DEFAULT_TVL_CAP: i128 = 100_000_000_000_i128;
 const DEFAULT_USER_DEPOSIT_CAP: i128 = 10_000_000_000_i128;
 const DEFAULT_MIN_DEPOSIT: i128 = 1_000_000_i128;
 const DEFAULT_MAX_DEPOSIT: i128 = 10_000_000_000_i128;
+/// Absolute upper bound the owner can configure via `set_deposit_limits`.
+///
+/// Comfortably above any realistic per-transaction limit, this rejects
+/// configuration mistakes (e.g. an accidental `i128::MAX`) that would
+/// otherwise disable the per-transaction maximum-deposit guard entirely.
+const MAX_DEPOSIT_CEILING: i128 = 100_000_000_000_i128;
 /// Default Blend token approval lifetime.
 /// 100_000 ledgers × ~5s per ledger ≈ 5.7 days on Stellar mainnet.
 pub(crate) const DEFAULT_APPROVAL_TTL: u32 = 100_000;
@@ -970,15 +1012,16 @@ const USER_SHARES_TTL_EXTEND_TO: u32 = 100;
 const DEFAULT_BLEND_APPROVAL_TTL: u32 = 100_000;
 
 use topics::{
-    TOPIC_AGENT_UPDATE_CANCELLED, TOPIC_AGENT_UPDATE_CONFIRMED, TOPIC_AGENT_UPDATE_PROPOSED,
-    TOPIC_AGENT_UPDATED, TOPIC_ASSETS_UPDATED, TOPIC_BLEND_POOL_CONFIGURED, TOPIC_BLEND_SUPPLY,
-    TOPIC_BLEND_WITHDRAW, TOPIC_CAPS_UPDATED, TOPIC_DEPOSIT, TOPIC_DEPOSIT_LIMITS_UPDATED,
-    TOPIC_DEX_POOL_CONFIGURED, TOPIC_DEX_SUPPLY, TOPIC_DEX_WITHDRAW, TOPIC_EMERGENCY_PAUSED,
-    TOPIC_INIT, TOPIC_LIMITS_UPDATED, TOPIC_OWNERSHIP_CANCELLED, TOPIC_OWNERSHIP_INITIATED,
-    TOPIC_OWNERSHIP_TRANSFERRED, TOPIC_PAUSED, TOPIC_PROTOCOL_CHANGED, TOPIC_REBALANCE,
-    TOPIC_REBALANCE_FAILED, TOPIC_TVL_CAP_UPDATED, TOPIC_UNPAUSED, TOPIC_UPGRADE_CANCELLED,
-    TOPIC_UPGRADE_SCHEDULED, TOPIC_UPGRADED, TOPIC_USER_CAP_UPDATED, TOPIC_USER_STRATEGY_UPDATED,
-    TOPIC_WITHDRAW,
+    TOPIC_AGENT_UPDATED, TOPIC_AGENT_UPDATE_CANCELLED, TOPIC_AGENT_UPDATE_CONFIRMED,
+    TOPIC_AGENT_UPDATE_PROPOSED, TOPIC_APPROVAL_TTL_UPDATED, TOPIC_ASSETS_UPDATED,
+    TOPIC_BLEND_POOL_CONFIGURED, TOPIC_BLEND_SUPPLY, TOPIC_BLEND_WITHDRAW, TOPIC_CAPS_UPDATED,
+    TOPIC_DEPOSIT, TOPIC_DEPOSIT_LIMITS_UPDATED, TOPIC_DEX_POOL_CONFIGURED, TOPIC_DEX_SUPPLY,
+    TOPIC_DEX_WITHDRAW, TOPIC_EMERGENCY_PAUSED, TOPIC_INIT, TOPIC_LIMITS_UPDATED,
+    TOPIC_OWNERSHIP_CANCELLED, TOPIC_OWNERSHIP_INITIATED, TOPIC_OWNERSHIP_TRANSFERRED,
+    TOPIC_PAUSED, TOPIC_PROTOCOL_CHANGED, TOPIC_REBALANCE, TOPIC_REBALANCE_COOLDOWN_UPDATED,
+    TOPIC_REBALANCE_FAILED, TOPIC_TVL_CAP_UPDATED, TOPIC_UNPAUSED, TOPIC_UPGRADED,
+    TOPIC_UPGRADE_CANCELLED, TOPIC_UPGRADE_SCHEDULED, TOPIC_USER_CAP_UPDATED,
+    TOPIC_USER_STRATEGY_UPDATED, TOPIC_WITHDRAW,
 };
 
 impl BlendPoolClient {
@@ -1230,6 +1273,20 @@ impl NeuroWealthVault {
         }
     }
 
+    /// The canonical "burned" Stellar account: the ed25519 public key whose
+    /// 32-byte payload is all zeros. No known private key can sign for it.
+    ///
+    /// `soroban_sdk::Address` has no `Default` impl, so this is the
+    /// zero-address sentinel used to reject burned addresses in `initialize`
+    /// (issue #434).
+    #[inline]
+    fn zero_address(env: &Env) -> Address {
+        Address::from_string(&String::from_str(
+            env,
+            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        ))
+    }
+
     // ==========================================================================
     // INITIALIZATION
     // ==========================================================================
@@ -1267,6 +1324,7 @@ impl NeuroWealthVault {
     /// - If the vault has already been initialized (Agent key already exists).
     /// - If the caller is not the expected deployer.
     /// - If deployer authorization fails.
+    /// - If `deployer`, `owner`, `agent`, or `usdc_token` is the zero address.
     pub fn initialize(
         env: Env,
         deployer: Address,
@@ -1277,6 +1335,22 @@ impl NeuroWealthVault {
     ) {
         if env.storage().instance().has(&DataKey::Agent) {
             panic_with_error!(&env, VaultError::AlreadyInitialized);
+        }
+
+        // Reject the zero address for every role so a vault can never be
+        // initialized with a burned/unusable address (issue #434).
+        let zero = Self::zero_address(&env);
+        if deployer == zero {
+            panic_with_error!(&env, VaultError::DeployerCannotBeZeroAddress);
+        }
+        if owner == zero {
+            panic_with_error!(&env, VaultError::OwnerCannotBeZeroAddress);
+        }
+        if agent == zero {
+            panic_with_error!(&env, VaultError::AgentCannotBeZeroAddress);
+        }
+        if usdc_token == zero {
+            panic_with_error!(&env, VaultError::UsdcTokenCannotBeZeroAddress);
         }
 
         // Verify the deployer is the one that actually deployed the contract
@@ -2462,6 +2536,7 @@ impl NeuroWealthVault {
     /// - If the caller is not the owner.
     /// - If min is less than 1 USDC (1_000_000 stroops).
     /// - If max is less than min.
+    /// - If max exceeds [`MAX_DEPOSIT_CEILING`].
     pub fn set_deposit_limits(env: Env, min: i128, max: i128) {
         Self::require_initialized(&env);
         Self::require_is_owner(&env);
@@ -2473,6 +2548,11 @@ impl NeuroWealthVault {
             VaultError::MinimumDepositTooLow,
         );
         Self::require(&env, max >= min, VaultError::MaximumDepositBelowMinimum);
+        Self::require(
+            &env,
+            max <= MAX_DEPOSIT_CEILING,
+            VaultError::MaximumDepositExceedsCeiling,
+        );
 
         let old_min = env
             .storage()
@@ -2520,8 +2600,8 @@ impl NeuroWealthVault {
     ///
     /// # Events
     ///
-    /// None. The cooldown is configuration-only; read the effective value back
-    /// with [`get_rebalance_cooldown`](crate::NeuroWealthVault::get_rebalance_cooldown).
+    /// Emits:
+    /// - `RebalanceCooldownUpdatedEvent`
     ///
     /// # Errors
     ///
@@ -2555,6 +2635,12 @@ impl NeuroWealthVault {
         Self::require_initialized(&env);
         Self::require_is_owner(&env);
 
+        let old_interval: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinRebalanceInterval)
+            .unwrap_or(0);
+
         if interval == 0 {
             // Removing the key disables the cooldown entirely.
             env.storage()
@@ -2565,6 +2651,14 @@ impl NeuroWealthVault {
                 .instance()
                 .set(&DataKey::MinRebalanceInterval, &interval);
         }
+
+        env.events().publish(
+            (TOPIC_REBALANCE_COOLDOWN_UPDATED,),
+            RebalanceCooldownUpdatedEvent {
+                old_interval,
+                new_interval: interval,
+            },
+        );
     }
 
     /// Returns the configured minimum rebalance interval (ledgers), or `0` if
@@ -2637,7 +2731,8 @@ impl NeuroWealthVault {
     ///
     /// # Events
     ///
-    /// None.
+    /// Emits:
+    /// - `ApprovalTtlUpdatedEvent`
     ///
     /// # Errors
     ///
@@ -2674,7 +2769,17 @@ impl NeuroWealthVault {
             panic_with_error!(&env, VaultError::ApprovalTtlTooHigh);
         }
 
+        let old_ttl = Self::get_approval_ttl_internal(&env);
+
         env.storage().instance().set(&DataKey::ApprovalTtl, &ttl);
+
+        env.events().publish(
+            (TOPIC_APPROVAL_TTL_UPDATED,),
+            ApprovalTtlUpdatedEvent {
+                old_ttl,
+                new_ttl: ttl,
+            },
+        );
     }
 
     /// Returns the shared protocol approval TTL in ledgers.

--- a/neurowealth-vault/contracts/vault/src/tests/test_approval_ttl.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_approval_ttl.rs
@@ -1,11 +1,11 @@
 //! Tests for configurable Blend token approval TTL.
 
 use super::utils::*;
-use crate::DEFAULT_APPROVAL_TTL;
+use crate::{ApprovalTtlUpdatedEvent, DEFAULT_APPROVAL_TTL, TOPIC_APPROVAL_TTL_UPDATED};
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, MockAuth, MockAuthInvoke},
-    Address, Env, IntoVal,
+    Address, Env, IntoVal, TryFromVal,
 };
 
 fn setup_blend_position(
@@ -165,6 +165,76 @@ fn test_set_approval_ttl_rejects_above_maximum() {
     );
 }
 
+/// `set_approval_ttl` emits `ApprovalTtlUpdatedEvent` with the old and new
+/// TTL so indexers can track TTL changes without polling storage (Issue #437).
+#[test]
+fn test_set_approval_ttl_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner) = setup_vault(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_approval_ttl(&17_280_u32);
+
+    let events = find_events_by_topic(env.events().all(), &env, TOPIC_APPROVAL_TTL_UPDATED);
+    assert_eq!(
+        events.len(),
+        1,
+        "exactly one approval-ttl-updated event expected"
+    );
+
+    let (_, _, data) = &events[0];
+    let event = ApprovalTtlUpdatedEvent::try_from_val(&env, data)
+        .expect("should be a valid ApprovalTtlUpdatedEvent");
+    assert_eq!(
+        event.old_ttl, DEFAULT_APPROVAL_TTL,
+        "old_ttl before any explicit configuration is the default TTL"
+    );
+    assert_eq!(event.new_ttl, 17_280);
+}
+
+/// A second call to `set_approval_ttl` reports the previously configured TTL
+/// as `old_ttl`, not the all-time default.
+#[test]
+fn test_set_approval_ttl_event_reflects_previous_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner) = setup_vault(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_approval_ttl(&50_000_u32);
+    client.set_approval_ttl(&200_000_u32);
+
+    let events = find_events_by_topic(env.events().all(), &env, TOPIC_APPROVAL_TTL_UPDATED);
+    assert_eq!(events.len(), 2, "two approval-ttl-updated events expected");
+
+    let (_, _, data) = &events[1];
+    let event = ApprovalTtlUpdatedEvent::try_from_val(&env, data)
+        .expect("should be a valid ApprovalTtlUpdatedEvent");
+    assert_eq!(event.old_ttl, 50_000);
+    assert_eq!(event.new_ttl, 200_000);
+}
+
+/// A rejected `set_approval_ttl` call (out of bounds) must not emit an event.
+#[test]
+fn test_set_approval_ttl_rejected_call_emits_no_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner) = setup_vault(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let _ = client.try_set_approval_ttl(&999_u32);
+
+    let events = find_events_by_topic(env.events().all(), &env, TOPIC_APPROVAL_TTL_UPDATED);
+    assert!(
+        events.is_empty(),
+        "a rejected set_approval_ttl call must not emit an event"
+    );
+}
+
 // ─── DEX supply path (#341) ─────────────────────────────────────────────────
 //
 // The DEX supply path (`rebalance("dex", ..)` → `add_liquidity`) approves the
@@ -203,8 +273,7 @@ fn test_dex_approval_expiry_minimum_ttl_is_valid() {
 #[test]
 fn test_default_approval_ttl_used_for_dex_supply() {
     let env = Env::default();
-    let (contract_id, _usdc_token, dex_pool, client, token_client) =
-        setup_dex_position(&env, None);
+    let (contract_id, _usdc_token, dex_pool, client, token_client) = setup_dex_position(&env, None);
 
     assert_eq!(client.get_approval_ttl(), DEFAULT_APPROVAL_TTL);
 

--- a/neurowealth-vault/contracts/vault/src/tests/test_checked_arithmetic.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_checked_arithmetic.rs
@@ -6,7 +6,21 @@
 //! `i128::MAX` to actually exercise those guards.
 
 use super::utils::*;
+use crate::DataKey;
 use soroban_sdk::{testutils::Address as _, Address, Env};
+
+/// Sets `MinDeposit`/`MaxDeposit` directly in storage, bypassing
+/// `set_deposit_limits`'s owner-facing `MAX_DEPOSIT_CEILING` guard (issue
+/// #435). These boundary tests intentionally push `max` to `i128::MAX` to
+/// exercise checked-arithmetic guards deeper in the deposit/share-conversion
+/// path, which is a different concern than the ceiling validation on the
+/// admin entrypoint.
+fn set_deposit_limits_unchecked(env: &Env, contract_id: &Address, min: i128, max: i128) {
+    env.as_contract(contract_id, || {
+        env.storage().instance().set(&DataKey::MinDeposit, &min);
+        env.storage().instance().set(&DataKey::MaxDeposit, &max);
+    });
+}
 
 /// A single very large deposit (well within `i128`) succeeds and books shares
 /// exactly 1:1 on bootstrap — confirming the checked math handles large operands
@@ -22,7 +36,7 @@ fn test_large_deposit_within_range_succeeds() {
 
     // Disable per-user / TVL caps and raise the per-deposit max to allow a huge deposit.
     client.set_limits(&0, &0);
-    client.set_deposit_limits(&1_000_000_i128, &i128::MAX);
+    set_deposit_limits_unchecked(&env, &contract_id, 1_000_000_i128, i128::MAX);
 
     let user = Address::generate(&env);
     let amount = 1_000_000_000_000_000_000_i128; // 1e18, far below i128::MAX (~1.7e38)
@@ -54,7 +68,7 @@ fn test_convert_to_shares_mul_overflow_is_checked() {
     let token = TestTokenClient::new(&env, &usdc_token);
 
     client.set_limits(&0, &0);
-    client.set_deposit_limits(&1_000_000_i128, &i128::MAX);
+    set_deposit_limits_unchecked(&env, &contract_id, 1_000_000_i128, i128::MAX);
 
     // Bootstrap a large share supply: total_shares == total_assets == 1e18.
     let user = Address::generate(&env);
@@ -79,7 +93,7 @@ fn test_user_deposit_cap_boundary() {
 
     let cap = 100_000_000_i128;
     client.set_user_deposit_cap(&cap);
-    client.set_deposit_limits(&1_000_000_i128, &i128::MAX);
+    set_deposit_limits_unchecked(&env, &contract_id, 1_000_000_i128, i128::MAX);
 
     let user = Address::generate(&env);
     token.mint(&user, &(cap + 1_000_000));
@@ -123,7 +137,7 @@ fn test_large_balance_full_withdraw() {
     let token = TestTokenClient::new(&env, &usdc_token);
 
     client.set_limits(&0, &0);
-    client.set_deposit_limits(&1_000_000_i128, &i128::MAX);
+    set_deposit_limits_unchecked(&env, &contract_id, 1_000_000_i128, i128::MAX);
 
     let user = Address::generate(&env);
     let amount = 5_000_000_000_000_000_000_i128; // 5e18
@@ -151,7 +165,7 @@ fn test_update_total_assets_decrease_bound_overflow_is_checked() {
     let token = TestTokenClient::new(&env, &usdc_token);
 
     client.set_limits(&0, &0);
-    client.set_deposit_limits(&1_000_000_i128, &i128::MAX);
+    set_deposit_limits_unchecked(&env, &contract_id, 1_000_000_i128, i128::MAX);
 
     // Drive stored TotalAssets to i128::MAX via a max-sized deposit.
     let user = Address::generate(&env);
@@ -181,7 +195,10 @@ fn test_exchange_rate_checked_div_succeeds() {
 
     // Bootstrap: 1:1, so rate = 10_000_000 (scalar = 10_000_000, rate = 1.0)
     let rate = client.get_exchange_rate();
-    assert_eq!(rate, 10_000_000_i128, "bootstrap exchange rate should be 1:1 scaled");
+    assert_eq!(
+        rate, 10_000_000_i128,
+        "bootstrap exchange rate should be 1:1 scaled"
+    );
 }
 
 /// A small but valid decrease within bps bounds uses `.checked_div(10_000)`

--- a/neurowealth-vault/contracts/vault/src/tests/test_initialize.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_initialize.rs
@@ -2,7 +2,17 @@
 
 use super::utils::*;
 use crate::{VaultInitializedEvent, TOPIC_INIT};
-use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, TryFromVal};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, TryFromVal};
+
+/// The canonical "burned" Stellar account (ed25519 public key of all zero
+/// bytes) used to exercise `initialize`'s zero-address rejection (Issue
+/// #434). Mirrors `NeuroWealthVault::zero_address` in `lib.rs`.
+fn zero_address(env: &Env) -> Address {
+    Address::from_string(&String::from_str(
+        env,
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    ))
+}
 
 #[test]
 fn test_initialize_happy_path() {
@@ -119,13 +129,23 @@ fn test_initialize_emits_event() {
     client.initialize(&deployer, &owner, &agent, &usdc_token, &salt);
 
     let init_events = find_events_by_topic(env.events().all(), &env, TOPIC_INIT);
-    assert_eq!(init_events.len(), 1, "Exactly one init event should be emitted");
+    assert_eq!(
+        init_events.len(),
+        1,
+        "Exactly one init event should be emitted"
+    );
 
     let (_, _, data) = &init_events[0];
     let event = VaultInitializedEvent::try_from_val(&env, data)
         .expect("Should be a valid VaultInitializedEvent");
-    assert_eq!(event.agent, agent, "Event agent should match initialized agent");
-    assert_eq!(event.usdc_token, usdc_token, "Event usdc_token should match");
+    assert_eq!(
+        event.agent, agent,
+        "Event agent should match initialized agent"
+    );
+    assert_eq!(
+        event.usdc_token, usdc_token,
+        "Event usdc_token should match"
+    );
 }
 
 // ============================================================================
@@ -198,8 +218,7 @@ fn test_initialize_event_includes_owner_and_agent() {
 
     client.initialize(&deployer, &owner, &agent, &usdc_token, &salt);
 
-    let init_events =
-        find_events_by_topic(env.events().all(), &env, TOPIC_INIT);
+    let init_events = find_events_by_topic(env.events().all(), &env, TOPIC_INIT);
     assert_eq!(init_events.len(), 1, "init event must be emitted");
 
     // The event data is VaultInitializedEvent; verify it contains both roles
@@ -307,4 +326,96 @@ fn test_front_runner_with_own_address_as_deployer_is_rejected() {
         &usdc_token,
         &salt,
     );
+}
+
+// ============================================================================
+// ISSUE #434 — REJECT ZERO ADDRESS IN INITIALIZE()
+// ============================================================================
+
+#[test]
+#[should_panic(expected = "Error(Contract, #62)")]
+fn test_initialize_rejects_zero_deployer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deployer = zero_address(&env);
+    let salt = BytesN::from_array(&env, &[0u8; 32]);
+    let contract_id = env
+        .deployer()
+        .with_address(deployer.clone(), salt.clone())
+        .deployed_address();
+    env.register_contract(&contract_id, NeuroWealthVault);
+
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let agent = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+
+    client.initialize(&deployer, &owner, &agent, &usdc_token, &salt);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #63)")]
+fn test_initialize_rejects_zero_owner() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deployer = Address::generate(&env);
+    let salt = BytesN::from_array(&env, &[0u8; 32]);
+    let contract_id = env
+        .deployer()
+        .with_address(deployer.clone(), salt.clone())
+        .deployed_address();
+    env.register_contract(&contract_id, NeuroWealthVault);
+
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let agent = Address::generate(&env);
+    let owner = zero_address(&env);
+    let usdc_token = Address::generate(&env);
+
+    client.initialize(&deployer, &owner, &agent, &usdc_token, &salt);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #64)")]
+fn test_initialize_rejects_zero_agent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deployer = Address::generate(&env);
+    let salt = BytesN::from_array(&env, &[0u8; 32]);
+    let contract_id = env
+        .deployer()
+        .with_address(deployer.clone(), salt.clone())
+        .deployed_address();
+    env.register_contract(&contract_id, NeuroWealthVault);
+
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let agent = zero_address(&env);
+    let owner = Address::generate(&env);
+    let usdc_token = Address::generate(&env);
+
+    client.initialize(&deployer, &owner, &agent, &usdc_token, &salt);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #65)")]
+fn test_initialize_rejects_zero_usdc_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deployer = Address::generate(&env);
+    let salt = BytesN::from_array(&env, &[0u8; 32]);
+    let contract_id = env
+        .deployer()
+        .with_address(deployer.clone(), salt.clone())
+        .deployed_address();
+    env.register_contract(&contract_id, NeuroWealthVault);
+
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let agent = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let usdc_token = zero_address(&env);
+
+    client.initialize(&deployer, &owner, &agent, &usdc_token, &salt);
 }

--- a/neurowealth-vault/contracts/vault/src/tests/test_limits.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_limits.rs
@@ -1,7 +1,7 @@
 //! Tests for deposit limits and caps
 
 use super::utils::*;
-use crate::{DataKey, DEFAULT_MIN_DEPOSIT};
+use crate::{DataKey, DEFAULT_MIN_DEPOSIT, MAX_DEPOSIT_CEILING};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 #[test]
@@ -131,6 +131,52 @@ fn test_set_deposit_limits_max_less_than_min() {
     let max = 4_000_000_i128; // Less than min
 
     client.set_deposit_limits(&min, &max);
+}
+
+// ============================================================================
+// ISSUE #435 — UPPER BOUND ON set_deposit_limits' max
+// ============================================================================
+
+/// `max` set exactly to the ceiling is accepted (inclusive boundary).
+#[test]
+fn test_set_deposit_limits_max_at_ceiling_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_deposit_limits(&DEFAULT_MIN_DEPOSIT, &MAX_DEPOSIT_CEILING);
+
+    assert_eq!(client.get_max_deposit(), MAX_DEPOSIT_CEILING);
+}
+
+/// One unit above the ceiling must be rejected, preventing a misconfigured
+/// astronomically-high per-transaction maximum (e.g. an accidental `i128::MAX`).
+#[test]
+#[should_panic(expected = "Error(Contract, #66)")]
+fn test_set_deposit_limits_max_above_ceiling_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_deposit_limits(&DEFAULT_MIN_DEPOSIT, &(MAX_DEPOSIT_CEILING + 1));
+}
+
+/// An accidental `i128::MAX` (the historical footgun this issue guards
+/// against) must be rejected rather than silently disabling the per-tx cap.
+#[test]
+#[should_panic(expected = "Error(Contract, #66)")]
+fn test_set_deposit_limits_rejects_i128_max() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_deposit_limits(&DEFAULT_MIN_DEPOSIT, &i128::MAX);
 }
 
 #[test]

--- a/neurowealth-vault/contracts/vault/src/tests/test_rebalance_cooldown.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_rebalance_cooldown.rs
@@ -5,7 +5,8 @@
 //!   2. Agent call within cooldown panics with clear error (Error(Contract, #43)).
 
 use super::utils::*;
-use soroban_sdk::{symbol_short, testutils::Ledger, Env};
+use crate::{RebalanceCooldownUpdatedEvent, TOPIC_REBALANCE_COOLDOWN_UPDATED};
+use soroban_sdk::{symbol_short, testutils::Ledger, Env, TryFromVal};
 
 // ============================================================================
 // AC-1: Configurable minimum ledgers between rebalances (owner-set)
@@ -148,6 +149,82 @@ fn test_owner_can_set_cooldown_to_one_ledger() {
 
     client.set_rebalance_cooldown(&1_u32);
     assert_eq!(client.get_rebalance_cooldown(), 1);
+}
+
+/// `set_rebalance_cooldown` emits `RebalanceCooldownUpdatedEvent` with the
+/// old and new interval so indexers can track cooldown changes without
+/// polling storage (Issue #436).
+#[test]
+fn test_set_rebalance_cooldown_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner) = setup_vault(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_rebalance_cooldown(&720_u32);
+
+    let events = find_events_by_topic(env.events().all(), &env, TOPIC_REBALANCE_COOLDOWN_UPDATED);
+    assert_eq!(
+        events.len(),
+        1,
+        "exactly one cooldown-updated event expected"
+    );
+
+    let (_, _, data) = &events[0];
+    let event = RebalanceCooldownUpdatedEvent::try_from_val(&env, data)
+        .expect("should be a valid RebalanceCooldownUpdatedEvent");
+    assert_eq!(
+        event.old_interval, 0,
+        "default cooldown before the change is 0"
+    );
+    assert_eq!(event.new_interval, 720);
+}
+
+/// A second call to `set_rebalance_cooldown` reports the previous interval
+/// as `old_interval`, not the all-time default.
+#[test]
+fn test_set_rebalance_cooldown_event_reflects_previous_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner) = setup_vault(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_rebalance_cooldown(&50_u32);
+    client.set_rebalance_cooldown(&200_u32);
+
+    let events = find_events_by_topic(env.events().all(), &env, TOPIC_REBALANCE_COOLDOWN_UPDATED);
+    assert_eq!(events.len(), 2, "two cooldown-updated events expected");
+
+    let (_, _, data) = &events[1];
+    let event = RebalanceCooldownUpdatedEvent::try_from_val(&env, data)
+        .expect("should be a valid RebalanceCooldownUpdatedEvent");
+    assert_eq!(event.old_interval, 50);
+    assert_eq!(event.new_interval, 200);
+}
+
+/// Disabling the cooldown (interval = 0) still emits an event with the
+/// correct old/new pair.
+#[test]
+fn test_set_rebalance_cooldown_to_zero_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner) = setup_vault(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    client.set_rebalance_cooldown(&100_u32);
+    client.set_rebalance_cooldown(&0_u32);
+
+    let events = find_events_by_topic(env.events().all(), &env, TOPIC_REBALANCE_COOLDOWN_UPDATED);
+    assert_eq!(events.len(), 2);
+
+    let (_, _, data) = &events[1];
+    let event = RebalanceCooldownUpdatedEvent::try_from_val(&env, data)
+        .expect("should be a valid RebalanceCooldownUpdatedEvent");
+    assert_eq!(event.old_interval, 100);
+    assert_eq!(event.new_interval, 0);
 }
 
 // ============================================================================
@@ -402,7 +479,10 @@ fn test_sliding_cooldown_window_after_successful_second_call() {
 
     // Immediately after the second call the new window is active — must be blocked
     let result = client.try_rebalance(&symbol_short!("none"), &0_i128, &0_i128);
-    assert!(result.is_err(), "third call must be blocked by new cooldown window");
+    assert!(
+        result.is_err(),
+        "third call must be blocked by new cooldown window"
+    );
 }
 
 // ============================================================================
@@ -428,7 +508,10 @@ fn test_very_large_cooldown_blocks_rebalance() {
     });
 
     let result = client.try_rebalance(&symbol_short!("none"), &0_i128, &0_i128);
-    assert!(result.is_err(), "must be blocked when elapsed < huge_interval");
+    assert!(
+        result.is_err(),
+        "must be blocked when elapsed < huge_interval"
+    );
 }
 
 /// Owner lowering the cooldown mid-window allows the next call sooner.
@@ -484,7 +567,10 @@ fn test_cooldown_survives_pause_unpause_cycle() {
 
     // Still within the original window — must be blocked
     let result = client.try_rebalance(&symbol_short!("none"), &0_i128, &0_i128);
-    assert!(result.is_err(), "cooldown must still be active after unpause");
+    assert!(
+        result.is_err(),
+        "cooldown must still be active after unpause"
+    );
 }
 
 /// After pause/unpause the rebalance succeeds once the cooldown elapses.

--- a/neurowealth-vault/contracts/vault/src/topics.rs
+++ b/neurowealth-vault/contracts/vault/src/topics.rs
@@ -87,3 +87,7 @@ pub const TOPIC_AGENT_UPDATE_CANCELLED: Symbol = symbol_short!("agt_cncl");
 pub const TOPIC_UPGRADE_SCHEDULED: Symbol = symbol_short!("upg_sched");
 /// Topic for `UpgradeCancelledEvent`, published by `cancel_upgrade`.
 pub const TOPIC_UPGRADE_CANCELLED: Symbol = symbol_short!("upg_cncl");
+/// Topic for `RebalanceCooldownUpdatedEvent`, published by `set_rebalance_cooldown`.
+pub const TOPIC_REBALANCE_COOLDOWN_UPDATED: Symbol = symbol_short!("reb_cd");
+/// Topic for `ApprovalTtlUpdatedEvent`, published by `set_approval_ttl`.
+pub const TOPIC_APPROVAL_TTL_UPDATED: Symbol = symbol_short!("ttl_upd");

--- a/packages/vault-client/src/generated/vault.ts
+++ b/packages/vault-client/src/generated/vault.ts
@@ -199,6 +199,22 @@ export interface DepositLimitsUpdatedEvent {
 }
 
 /** Emitted by the contract. */
+export interface RebalanceCooldownUpdatedEvent {
+  /** Minimum ledgers between rebalances before the change, or `0` if disabled */
+  old_interval: number;
+  /** Minimum ledgers between rebalances after the change, or `0` if disabled */
+  new_interval: number;
+}
+
+/** Emitted by the contract. */
+export interface ApprovalTtlUpdatedEvent {
+  /** Approval TTL in ledgers before the change */
+  old_ttl: number;
+  /** Approval TTL in ledgers after the change */
+  new_ttl: number;
+}
+
+/** Emitted by the contract. */
 export interface AgentUpdatedEvent {
   /** Agent address that was authorized before the change */
   old_agent: string;
@@ -470,6 +486,38 @@ export const VaultErrorCode = {
   NoTimelockPending: 49,
   /** The timelock delay has not yet elapsed. */
   TimelockNotExpired: 50,
+  /** Share conversion intermediate product overflow (assets * total_shares). */
+  ShareConversionOverflow: 51,
+  /** Total deposits arithmetic overflow. */
+  TotalDepositsOverflow: 52,
+  /** User shares arithmetic overflow. */
+  SharesOverflow: 53,
+  /** Total shares arithmetic overflow. */
+  TotalSharesOverflow: 54,
+  /** Total assets arithmetic overflow. */
+  TotalAssetsOverflow: 55,
+  /** Share conversion intermediate product overflow (shares * total_assets). */
+  ShareToAssetConversionOverflow: 56,
+  /** Exchange rate intermediate product overflow (total_assets * scalar). */
+  ExchangeRateOverflow: 57,
+  /** Arithmetic underflow in withdrawal. */
+  WithdrawalUnderflow: 58,
+  /** Maximum decrease calculation overflow. */
+  MaxDecreaseOverflow: 59,
+  /** Total available balance overflow. */
+  TotalAvailableOverflow: 60,
+  /** Version counter overflow. */
+  VersionOverflow: 61,
+  /** Deployer address supplied to `initialize` is the zero address. */
+  DeployerCannotBeZeroAddress: 62,
+  /** Owner address supplied to `initialize` is the zero address. */
+  OwnerCannotBeZeroAddress: 63,
+  /** Agent address supplied to `initialize` is the zero address. */
+  AgentCannotBeZeroAddress: 64,
+  /** USDC token address supplied to `initialize` is the zero address. */
+  UsdcTokenCannotBeZeroAddress: 65,
+  /** Maximum per-transaction deposit exceeds the absolute configured ceiling. */
+  MaximumDepositExceedsCeiling: 66,
   /** General validation error */
   ValidationError: 100,
   /** Vault is paused, deposits and withdrawals disabled */


### PR DESCRIPTION
## Summary

Closes #434 
Closes #435 
Closes #436 
Closes #437 
 — four small, related hardening fixes to the vault's admin/config entrypoints:

- **#434 — Reject zero-address inputs in `initialize()`.** `deployer`, `owner`, `agent`, and `usdc_token` are now checked against the canonical "burned" Stellar account (the ed25519 public key whose 32-byte payload is all zeros — no known private key can sign for it) and rejected with dedicated error codes. `soroban_sdk::Address` has no `Default` impl in the pinned SDK version (21.x), so the zero-address sentinel is constructed via `Address::from_string` from the well-known strkey `GAAAA...WHF`, computed and verified against the Stellar strkey spec (version byte `0x30` + 32 zero bytes + CRC16-XMODEM checksum, base32-encoded).
- **#435 — Cap `set_deposit_limits`'s `max` at a sane ceiling.** Added `MAX_DEPOSIT_CEILING` (100,000,000,000 raw units) and a new `VaultError::MaximumDepositExceedsCeiling`. This closes the gap where `max` could be set to an arbitrarily large value (including an accidental `i128::MAX`), which would effectively disable the per-transaction maximum-deposit guard.
- **#436 — Emit `RebalanceCooldownUpdatedEvent` from `set_rebalance_cooldown`.** Previously this setter was silent; it now emits old/new interval on every call, matching the pattern used elsewhere (`set_caps`, `set_deposit_limits`, etc.).
- **#437 — Emit `ApprovalTtlUpdatedEvent` from `set_approval_ttl`.** Same rationale as #436, for the shared Blend/DEX approval TTL setter.

## Design notes

- New `VaultError` codes: `DeployerCannotBeZeroAddress` (62), `OwnerCannotBeZeroAddress` (63), `AgentCannotBeZeroAddress` (64), `UsdcTokenCannotBeZeroAddress` (65), `MaximumDepositExceedsCeiling` (66).
- New topics: `TOPIC_REBALANCE_COOLDOWN_UPDATED` (`reb_cd`), `TOPIC_APPROVAL_TTL_UPDATED` (`ttl_upd`) — declared in `topics.rs` per the existing single-source-of-truth convention.
- `set_deposit_limits`'s ceiling is intentionally **not** tied to `DEFAULT_MAX_DEPOSIT` (which is the *default*, owner-raisable value) — a ceiling equal to the default would make it impossible for an owner to ever raise the cap. `MAX_DEPOSIT_CEILING` is a separate, more generous absolute bound.
- `test_checked_arithmetic.rs` had five boundary tests that intentionally called `set_deposit_limits(&1_000_000, &i128::MAX)` to disable the per-tx max and exercise unrelated checked-arithmetic overflow guards (issue #127) via the public `deposit()` path. Since the new ceiling would now reject that call, those tests were updated to write `MinDeposit`/`MaxDeposit` directly into storage via `env.as_contract(...)` (mirroring an existing precedent in `test_limits.rs`), bypassing the owner-facing validation entirely — which is correct here, since these tests target internal arithmetic invariants, not `set_deposit_limits`'s own input validation.

## ⚠️ Pre-existing build issue on `main` (unrelated to this PR)

While implementing this, I found that `main` currently **does not compile** for reasons unrelated to #434-437. It looks like fallout from the most recent merge (`gelluisaac/build`, addressing #430-433):

1. `const DEFAULT_TVL_CAP` is declared **twice** in `lib.rs` (lines ~150 and ~942) — a hard `E0428` compile error.
2. `VaultError` has grown to 61 pre-existing variants (66 after this PR), but Soroban's `#[contracterror]` macro hard-caps error enums at **50** cases (`VecM<ScSpecUdtErrorEnumCaseV0, 50>` in `stellar-xdr`) — the proc-macro panics with `LengthExceedsMax` before `VaultError` is even generated.
3. Several functions were refactored to use `.ok_or(VaultError::X)?` but their signatures were never updated to return `Result`, so `?` doesn't type-check (`E0277`) — looks like an incomplete "replace `expect()` with typed errors" pass.

None of these are things this PR touches or introduces — I verified by checking out clean `origin/main` in isolation. I was **not** able to run `cargo test` / `cargo clippy` for real against this branch as a result. Instead, I verified this PR's specific changes compile and type-check correctly using an isolated scratch copy of the crate with the pre-existing enum trimmed back under 50 cases just far enough to get the type-checker running (not part of this PR, purely a local verification technique) — confirmed zero compile errors trace to any file or symbol this PR touches.

What I *was* able to verify directly against the real source:
- `python3 scripts/generate-spec.py` + `python3 scripts/validate-spec.py` — pass cleanly (regex-based, unaffected by the compile issue).
- `node scripts/generate-client.js` — regenerated successfully.
- `rustfmt --check` on every file this PR touches — clean.

**Recommendation:** file a separate issue/PR for the three items above before merging this one (or any other PR) into `main`, since CI (`cargo test`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`) will not currently pass on `main` regardless of what this PR adds.

## Checklist

- [x] I have updated `CHANGELOG.md` under `[Unreleased]` for the new error codes and events.
- [x] This PR does not bump `get_version()` (no storage-layout or serialization change).
- [x] I have included tests for the new contract behavior (zero-address rejection ×4, deposit-limit ceiling ×3, cooldown-event ×3, approval-ttl-event ×3).
- [x] New events are reflected in `EVENTS.md`.
- [ ] `cargo test` / `cargo clippy` could not be run to completion locally due to the pre-existing, unrelated build breakage on `main` described above. `contract-spec.json` / `vault.ts` regeneration and `rustfmt --check` were run and pass for every file this PR touches.
