### PR TITLE
test(vault): add agent timelock and DEX slippage/rotation tests

### DIFF
--- a/neurowealth-vault/contracts/vault/src/tests/test_agent_timelock.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_agent_timelock.rs
@@ -208,3 +208,72 @@ fn test_get_pending_agent_update_none_initially() {
         "no pending update should exist initially"
     );
 }
+
+// ─── Issue #513 ──────────────────────────────────────────────────────────────
+
+/// Pins the current behaviour when `confirm_agent_update()` is called well
+/// after the timelock expiry ledger has passed.
+///
+/// The timelock is a *minimum* delay, not a window with an upper deadline.
+/// Advancing many ledgers past `expiry` must still succeed — there is no
+/// `TimelockExpired` guard.
+#[test]
+fn test_confirm_agent_update_long_after_expiry_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _old_agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let new_agent = Address::generate(&env);
+    client.update_agent(&new_agent);
+
+    let (_, expiry) = client.get_pending_agent_update().unwrap();
+
+    // Advance the ledger 100 000 ledgers past the expiry.
+    env.ledger().set_sequence_number(expiry + 100_000);
+
+    // Must succeed — no upper deadline is enforced.
+    client.confirm_agent_update();
+
+    assert_eq!(
+        client.get_agent(),
+        new_agent,
+        "agent must be updated even when confirmed long after expiry"
+    );
+    assert!(
+        client.get_pending_agent_update().is_none(),
+        "pending state must be cleared after late confirmation"
+    );
+}
+
+// ─── Issue #514 ──────────────────────────────────────────────────────────────
+
+/// `cancel_agent_update()` panics with `NoTimelockPending` (#49) when called
+/// after a previous proposal was already cancelled — the slot is empty again.
+///
+/// This is distinct from the "never-proposed" variant: it verifies that the
+/// cancel path itself clears the pending slot so a second cancel has nothing
+/// to act on.
+#[test]
+#[should_panic(expected = "Error(Contract, #49)")]
+fn test_cancel_agent_update_after_prior_cancel_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let new_agent = Address::generate(&env);
+    // Propose, then cancel — pending slot is now empty.
+    client.update_agent(&new_agent);
+    client.cancel_agent_update();
+
+    assert!(
+        client.get_pending_agent_update().is_none(),
+        "pending state must be empty after first cancel"
+    );
+
+    // Cancelling again with no pending proposal must panic.
+    client.cancel_agent_update();
+}

--- a/neurowealth-vault/contracts/vault/src/tests/test_dex_integration.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_dex_integration.rs
@@ -297,3 +297,115 @@ fn test_dex_partial_fill_rebalance_accounts_for_actual_amount() {
     // The protocol is still tracked as "dex" (rebalance succeeded with partial fill).
     assert_eq!(vault_client.get_current_protocol(), Symbol::new(&env, "dex"));
 }
