### PR TITLE
fix: compilation errors and 3 pre-existing test failures (builds on #530)

### DIFF
--- a/neurowealth-vault/contracts/vault/src/tests/test_dex_integration.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_dex_integration.rs
@@ -322,7 +322,10 @@ fn test_dex_balance_delta_against_lying_pool() {
     vault_client.set_dex_pool(&owner, &dex_pool);
 
     let deposit_amount = 50_000_000_i128;
-    token_client.mint(&vault_id, &deposit_amount);
+    // Use mint_and_deposit so TotalAssets is properly recorded (deposit
+    // updates TotalAssets; direct mint to the vault address does not).
+    let user = Address::generate(&env);
+    mint_and_deposit(&env, &vault_client, &usdc_token, &user, deposit_amount);
 
     // Configure the pool to lie: it will actually transfer `deposit_amount`
     // but report double that amount as its return value.

--- a/neurowealth-vault/contracts/vault/src/tests/test_dex_integration.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_dex_integration.rs
@@ -9,7 +9,7 @@
 
 use super::utils::*;
 use soroban_sdk::{
-    symbol_short, testutils::Address as _, vec, Address, Env, IntoVal, Symbol, Val, Vec,
+    symbol_short, testutils::Address as _, vec, Address, Env, IntoVal, String, Symbol, Val, Vec,
 };
 
 #[test]
@@ -129,6 +129,101 @@ fn test_set_dex_pool_non_owner_panics() {
     let stranger = Address::generate(&env);
     // OnlyOwnerCanConfigurePool (#28).
     vault_client.set_dex_pool(&stranger, &dex_pool);
+}
+
+// ─── Issue #530: set_dex_pool with non-contract address fails gracefully ─────
+//
+// The vault probes pool addresses on configuration by calling
+// `DexPoolClient::get_balance`, which internally calls `env.invoke_contract`.
+// When the supplied address has no deployed Soroban contract, the host
+// environment panics with a HostError before the pool address is written to
+// storage, so `get_dex_pool()` safely returns `None` (the transaction rolls
+// back entirely).
+
+/// Random address with no contract deployed should panic with a host error.
+#[test]
+#[should_panic(expected = "HostError")]
+fn test_set_dex_pool_random_non_contract_address_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, _agent, owner, _usdc_token, _dex_pool) = setup_vault_with_token_and_dex(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+
+    // Address::generate creates a random address with no contract deployed at it.
+    let non_contract = Address::generate(&env);
+
+    // The pool probe (`DexPoolClient::get_balance` → `env.invoke_contract`)
+    // fails because no contract is registered at `non_contract`.
+    vault_client.set_dex_pool(&owner, &non_contract);
+}
+
+/// The canonical burned Stellar account (all-zeros ed25519 key) should also
+/// be rejected — it has no contract deployed at it.
+#[test]
+#[should_panic(expected = "HostError")]
+fn test_set_dex_pool_zero_address_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, _agent, owner, _usdc_token, _dex_pool) = setup_vault_with_token_and_dex(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+
+    // The canonical burned Stellar account — no contract at this address.
+    let zero_addr = Address::from_string(&String::from_str(
+        &env,
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    ));
+
+    vault_client.set_dex_pool(&owner, &zero_addr);
+}
+
+/// An ed25519 account-type address (not a contract address) should also
+/// be rejected because no Soroban contract is deployed at it.
+#[test]
+#[should_panic(expected = "HostError")]
+fn test_set_dex_pool_ed25519_account_address_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, _agent, owner, _usdc_token, _dex_pool) = setup_vault_with_token_and_dex(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+
+    // An ed25519 account-type address (G…), not a contract address (C…).
+    // It has no Soroban contract deployed at it.
+    let account_addr = Address::from_string(&String::from_str(
+        &env,
+        "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMKJS",
+    ));
+
+    vault_client.set_dex_pool(&owner, &account_addr);
+}
+
+/// Verify that after a failed set_dex_pool call (non-contract address),
+/// get_dex_pool still returns None — the transaction rolled back completely.
+#[test]
+fn test_set_dex_pool_non_contract_does_not_persist() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (vault_id, _agent, owner, _usdc_token, _dex_pool) = setup_vault_with_token_and_dex(&env);
+    let vault_client = NeuroWealthVaultClient::new(&env, &vault_id);
+
+    // Before any set_dex_pool call, the pool is None.
+    assert_eq!(vault_client.get_dex_pool(), None);
+
+    let non_contract = Address::generate(&env);
+
+    // Use try_set_dex_pool to catch the error instead of panicking.
+    let result = vault_client.try_set_dex_pool(&owner, &non_contract);
+    assert!(result.is_err(), "set_dex_pool with non-contract address must fail");
+
+    // The DEX pool storage must remain untouched after the failed call.
+    assert_eq!(
+        vault_client.get_dex_pool(),
+        None,
+        "get_dex_pool must return None after a rejected set_dex_pool"
+    );
 }
 
 #[test]

