### PR TITLE
test: assert accept-after-cancel rejects with CallerIsNotPendingOwner…

### DIFF
--- a/neurowealth-vault/contracts/vault/src/tests/test_access_control.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_access_control.rs
@@ -603,7 +603,8 @@ fn test_wrong_address_cannot_accept_ownership() {
 }
 
 #[test]
-#[should_panic(expected = "vault: no pending owner")]
+// No pending transfer -> accept_ownership rejects with VaultError::CallerIsNotPendingOwner (code 29).
+#[should_panic(expected = "Error(Contract, #29)")]
 fn test_accept_ownership_without_pending_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -650,7 +651,9 @@ fn test_cancel_without_pending_panics() {
 }
 
 #[test]
-#[should_panic(expected = "vault: no pending owner")]
+// #538: once a transfer is cancelled the pending state is cleared, so a later
+// accept_ownership rejects with VaultError::CallerIsNotPendingOwner (code 29).
+#[should_panic(expected = "Error(Contract, #29)")]
 fn test_accept_after_cancel_panics() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary

Resolves the ownership state-machine verification requested in #538: once a
transfer is cancelled via `cancel_ownership_transfer()`, the pending state is
cleared and a later `accept_ownership()` must be rejected.

While implementing this, I found that the two tests already covering this path
in `test_access_control.rs` asserted a panic string the contract **never
emits** — so they were failing rather than verifying anything:

- `test_accept_after_cancel_panics`
- `test_accept_ownership_without_pending_panics`

Both used `#[should_panic(expected = "vault: no pending owner")]`. That string
does not exist anywhere in the contract. When no pending transfer exists,
`accept_ownership()` panics with `VaultError::CallerIsNotPendingOwner`, which
surfaces as `Error(Contract, #29)`.

## Change

Corrected both `should_panic` strings to `"Error(Contract, #29)"`, matching the
convention already used by the sibling tests in the same file
(`test_wrong_address_cannot_accept_ownership`, `test_cancel_without_pending_panics`),
and added clarifying comments.

```rust
// #538: once a transfer is cancelled the pending state is cleared, so a later
// accept_ownership rejects with VaultError::CallerIsNotPendingOwner (code 29).
#[should_panic(expected = "Error(Contract, #29)")]
fn test_accept_after_cancel_panics() { ... }
```

## Test steps verified (per #538)

1. `transfer_ownership(new_owner)` — pending owner set
2. `cancel_ownership_transfer()` — pending state cleared
3. `new_owner` calls `accept_ownership()` — panics with `Error(Contract, #29)`
   (`VaultError::CallerIsNotPendingOwner`, the codebase's equivalent of
   `NoPendingOwnershipTransfer`)

## Notes

- `VaultError::CallerIsNotPendingOwner` (discriminant `29`) is the contract's
  guard for both "not the pending owner" and "no pending transfer exists"; there
  is no separate `NoPendingOwnershipTransfer` variant.
- I could not run `cargo test` locally — this Windows environment has no MSVC
  linker installed for the `x86_64-pc-windows-msvc` toolchain. The change is a
  one-line assertion correction aligned with passing sibling tests in the same
  file; CI will run the full suite.

Closes #538
