### PR TITLE
test: confirm_agent_update after cancel_agent_update is rejected (fixes #533)

### DIFF
--- a/neurowealth-vault/contracts/vault/src/tests/test_agent_timelock.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_agent_timelock.rs
@@ -277,3 +277,33 @@ fn test_cancel_agent_update_after_prior_cancel_rejected() {
     // Cancelling again with no pending proposal must panic.
     client.cancel_agent_update();
 }
+
+// ─── Issue #533 ──────────────────────────────────────────────────────────────
+
+/// `confirm_agent_update()` panics with `NoTimelockPending` (#49) when called
+/// after the pending proposal was already cancelled — the slot is empty again.
+///
+/// This verifies that cancel clears the pending state so that a subsequent
+/// confirm has nothing to act on.
+#[test]
+#[should_panic(expected = "Error(Contract, #49)")]
+fn test_confirm_after_cancel_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, _agent, _owner, _usdc_token) = setup_vault_with_token(&env);
+    let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    let new_agent = Address::generate(&env);
+    // Propose, then cancel — pending slot is now empty.
+    client.update_agent(&new_agent);
+    client.cancel_agent_update();
+
+    assert!(
+        client.get_pending_agent_update().is_none(),
+        "pending state must be empty after cancel"
+    );
+
+    // Confirming with no pending proposal must panic.
+    client.confirm_agent_update();
+}


### PR DESCRIPTION
## Description

Adds a test verifying that `confirm_agent_update()` is rejected when the agent update was previously cancelled via `cancel_agent_update()`.

## Related Issue

Closes #533

## Motivation

The two-step agent update has a clear state machine: **proposed → (confirmed | cancelled)**. Once cancelled, the proposal is cleared and a subsequent `confirm_agent_update()` must fail.

## Test Steps

1. Propose new agent via `update_agent(new_agent)`
2. Cancel the proposal via `cancel_agent_update()`
3. Assert pending state is empty
4. Call `confirm_agent_update()` and assert it panics with `Error(Contract, #49)` (NoTimelockPending)

## Related

- #317 (two-step timelocked agent update)
- `test_agent_timelock.rs`