--- a/neurowealth-vault/contracts/vault/src/tests/test_rebalance_cooldown.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_rebalance_cooldown.rs
@@ -255,23 +255,39 @@ fn test_rebalance_within_cooldown_panics() {
 
 /// Calling harvest twice in the same ledger when cooldown == 1 panics with
 /// `RebalanceCooldownActive` (Error(Contract, #43)).
+///
+/// Harvest requires a configured pool and non-"none" protocol, so this test
+/// first sets up a Blend pool and rebalances into it, then advances the
+/// ledger past the cooldown before running the two-harvest sequence.
 #[test]
 #[should_panic(expected = "Error(Contract, #43)")]
 fn test_harvest_within_cooldown_panics() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (contract_id, _agent, _owner) = setup_vault(&env);
+    let (contract_id, _agent, owner, _usdc_token, blend_pool) =
+        setup_vault_with_token_and_blend(&env);
     let client = NeuroWealthVaultClient::new(&env, &contract_id);
+
+    // Set up Blend pool so harvest has a valid protocol to work with.
+    client.set_blend_pool(&owner, &blend_pool);
+    client.rebalance(&symbol_short!("blend"), &850, &0_i128);
+
+    // Advance ledger past the cooldown we're about to set, so the first
+    // harvest below is not blocked by the rebalance's LastRebalanceLedger.
+    let last = client.get_last_rebalance_ledger();
+    env.ledger().with_mut(|li| {
+        li.sequence_number = last + 20;
+    });
 
     // Set cooldown to 10 ledgers
     client.set_rebalance_cooldown(&10_u32);
 
     // First harvest succeeds and stores the current ledger
-    client.harvest();
+    client.harvest(&0_i128);
 
     // Immediately attempt a second harvest in the same ledger — must panic
-    client.harvest();
+    client.harvest(&0_i128);
 }
 
 /// `try_rebalance` returns the cooldown error without unwinding the test.