+
+// ─── Issue #515: DEX pool rotation mid-deployment ────────────────────────────
+//
+// Documents that rotating the configured DEX pool address while funds are
+// actively deployed silently strands those funds: every subsequent lookup
+// reads the *new* pool address from storage, so the vault loses the ability
+// to see or recover the position in the *old* pool.
+//
+// Pre-fix this test pins the stranding behaviour.  Once a guard is added to
+// `set_dex_pool` that rejects rotation while `CurrentProtocol == "dex"`, flip
+// the rotation call below to expect a panic instead.
+
+#[test]
+fn test_set_dex_pool_rotation_while_deployed_strands_funds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, _agent, owner, usdc_token, old_pool) = setup_vault_with_token_and_dex(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+    let old_pool_client = MockDexPoolClient::new(&env, &old_pool);
+
+    vault_client.set_dex_pool(&owner, &old_pool);
+
+    // Deploy funds to the DEX.
+    let deposit_amount = 20_000_000_i128;
+    token_client.mint(&vault_id, &deposit_amount);
+    vault_client.rebalance(&Symbol::new(&env, "dex"), &850, &0_i128);
+    assert_eq!(
+        old_pool_client.balance(&usdc_token, &vault_id),
+        deposit_amount,
+        "funds must be deployed to the old pool"
+    );
+    assert_eq!(vault_client.get_current_protocol(), Symbol::new(&env, "dex"));
+
+    // Rotate the DEX pool address while funds are still deployed.
+    // No guard currently exists — this succeeds.
+    let new_pool = env.register_contract(None, MockDexPool);
+    vault_client.set_dex_pool(&owner, &new_pool);
+    assert_eq!(vault_client.get_dex_pool(), Some(new_pool.clone()));
+
+    // Funds remain stuck in the old pool; the vault's pointer now targets new_pool.
+    assert_eq!(
+        old_pool_client.balance(&usdc_token, &vault_id),
+        deposit_amount,
+        "deployed funds remain in the old pool, untouched by rotation"
+    );
+    let new_pool_client = MockDexPoolClient::new(&env, &new_pool);
+    assert_eq!(
+        new_pool_client.balance(&usdc_token, &vault_id),
+        0,
+        "new pool has no balance"
+    );
+
+    // Attempting to exit the position silently succeeds without recovering
+    // anything: the vault queries new_pool (via DataKey::DexPool), sees 0,
+    // and flips CurrentProtocol to "none" — funds remain stranded.
+    vault_client.rebalance(&Symbol::new(&env, "none"), &0, &0_i128);
+
+    assert_eq!(
+        vault_client.get_current_protocol(),
+        Symbol::new(&env, "none"),
+        "vault believes it exited the position cleanly"
+    );
+    assert_eq!(
+        token_client.balance(&vault_id),
+        0,
+        "no funds were actually recovered"
+    );
+    assert_eq!(
+        old_pool_client.balance(&usdc_token, &vault_id),
+        deposit_amount,
+        "funds remain permanently stranded in the old pool"
+    );
+}
+
+// ─── Issue #516: min_out slippage on the DEX withdrawal leg ─────────────────
+//
+// Regression test: when `rebalance()` exits a DEX position and the pool
+// returns fewer tokens than `min_out`, the call must panic with
+// `VaultError::MinOutNotMet` (#42) and leave no partial state change.
+//
+// Uses `set_max_withdraw_limit` to cap what the mock DEX returns, simulating
+// a withdrawal partial-fill below the caller's slippage tolerance.
+
+#[test]
+#[should_panic(expected = "Error(Contract, #42)")]
+fn test_rebalance_dex_withdraw_leg_below_min_out_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, _agent, owner, usdc_token, dex_pool) = setup_vault_with_token_and_dex(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+    let dex_client = MockDexPoolClient::new(&env, &dex_pool);
+
+    vault_client.set_dex_pool(&owner, &dex_pool);
+
+    // Deploy 100 USDC into the DEX pool.
+    let deposit_amount = 100_000_000_i128;
+    token_client.mint(&vault_id, &deposit_amount);
+    vault_client.rebalance(&Symbol::new(&env, "dex"), &850, &0_i128);
+    assert_eq!(token_client.balance(&dex_pool), deposit_amount);
+
+    // Cap the pool's withdrawal to 30 USDC — simulates a partial-fill exit.
+    dex_client.set_max_withdraw_limit(&30_000_000);
+
+    // Attempt to exit with min_out = 50 USDC.
+    // The pool can only return 30 USDC, which is below min_out — must panic
+    // with MinOutNotMet (#42), leaving no partial state change.
+    vault_client.rebalance(&Symbol::new(&env, "none"), &0, &50_000_000_i128);
+}


### PR DESCRIPTION
## Summary

- Added `test_confirm_agent_update_long_after_expiry_succeeds` — pins that the timelock is a minimum delay with no upper deadline; confirming 100 000 ledgers past expiry still succeeds
- Added `test_cancel_agent_update_after_prior_cancel_rejected` — distinct from the never-proposed cancel case: propose → cancel → cancel again asserts `NoTimelockPending` (#49), verifying the first cancel clears the slot
- Added `test_set_dex_pool_rotation_while_deployed_strands_funds` in `test_dex_integration.rs` — documents current pre-guard behaviour where rotating the DEX pool address mid-deployment silently strands the deployed position, mirroring the Blend-side test
- Added `test_rebalance_dex_withdraw_leg_below_min_out_panics` — regression test for the DEX withdrawal leg: when `set_max_withdraw_limit` caps pool returns below `min_out`, `rebalance()` panics with `MinOutNotMet` (#42) with no partial state change persisted

Closes #513
Closes #514
Closes #515
Closes #516