### PR TITLE
test: reject zero-asset deposit with AmountMustBePositive (fixes #537)

### DIFF
--- a/neurowealth-vault/contracts/vault/src/tests/test_deposit.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_deposit.rs
@@ -39,6 +39,63 @@ fn test_deposit_maximum_succeeds() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #37)")]
+fn test_deposit_zero_assets_rejected() {
+    // A zero-asset deposit must be rejected early with AmountMustBePositive (#37),
+    // before any token transfer or storage write occurs. Zero-value deposits would
+    // otherwise consume ledger resources without changing vault state (Issue #537).
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    let user = Address::generate(&env);
+
+    // Fund the user with some USDC so the rejection is clearly about the zero
+    // amount, not an insufficient balance.
+    token_client.mint(&user, &10_000_000_i128);
+    client.deposit(&user, &0_0000000_i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #37)")]
+fn test_deposit_zero_after_approving_zero_rejected() {
+    // Edge case: explicitly approve zero tokens, then deposit zero. The positive-amount
+    // guard fires before the token transfer, so the allowance value is irrelevant (#537).
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+    let token_client = TestTokenClient::new(&env, &usdc_token);
+
+    let user = Address::generate(&env);
+
+    token_client.mint(&user, &10_000_000_i128);
+    token_client.approve(&user, &contract_id, &0_i128, &u32::MAX);
+    client.deposit(&user, &0_0000000_i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #37)")]
+fn test_deposit_zero_with_no_allowance_rejected() {
+    // Edge case: deposit zero with no allowance set at all. The vault still rejects
+    // on the positive-amount guard before touching the token contract (#537).
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+
+    // No mint, no approve — nothing but a zero-amount deposit.
+    client.deposit(&user, &0_0000000_i128);
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #38)")]
 fn test_deposit_below_minimum_panics() {
     let env = Env::default();


### PR DESCRIPTION
## Description

Adds tests verifying that `deposit()` rejects a zero-asset deposit early,
before any ledger resources are consumed. Zero-value deposits would otherwise
trigger storage operations without changing vault state.

Closes #537.

## What changed

Three tests added to `contracts/vault/src/tests/test_deposit.rs`:

| Test | Scenario |
|---|---|
| `test_deposit_zero_assets_rejected` | Funded user calls `deposit(user, 0)` |
| `test_deposit_zero_after_approving_zero_rejected` | Approve 0 tokens, then `deposit(user, 0)` |
| `test_deposit_zero_with_no_allowance_rejected` | `deposit(user, 0)` with no allowance set |

## Expected error

All three assert `Error(Contract, #37)` — `VaultError::AmountMustBePositive`.

`deposit()` calls `require_positive_amount()` as its **first** validation
(before the token transfer), and that guard panics with `AmountMustBePositive`
for any `amount <= 0`. There is no dedicated `ZeroDeposit` variant; `#37` is
the "or equivalent" error the issue allows. Because the guard runs before any
token interaction, the outcome is identical whether the allowance is zero or
unset — which is exactly what the two edge-case tests confirm.

## Testing

```bash
cd neurowealth-vault
cargo test comprehensive_tests::test_deposit::test_deposit_zero
```

> Note: I was unable to run the suite on my local machine (no MSVC linker
> available); the assertions are derived from the contract source. Please rely
> on CI / a reviewer's local run to confirm the compile + pass.

## Checklist

- [x] Tests added
- [x] Follows existing test conventions in `test_deposit.rs`
- [x] No production code changed (test-only)