--- a/neurowealth-vault/contracts/vault/src/tests/test_share_conversion_proptest.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_share_conversion_proptest.rs
@@ -377,7 +377,7 @@ proptest! {
             .expect("overflow not possible at tested bounds");
 
         if shares_minted == 0 {
-            return;
+            return Ok(());
         }
 
         let new_total_shares = total_shares + shares_minted;
@@ -386,8 +386,16 @@ proptest! {
         // Harvest adds yield to total_assets without changing total_shares
         let post_harvest_assets = new_total_assets + harvest_yield;
 
-        // User withdraws their assets via ceil conversion for the shares
-        let shares_to_burn = shares_ceil(shares_minted, new_total_shares, post_harvest_assets)
+        // User wants to withdraw their full position. First compute the
+        // assets they are entitled to, then compute shares to burn via ceil.
+        let entitled_assets = assets_from_shares(shares_minted, new_total_shares, post_harvest_assets)
+            .expect("overflow not possible at tested bounds");
+
+        if entitled_assets == 0 {
+            return Ok(());
+        }
+
+        let shares_to_burn = shares_ceil(entitled_assets, new_total_shares, post_harvest_assets)
             .expect("overflow not possible at tested bounds");
         
         let assets_returned = assets_from_shares(shares_to_burn, new_total_shares, post_harvest_assets)

--- a/neurowealth-vault/fuzz/fuzz_targets/admin_timelock_interleaved.rs
+++ b/neurowealth-vault/fuzz/fuzz_targets/admin_timelock_interleaved.rs
@@ -242,7 +242,7 @@ fuzz_target!(|data: &[u8]| {
 
                 // ── Verify invariants ──
                 let actual_upgrade = client.get_pending_upgrade();
-                match (upgrade_pending_hash, upgrade_pending_expiry) {
+                match (upgrade_pending_hash.clone(), upgrade_pending_expiry) {
                     (Some(_), Some(expiry)) => {
                         assert!(
                             actual_upgrade.is_some(),

--- a/neurowealth-vault/fuzz/fuzz_targets/rebalance_transitions.rs
+++ b/neurowealth-vault/fuzz/fuzz_targets/rebalance_transitions.rs
@@ -193,7 +193,7 @@ fuzz_target!(|data: &[u8]| {
                 }
                 1 => {
                     // Rebalance to a target protocol
-                    let protocol = protocols[protocol_idx];
+                    let protocol = protocols[protocol_idx].clone();
                     let expected_apy = (raw as i128) % 10_000;
                     client.rebalance(&protocol, &expected_apy, &0);
                 }

--- a/neurowealth-vault/fuzz/fuzz_targets/upgrade_timelock.rs
+++ b/neurowealth-vault/fuzz/fuzz_targets/upgrade_timelock.rs
@@ -16,7 +16,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use neurowealth_vault::{NeuroWealthVault, NeuroWealthVaultClient};
-use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::{Address as _, Ledger};
 use soroban_sdk::{Address, BytesN, Env};
 
 const DEFAULT_TIMELOCK_DELAY: u32 = 100;
@@ -138,7 +138,7 @@ fuzz_target!(|data: &[u8]| {
             Ok(()) => {
                 // Verify invariants after successful operation
                 let actual_pending = client.get_pending_upgrade();
-                match (pending_hash, pending_expiry) {
+                match (pending_hash.clone(), pending_expiry) {
                     (Some(hash), Some(expiry)) => {
                         assert!(
                             actual_pending.is_some(),


### PR DESCRIPTION
# Closes #530

## Summary

Fixes all compilation errors in the fuzz targets and resolves 3 pre-existing test failures that were preventing the test suite from building. All changes are on the `test/530-set-dex-pool-non-contract-address` branch which builds on the `#530` test additions.

## Changes

### 🔧 Compilation fixes (fuzz targets — 3 files)

| File | Error | Fix |
|------|-------|-----|
| `fuzz/fuzz_targets/upgrade_timelock.rs` | Missing `Ledger` import for `set_sequence_number` | Added `use soroban_sdk::testutils::Ledger` |
| `fuzz/fuzz_targets/upgrade_timelock.rs` | Move of `pending_hash` in `Fn` closure | Added `.clone()` in match arm |
| `fuzz/fuzz_targets/rebalance_transitions.rs` | Move of `protocols[_]` in `Fn` closure | Changed to `.clone()` |
| `fuzz/fuzz_targets/admin_timelock_interleaved.rs` | Same move issue with `upgrade_pending_hash` | Added `.clone()` in match arm |

### 🧪 Test fixes (vault tests — 3 files)

#### 1. `test_rebalance_cooldown.rs` — `test_harvest_within_cooldown_panics`

**Root cause:** The `harvest()` entrypoint requires a non-`"none"` protocol (blend or dex). The test was calling `harvest()` on a freshly initialized vault with no pool configured, causing `Error(Contract, #17)` (UnsupportedProtocol) instead of the expected `#43` (RebalanceCooldownActive).

**Fix:**
- Changed from `setup_vault()` to `setup_vault_with_token_and_blend()`
- Configures a Blend pool and rebalances into it
- Advances the ledger past the cooldown so the first harvest call succeeds
- Changed `harvest()` calls to `harvest(&0_i128)` to supply the required `min_out` argument

#### 2. `test_dex_integration.rs` — `test_dex_balance_delta_against_lying_pool`

**Root cause:** Tokens were minted directly to the vault address via `token_client.mint(&vault_id, ...)`, bypassing the `deposit()` entrypoint. This meant `TotalAssets` was never written to storage, so `get_total_assets()` returned `0` instead of the deposited amount.

**Fix:**
- Changed from direct `mint()` to `mint_and_deposit()` with a user address
- This ensures `deposit()` is called, which properly records `TotalAssets` in instance storage

#### 3. `test_share_conversion_proptest.rs` — `prop_harvest_conversion_round_trip`

**Root cause:** The proptest was passing `shares_minted` directly to `shares_ceil()`, treating shares as if they were assets. The withdrawal path should first compute the entitled assets from the shares via `assets_from_shares()`, then compute shares to burn via `shares_ceil()`. This caused extreme failures at pathological input ratios (e.g. `total_assets=1, total_shares=466B`).

**Fix:**
- Added intermediate `entitled_assets = assets_from_shares(shares_minted, ...)` step
- Added early return `if entitled_assets == 0 { return Ok(()); }`
- Changed bare `return;` to `return Ok(());` (required by `proptest!` macro)
- Passes `entitled_assets` instead of `shares_minted` to `shares_ceil()`

## Verification

- ✅ `cargo check` — clean (zero errors, only pre-existing warnings)
- ✅ `cargo test test_harvest_within_cooldown` — passes
- ✅ `cargo test test_dex_balance_delta_against_lying_pool` — passes
- ✅ `cargo test prop_harvest_conversion_round_trip` — passes
- ✅ `cargo test --lib` — compiles and runs (545 pass / 34 pre-existing failures unrelated to these changes)
