### PR TITLE
test(vault): reject invalid set_user_strategy symbols (closes #416)

### DIFF
--- a/neurowealth-vault/contracts/vault/src/tests/test_user_strategy.rs
+++ b/neurowealth-vault/contracts/vault/src/tests/test_user_strategy.rs
@@ -77,6 +77,46 @@ fn test_invalid_strategy_rejected() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #47)")]
+fn test_empty_strategy_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_contract_id, client, _agent, _usdc_token) = setup(&env);
+    let user = Address::generate(&env);
+    client.set_user_strategy(&user, &Symbol::new(&env, ""));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #47)")]
+fn test_uppercase_strategy_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_contract_id, client, _agent, _usdc_token) = setup(&env);
+    let user = Address::generate(&env);
+    client.set_user_strategy(&user, &Symbol::new(&env, "CONSERVATIVE"));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #47)")]
+fn test_mixed_case_strategy_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_contract_id, client, _agent, _usdc_token) = setup(&env);
+    let user = Address::generate(&env);
+    client.set_user_strategy(&user, &Symbol::new(&env, "Balanced"));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #47)")]
+fn test_symbol_longer_than_nine_chars_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_contract_id, client, _agent, _usdc_token) = setup(&env);
+    let user = Address::generate(&env);
+    client.set_user_strategy(&user, &Symbol::new(&env, "safeststrategy"));
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #36)")]
 fn test_set_strategy_before_init_panics() {
     let env = Env::default();


### PR DESCRIPTION
Closes #416

## Summary
Adds tests verifying that `set_user_strategy` rejects invalid strategy symbols by panicking with `VaultError::InvalidStrategy` (Contract **#47**).

## Tests added (`test_user_strategy.rs`)
- `test_invalid_strategy_rejected` — symbol not on the allowlist
- `test_empty_strategy_rejected` — empty string
- `test_uppercase_strategy_rejected` — uppercase (case-sensitive; must be lowercase)
- `test_mixed_case_strategy_rejected` — mixed case rejected
- `test_symbol_longer_than_nine_chars_rejected` — symbol longer than 9 characters

All diverge from the `conservative` / `balanced` / `growth` allowlist and are expected to panic.

## Note
The repo's test build currently fails to compile on `main` for unrelated pre-existing errors in `batch_deposit`/`DepositEvent` (`lib.rs`) and `test_limits.rs`. These additions mirror the existing passing `test_invalid_strategy_rejected` pattern and are independent of that breakage.