### PR TITLE
feat: reject zero wasm hash in schedule_upgrade (fixes #529)

### DIFF
--- a/neurowealth-vault/contracts/vault/src/lib.rs
+++ b/neurowealth-vault/contracts/vault/src/lib.rs
@@ -280,6 +280,7 @@ impl VaultError {
     pub const MaxDecreaseOverflow: Self = Self::InvalidStrategy;
     pub const TotalAvailableOverflow: Self = Self::InvalidStrategy;
     pub const VersionOverflow: Self = Self::InvalidStrategy;
+    pub const InvalidWasmHash: Self = Self::InvalidStrategy;
 }
 
 // ============================================================================
@@ -4079,6 +4080,12 @@ impl NeuroWealthVault {
             &env,
             !env.storage().instance().has(&DataKey::PendingUpgradeHash),
             VaultError::TimelockAlreadyPending,
+        );
+
+        Self::require(
+            &env,
+            new_wasm_hash != BytesN::from_array(&env, &[0u8; 32]),
+            VaultError::InvalidWasmHash,
         );
 
         let effective_ledger = env

--- a/neurowealth-vault/contracts/vault/src/tests/test_upgrade_timelock.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_upgrade_timelock.rs
@@ -107,6 +107,30 @@ fn test_schedule_blocked_while_paused() {
     client.schedule_upgrade(&owner, &fake_hash(&env, 4));
 }
 
+/// Scheduling with a zeroed wasm hash must be rejected (InvalidWasmHash).
+/// The pending upgrade state must remain None after the failed attempt.
+#[test]
+fn test_schedule_zero_hash_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let zero_hash = BytesN::from_array(&env, &[0u8; 32]);
+    let result = client.try_schedule_upgrade(&owner, &zero_hash);
+    assert_eq!(
+        result,
+        Err(Ok(soroban_sdk::Error::from_contract_error(47))),
+        "zero wasm hash should be rejected with VaultError::InvalidWasmHash"
+    );
+
+    assert!(
+        client.get_pending_upgrade().is_none(),
+        "pending upgrade must remain None after rejected zero hash"
+    );
+}
+
 // ── execute flow ──────────────────────────────────────────────────────────────
 
 /// Executing before the timelock has elapsed must be rejected (TimelockNotExpired, #50).


### PR DESCRIPTION
## Summary

Adds a validation guard in `schedule_upgrade()` that rejects a zeroed wasm hash (`[0u8; 32]`) at scheduling time, preventing the vault from entering a stuck "pending upgrade" state that would require a cancel to recover from.

Closes #529

## Changes

### `neurowealth-vault/contracts/vault/src/lib.rs`

- **`VaultError::InvalidWasmHash`** — new const alias mapping to `InvalidStrategy = 47`, following the established pattern for working around Soroban's 50-case `#[contracterror]` limit.
- **`schedule_upgrade()`** — added a `require` guard after the `TimelockAlreadyPending` check that compares the incoming `new_wasm_hash` against `BytesN::from_array(&env, &[0u8; 32])`. Rejects with `VaultError::InvalidWasmHash` before any storage mutation or event emission.

### `neurowealth-vault/contracts/vault/src/tests/test_upgrade_timelock.rs`

- **`test_schedule_zero_hash_rejected`** — calls `try_schedule_upgrade` with a zeroed hash, asserts:
  - The call returns `Err(Ok(soroban_sdk::Error::from_contract_error(47)))`
  - `get_pending_upgrade()` returns `None` (state is clean)

## Testing

Run the new test:
```
cargo test -p neurowealth-vault test_schedule_zero_hash_rejected
```